### PR TITLE
Bruno/add dataset metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea/
 __pycache__/
 .vscode
+*.pyc
+kloppy.egg-info
+pip-wheel-metadata
+env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -45,7 +45,7 @@ class Team:
     team_id: str
     name: str
     ground: Ground
-    players: List[Player] = field(default_factory=dict)
+    players: List[Player] = field(default_factory=list)
 
     def __str__(self):
         return self.team_id
@@ -57,6 +57,13 @@ class Team:
         if not isinstance(other, Team):
             return False
         return self.team_id == other.team_id
+
+    def get_player_by_jersey_number(self, jersey_no: str):
+        for player in self.players:
+            if player.jersey_no == jersey_no:
+                return player
+
+        return None
 
 
 class BallState(Enum):

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -32,11 +32,11 @@ class Position:
 class Player:
     player_id: str
     team: "Team"
-    name: str
-    first_name: str
-    last_name: str
     jersey_no: str
-    position: Position
+    name: str = None
+    first_name: str = None
+    last_name: str = None
+    position: Position = None
     attributes: Optional[Dict] = field(default_factory=dict, compare=False)
 
 

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -18,14 +18,14 @@ class Ground(Enum):
     REFEREE = "referee"
 
 
-@dataclass
+@dataclass(frozen=True)
 class Position:
     position_id: str
     name: str
     coordinates: Point
 
 
-@dataclass
+@dataclass(frozen=True)
 class Player:
     player_id: str
     team: "Team"
@@ -34,7 +34,7 @@ class Player:
     last_name: str
     jersey_no: str
     position: Position
-    attributes: Optional[Dict] = field(default_factory=dict)
+    attributes: Optional[Dict] = field(default_factory=dict, compare=False)
 
 
 @dataclass
@@ -46,6 +46,14 @@ class Team:
 
     def __str__(self):
         return self.team_id
+
+    def __hash__(self):
+        return hash(self.team_id)
+
+    def __eq__(self, other):
+        if not isinstance(other, Team):
+            return False
+        return self.team_id == other.team_id
 
 
 class BallState(Enum):

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -17,6 +17,9 @@ class Ground(Enum):
     AWAY = "away"
     REFEREE = "referee"
 
+    def __str__(self):
+        return self.value
+
 
 @dataclass(frozen=True)
 class Position:

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -146,8 +146,7 @@ class DataRecord(ABC):
 
 @dataclass
 class MetaData:
-    home_team: Team
-    away_team: Team
+    teams: List[Team]
     periods: List[Period]
     pitch_dimensions: PitchDimensions
     score: List  # first home, second away [0,0]

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -90,7 +90,6 @@ class Orientation(Enum):
         attacking_direction: AttackingDirection,
         ball_owning_team: Team,
         action_executing_team: Team,
-        meta_data: "MetaData",
     ):
         if self == Orientation.FIXED_HOME_AWAY:
             return -1
@@ -111,18 +110,18 @@ class Orientation(Enum):
             else:
                 raise Exception("AttackingDirection not set")
         elif self == Orientation.BALL_OWNING_TEAM:
-            if ball_owning_team.team_id == MetaData.teams[0].team_id:
+            if ball_owning_team.ground == Ground.HOME:
                 return -1
-            elif ball_owning_team.team_id == MetaData.teams[1].team_id:
+            elif ball_owning_team.ground == Ground.AWAY:
                 return 1
             else:
                 raise Exception(
                     f"Invalid ball_owning_team: {ball_owning_team}"
                 )
         elif self == Orientation.ACTION_EXECUTING_TEAM:
-            if action_executing_team.team_id == MetaData.teams[0].team_id:
+            if action_executing_team.ground == Ground.HOME:
                 return -1
-            elif action_executing_team.team_id == MetaData.teams[1].team_id:
+            elif action_executing_team.ground == Ground.AWAY:
                 return 1
             else:
                 raise Exception(

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -6,21 +6,32 @@ from typing import Optional, List, Dict
 from .pitch import PitchDimensions
 
 
-class Team(Enum):
-    HOME = "home"
-    AWAY = "away"
-
-    def __str__(self):
-        return self.value
+@dataclass
+class Position:
+    position_id: str
+    name: str
+    coordinates: List
 
 
 @dataclass
 class Player:
     player_id: str
-    team: Team
     name: str
+    first_name: str
+    last_name: str
     jersey_no: str
-    attributes: Optional[Dict] = field(default_factory=dict)
+    position: Position
+    # attributes: Optional[Dict] = field(default_factory=dict)
+
+
+@dataclass
+class Team:
+    team_id: str
+    name: str
+    players: List[Player]
+
+    def __str__(self):
+        return self.team_id
 
 
 class BallState(Enum):
@@ -54,6 +65,7 @@ class Orientation(Enum):
         attacking_direction: AttackingDirection,
         ball_owning_team: Team,
         action_executing_team: Team,
+        meta_data: "MetaData",  # TODO is the using before assignment a problem?
     ):
         if self == Orientation.FIXED_HOME_AWAY:
             return -1
@@ -74,18 +86,18 @@ class Orientation(Enum):
             else:
                 raise Exception("AttackingDirection not set")
         elif self == Orientation.BALL_OWNING_TEAM:
-            if ball_owning_team == Team.HOME:
+            if ball_owning_team.team_id == MetaData.home_team.team_id:
                 return -1
-            elif ball_owning_team == Team.AWAY:
+            elif ball_owning_team.team_id == MetaData.away_team.team_id:
                 return 1
             else:
                 raise Exception(
                     f"Invalid ball_owning_team: {ball_owning_team}"
                 )
         elif self == Orientation.ACTION_EXECUTING_TEAM:
-            if action_executing_team == Team.HOME:
+            if action_executing_team.team_id == MetaData.home_team.team_id:
                 return -1
-            elif action_executing_team == Team.AWAY:
+            elif action_executing_team.team_id == MetaData.away_team.team_id:
                 return 1
             else:
                 raise Exception(
@@ -133,18 +145,18 @@ class DataRecord(ABC):
 
 
 @dataclass
-class Dataset(ABC):
-    flags: DatasetFlag
-    pitch_dimensions: PitchDimensions
-    orientation: Orientation
+class MetaData:
+    home_team: Team
+    away_team: Team
     periods: List[Period]
-    records: List[DataRecord]
+    pitch_dimensions: PitchDimensions
+    score: List  # first home, second away [0,0]
+    frame_rate: float
+    orientation: Orientation
+    flags: DatasetFlag
 
 
 @dataclass
-class MetaData:
-    home_team_name: str
-    away_team_name: str
-    players: List[Player]
-    periods: List[Period]
-    pitch_dimensions: PitchDimensions
+class Dataset(ABC):
+    records: List[DataRecord]
+    meta_data: MetaData

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -65,6 +65,13 @@ class Team:
 
         return None
 
+    def get_player_by_id(self, id: str):
+        for player in self.players:
+            if player.player_id == id:
+                return player
+
+        return None
+
 
 class BallState(Enum):
     ALIVE = "alive"

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -3,19 +3,32 @@ from dataclasses import dataclass, field
 from enum import Enum, Flag
 from typing import Optional, List, Dict
 
-from .pitch import PitchDimensions
+from .pitch import PitchDimensions, Point
+
+
+@dataclass
+class Score:
+    home: int
+    away: int
+
+
+class Ground(Enum):
+    HOME = "home"
+    AWAY = "away"
+    REFEREE = "referee"
 
 
 @dataclass
 class Position:
     position_id: str
     name: str
-    coordinates: List
+    coordinates: Point
 
 
 @dataclass
 class Player:
     player_id: str
+    team: "Team"
     name: str
     first_name: str
     last_name: str
@@ -28,7 +41,8 @@ class Player:
 class Team:
     team_id: str
     name: str
-    players: List[Player]
+    ground: Ground
+    players: List[Player] = field(default_factory=dict)
 
     def __str__(self):
         return self.team_id
@@ -65,7 +79,7 @@ class Orientation(Enum):
         attacking_direction: AttackingDirection,
         ball_owning_team: Team,
         action_executing_team: Team,
-        meta_data: "MetaData",  # TODO is the using before assignment a problem?
+        meta_data: "MetaData",
     ):
         if self == Orientation.FIXED_HOME_AWAY:
             return -1
@@ -86,18 +100,18 @@ class Orientation(Enum):
             else:
                 raise Exception("AttackingDirection not set")
         elif self == Orientation.BALL_OWNING_TEAM:
-            if ball_owning_team.team_id == MetaData.home_team.team_id:
+            if ball_owning_team.team_id == MetaData.teams[0].team_id:
                 return -1
-            elif ball_owning_team.team_id == MetaData.away_team.team_id:
+            elif ball_owning_team.team_id == MetaData.teams[1].team_id:
                 return 1
             else:
                 raise Exception(
                     f"Invalid ball_owning_team: {ball_owning_team}"
                 )
         elif self == Orientation.ACTION_EXECUTING_TEAM:
-            if action_executing_team.team_id == MetaData.home_team.team_id:
+            if action_executing_team.team_id == MetaData.teams[0].team_id:
                 return -1
-            elif action_executing_team.team_id == MetaData.away_team.team_id:
+            elif action_executing_team.team_id == MetaData.teams[1].team_id:
                 return 1
             else:
                 raise Exception(
@@ -149,7 +163,7 @@ class MetaData:
     teams: List[Team]
     periods: List[Period]
     pitch_dimensions: PitchDimensions
-    score: List  # first home, second away [0,0]
+    score: Score
     frame_rate: float
     orientation: Orientation
     flags: DatasetFlag

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -21,7 +21,7 @@ class Player:
     last_name: str
     jersey_no: str
     position: Position
-    # attributes: Optional[Dict] = field(default_factory=dict)
+    attributes: Optional[Dict] = field(default_factory=dict)
 
 
 @dataclass

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import List, Union, Dict
 
 from .pitch import Point
-from .common import DataRecord, Dataset, Team
+from .common import DataRecord, Dataset, Team, Player
 
 
 class ResultType(Enum):
@@ -70,8 +70,8 @@ class EventType(Enum):
 class Event(DataRecord, ABC):
     event_id: str
     team: Team
-    player_jersey_no: str
-    position: Point
+    player: Player
+    coordinates: Point
 
     result: ResultType
 
@@ -98,8 +98,8 @@ class ShotEvent(Event):
 @dataclass
 class PassEvent(Event):
     receive_timestamp: float
-    receiver_player_jersey_no: str
-    receiver_position: Point
+    receiver_player: Player
+    receiver_coordinates: Point
 
     result: PassResult
 
@@ -116,7 +116,7 @@ class TakeOnEvent(Event):
 @dataclass
 class CarryEvent(Event):
     end_timestamp: float
-    end_position: Point
+    end_coordinates: Point
 
     result: CarryResult
 

--- a/kloppy/domain/models/pitch.py
+++ b/kloppy/domain/models/pitch.py
@@ -21,7 +21,7 @@ class PitchDimensions:
     y_per_meter: float = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class Point:
     x: float
     y: float

--- a/kloppy/domain/models/tracking.py
+++ b/kloppy/domain/models/tracking.py
@@ -9,7 +9,7 @@ from .pitch import Point
 class Frame(DataRecord):
     frame_id: int
     players_coordinates: Dict[Player, Point]
-    ball_position: Point
+    ball_coordinates: Point
 
 
 @dataclass

--- a/kloppy/domain/models/tracking.py
+++ b/kloppy/domain/models/tracking.py
@@ -1,15 +1,32 @@
 from dataclasses import dataclass
 from typing import List, Dict
 
-from .common import Dataset, DataRecord
+from .common import Dataset, DataRecord, Ground
 from .pitch import Point
 
 
 @dataclass
 class Frame(DataRecord):
     frame_id: int
-    players_positions: Dict[str, Point]
+    players_coordinates: Dict[str, Point]
+    players_ground: Dict[str, Ground]
     ball_position: Point
+
+    @property
+    def home_team_players_coordinates(self):
+        return {
+            player_id: coordinates
+            for (player_id, coordinates) in self.players_coordinates.items()
+            if self.players_ground[player_id] == Ground.HOME
+        }
+
+    @property
+    def away_team_players_coordinates(self):
+        return {
+            player_id: coordinates
+            for (player_id, coordinates) in self.players_coordinates.items()
+            if self.players_ground[player_id] == Ground.AWAY
+        }
 
 
 @dataclass
@@ -19,6 +36,10 @@ class TrackingDataset(Dataset):
     @property
     def frames(self):
         return self.records
+
+    @property
+    def frame_rate(self):
+        return self.meta_data.frame_rate
 
 
 __all__ = ["Frame", "TrackingDataset"]

--- a/kloppy/domain/models/tracking.py
+++ b/kloppy/domain/models/tracking.py
@@ -1,32 +1,15 @@
 from dataclasses import dataclass
 from typing import List, Dict
 
-from .common import Dataset, DataRecord, Ground
+from .common import Dataset, DataRecord, Ground, Player
 from .pitch import Point
 
 
 @dataclass
 class Frame(DataRecord):
     frame_id: int
-    players_coordinates: Dict[str, Point]
-    players_ground: Dict[str, Ground]
+    players_coordinates: Dict[Player, Point]
     ball_position: Point
-
-    @property
-    def home_team_players_coordinates(self):
-        return {
-            player_id: coordinates
-            for (player_id, coordinates) in self.players_coordinates.items()
-            if self.players_ground[player_id] == Ground.HOME
-        }
-
-    @property
-    def away_team_players_coordinates(self):
-        return {
-            player_id: coordinates
-            for (player_id, coordinates) in self.players_coordinates.items()
-            if self.players_ground[player_id] == Ground.AWAY
-        }
 
 
 @dataclass

--- a/kloppy/domain/models/tracking.py
+++ b/kloppy/domain/models/tracking.py
@@ -8,14 +8,12 @@ from .pitch import Point
 @dataclass
 class Frame(DataRecord):
     frame_id: int
-    home_team_player_positions: Dict[str, Point]
-    away_team_player_positions: Dict[str, Point]
+    players_positions: Dict[str, Point]
     ball_position: Point
 
 
 @dataclass
 class TrackingDataset(Dataset):
-    frame_rate: int
     records: List[Frame]
 
     @property

--- a/kloppy/domain/services/__init__.py
+++ b/kloppy/domain/services/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from kloppy.domain import AttackingDirection, Frame, Ground
+from kloppy.domain import AttackingDirection, Frame
 
 from .transformers import Transformer
 
@@ -18,15 +18,15 @@ def attacking_direction_from_frame(frame: Frame) -> AttackingDirection:
     avg_x_home = avg(
         [
             coordinates.x
-            for player, coordinates in frame.players_coordinates.items()
-            if player.team.ground == Ground.HOME
+            for key, coordinates in frame.players_coordinates.items()
+            if "home" in key
         ]
     )
     avg_x_away = avg(
         [
             coordinates.x
-            for player, coordinates in frame.players_coordinates.items()
-            if player.team.ground == Ground.AWAY
+            for key, coordinates in frame.players_coordinates.items()
+            if "away" in key
         ]
     )
 

--- a/kloppy/domain/services/__init__.py
+++ b/kloppy/domain/services/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from kloppy.domain import AttackingDirection, Frame
+from kloppy.domain import AttackingDirection, Frame, Ground
 
 from .transformers import Transformer
 
@@ -18,15 +18,15 @@ def attacking_direction_from_frame(frame: Frame) -> AttackingDirection:
     avg_x_home = avg(
         [
             coordinates.x
-            for key, coordinates in frame.players_coordinates.items()
-            if "home" in key
+            for player, coordinates in frame.players_coordinates.items()
+            if player.team.ground == Ground.HOME
         ]
     )
     avg_x_away = avg(
         [
             coordinates.x
-            for key, coordinates in frame.players_coordinates.items()
-            if "away" in key
+            for player, coordinates in frame.players_coordinates.items()
+            if player.team.ground == Ground.AWAY
         ]
     )
 

--- a/kloppy/domain/services/__init__.py
+++ b/kloppy/domain/services/__init__.py
@@ -17,16 +17,16 @@ def attacking_direction_from_frame(frame: Frame) -> AttackingDirection:
     """ This method should only be called for the first frame of a """
     avg_x_home = avg(
         [
-            player.x
-            for player in frame.home_team_player_positions.values()
-            if player
+            coordinates.x
+            for key, coordinates in frame.players_coordinates.items()
+            if "home" in key
         ]
     )
     avg_x_away = avg(
         [
-            player.x
-            for player in frame.away_team_player_positions.values()
-            if player
+            coordinates.x
+            for key, coordinates in frame.players_coordinates.items()
+            if "away" in key
         ]
     )
 

--- a/kloppy/domain/services/transformers/__init__.py
+++ b/kloppy/domain/services/transformers/__init__.py
@@ -61,13 +61,11 @@ class Transformer:
                 ball_owning_team=ball_owning_team,
                 attacking_direction=attacking_direction,
                 action_executing_team=action_executing_team,
-                meta_data=meta_data,
             )
             orientation_factor_to = self._to_orientation.get_orientation_factor(
                 ball_owning_team=ball_owning_team,
                 attacking_direction=attacking_direction,
                 action_executing_team=action_executing_team,
-                meta_data=meta_data,
             )
             flip = orientation_factor_from != orientation_factor_to
         return flip

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -132,7 +132,7 @@ def _frame_to_pandas_row_converter(frame: Frame) -> Dict:
         ball_x=frame.ball_position.x if frame.ball_position else None,
         ball_y=frame.ball_position.y if frame.ball_position else None,
     )
-    for player_id, position in frame.players_positions.items():
+    for player_id, position in frame.players_coordinates.items():
         row.update(
             {f"{player_id}_x": position.x, f"{player_id}_y": position.y,}
         )

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -164,29 +164,29 @@ def _event_to_pandas_row_converter(event: Event) -> Dict:
         timestamp=event.timestamp,
         end_timestamp=None,
         ball_state=event.ball_state.value if event.ball_state else None,
-        ball_owning_team=event.ball_owning_team.value
+        ball_owning_team=event.ball_owning_team.team_id
         if event.ball_owning_team
         else None,
-        team=event.team.value,
-        player_jersey_no=event.player_jersey_no,
-        position_x=event.position.x if event.position else None,
-        position_y=event.position.y if event.position else None,
+        team=event.team.team_id,
+        player=event.player.player_id,
+        coordinates_x=event.coordinates.x if event.coordinates else None,
+        coordinates_y=event.coordinates.y if event.coordinates else None,
     )
     if isinstance(event, PassEvent) and event.result == PassResult.COMPLETE:
         row.update(
             {
                 "end_timestamp": event.receive_timestamp,
-                "end_position_x": event.receiver_position.x,
-                "end_position_y": event.receiver_position.y,
-                "receiver_jersey_no": event.receiver_player_jersey_no,
+                "end_coordinates_x": event.receiver_coordinates.x,
+                "end_coordinates_y": event.receiver_coordinates.y,
+                "receiver": event.receiver_player.player_id,
             }
         )
     elif isinstance(event, CarryEvent):
         row.update(
             {
                 "end_timestamp": event.end_timestamp,
-                "end_position_x": event.end_position.x,
-                "end_position_y": event.end_position.y,
+                "end_coordinates_x": event.end_coordinates.x,
+                "end_coordinates_y": event.end_coordinates.y,
             }
         )
     return row

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -21,6 +21,7 @@ from .domain import (
     CarryEvent,
     PassResult,
     EventType,
+    Player,
 )
 
 
@@ -129,16 +130,22 @@ def _frame_to_pandas_row_converter(frame: Frame) -> Dict:
         ball_owning_team=frame.ball_owning_team.value
         if frame.ball_owning_team
         else None,
-        ball_x=frame.ball_position.x if frame.ball_position else None,
-        ball_y=frame.ball_position.y if frame.ball_position else None,
+        ball_x=frame.ball_coordinates.x if frame.ball_coordinates else None,
+        ball_y=frame.ball_coordinates.y if frame.ball_coordinates else None,
     )
-    for player, position in frame.players_coordinates.items():
-        row.update(
-            {
-                f"{player.player_id}_x": position.x,
-                f"{player.player_id}_y": position.y,
-            }
-        )
+    for player, coordinates in frame.players_coordinates.items():
+
+        if isinstance(player, Player):
+            row.update(
+                {
+                    f"{player.player_id}_x": coordinates.x,
+                    f"{player.player_id}_y": coordinates.y,
+                }
+            )
+        else:
+            row.update(
+                {f"{player}_x": coordinates.x, f"{player}_y": coordinates.y,}
+            )
 
     return row
 

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -132,9 +132,12 @@ def _frame_to_pandas_row_converter(frame: Frame) -> Dict:
         ball_x=frame.ball_position.x if frame.ball_position else None,
         ball_y=frame.ball_position.y if frame.ball_position else None,
     )
-    for player_id, position in frame.players_coordinates.items():
+    for player, position in frame.players_coordinates.items():
         row.update(
-            {f"{player_id}_x": position.x, f"{player_id}_y": position.y,}
+            {
+                f"{player.player_id}_x": position.x,
+                f"{player.player_id}_y": position.y,
+            }
         )
 
     return row

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -132,19 +132,9 @@ def _frame_to_pandas_row_converter(frame: Frame) -> Dict:
         ball_x=frame.ball_position.x if frame.ball_position else None,
         ball_y=frame.ball_position.y if frame.ball_position else None,
     )
-    for jersey_no, position in frame.home_team_player_positions.items():
+    for player_id, position in frame.players_positions.items():
         row.update(
-            {
-                f"player_home_{jersey_no}_x": position.x,
-                f"player_home_{jersey_no}_y": position.y,
-            }
-        )
-    for jersey_no, position in frame.away_team_player_positions.items():
-        row.update(
-            {
-                f"player_away_{jersey_no}_x": position.x,
-                f"player_away_{jersey_no}_y": position.y,
-            }
+            {f"{player_id}_x": position.x, f"{player_id}_y": position.y,}
         )
 
     return row

--- a/kloppy/infra/serializers/tracking/epts/meta_data.py
+++ b/kloppy/infra/serializers/tracking/epts/meta_data.py
@@ -10,6 +10,8 @@ from kloppy.domain import (
     DatasetFlag,
     AttackingDirection,
     Orientation,
+    Position,
+    Point,
 )
 from kloppy.infra.utils import Readable
 
@@ -76,14 +78,28 @@ def _load_players(players_elm, team: Team) -> List[Player]:
             name=str(player_elm.find("Name")),
             first_name="",
             last_name="",
-            position=[],
+            position=_load_position_data(
+                player_elm.find("ProviderPlayerParameters")
+            ),
             attributes=_load_provider_parameters(
-                players_elm.find("ProviderPlayerParameters")
+                player_elm.find("ProviderPlayerParameters")
             ),
         )
         for player_elm in players_elm.iterchildren(tag="Player")
         if player_elm.attrib["teamId"] == team.team_id
     ]
+
+
+def _load_position_data(parent_elm) -> Position:
+    player_provider_parameters = _load_provider_parameters(parent_elm)
+    return Position(
+        position_id=player_provider_parameters["position_index"],
+        name=player_provider_parameters["position_type"],
+        coordinates=Point(
+            player_provider_parameters["position_x"],
+            player_provider_parameters["position_y"],
+        ),
+    )
 
 
 def _load_data_format_specifications(

--- a/kloppy/infra/serializers/tracking/epts/meta_data.py
+++ b/kloppy/infra/serializers/tracking/epts/meta_data.py
@@ -124,8 +124,8 @@ def load_meta_data(meta_data_file: Readable) -> EPTSMetaData:
     )
     score_elm = score_path.find(meta_data)
     _team_map = {
-        score_elm.attrib["idLocalTeam"]: Team.HOME,
-        score_elm.attrib["idVisitingTeam"]: Team.AWAY,
+        "HOME": score_elm.attrib["idLocalTeam"],
+        "AWAY": score_elm.attrib["idVisitingTeam"],
     }
 
     players = _load_players(meta_data.find("Players"), _team_map)

--- a/kloppy/infra/serializers/tracking/epts/meta_data.py
+++ b/kloppy/infra/serializers/tracking/epts/meta_data.py
@@ -211,8 +211,25 @@ def load_meta_data(meta_data_file: Readable) -> EPTSMetaData:
     pitch_dimensions = _load_pitch_dimensions(meta_data, sensors)
     periods = _load_periods(meta_data.find("GlobalConfig"), frame_rate)
 
+    if periods:
+        start_attacking_direction = periods[0].attacking_direction
+    else:
+        start_attacking_direction = None
+
+    orientation = (
+        (
+            Orientation.FIXED_HOME_AWAY
+            if start_attacking_direction == AttackingDirection.HOME_AWAY
+            else Orientation.FIXED_AWAY_HOME
+        )
+        if start_attacking_direction != AttackingDirection.NOT_SET
+        else None
+    )
+
+    meta_data.orientation = orientation
+
     return EPTSMetaData(
-        teams=[team for team in teams_meta_data.values()],
+        teams=list(teams_meta_data.values()),
         periods=periods,
         pitch_dimensions=pitch_dimensions,
         data_format_specifications=data_format_specifications,

--- a/kloppy/infra/serializers/tracking/epts/meta_data.py
+++ b/kloppy/infra/serializers/tracking/epts/meta_data.py
@@ -139,12 +139,12 @@ def load_meta_data(meta_data_file: Readable) -> EPTSMetaData:
     }
 
     teams_meta_data = {
-        key: Team(
-            team_id=value,
-            name=_team_name_map[value],
-            players=_load_players(meta_data.find("Players"), value),
+        ground: Team(
+            team_id=team_id,
+            name=_team_name_map[team_id],
+            players=_load_players(meta_data.find("Players"), team_id),
         )
-        for key, value in _team_map.items()
+        for ground, team_id in _team_map.items()
     }
 
     data_format_specifications = _load_data_format_specifications(
@@ -160,7 +160,7 @@ def load_meta_data(meta_data_file: Readable) -> EPTSMetaData:
         for channel in sensor.channels
     }
 
-    _all_players = []
+    _all_players = []  # TODO improve this loop
     for key, value in teams_meta_data.items():
         _all_players = _all_players + value.players
 
@@ -182,8 +182,7 @@ def load_meta_data(meta_data_file: Readable) -> EPTSMetaData:
     pitch_dimensions = _load_pitch_dimensions(meta_data, sensors)
 
     return EPTSMetaData(
-        home_team=teams_meta_data["home"],
-        away_team=teams_meta_data["away"],
+        teams=[teams_meta_data["home"], teams_meta_data["away"]],
         periods=periods,
         pitch_dimensions=pitch_dimensions,
         data_format_specifications=data_format_specifications,

--- a/kloppy/infra/serializers/tracking/epts/meta_data.py
+++ b/kloppy/infra/serializers/tracking/epts/meta_data.py
@@ -91,6 +91,9 @@ def _load_players(players_elm, team: Team) -> List[Player]:
 
 
 def _load_position_data(parent_elm) -> Position:
+    # TODO: _load_provider_parameters is called twice to set position data
+    # and then again to set the attributes. Also, data in position should not
+    # be duplicated in attributes either.
     player_provider_parameters = _load_provider_parameters(parent_elm)
     return Position(
         position_id=player_provider_parameters["position_index"],

--- a/kloppy/infra/serializers/tracking/epts/meta_data.py
+++ b/kloppy/infra/serializers/tracking/epts/meta_data.py
@@ -76,8 +76,6 @@ def _load_players(players_elm, team: Team) -> List[Player]:
             jersey_no=str(player_elm.find("ShirtNumber")),
             player_id=player_elm.attrib["id"],
             name=str(player_elm.find("Name")),
-            first_name="",
-            last_name="",
             position=_load_position_data(
                 player_elm.find("ProviderPlayerParameters")
             ),

--- a/kloppy/infra/serializers/tracking/epts/models.py
+++ b/kloppy/infra/serializers/tracking/epts/models.py
@@ -77,10 +77,7 @@ class PlayerChannelRef:
     ) -> str:
         if self.player_channel_id in player_channel_map:
             player_channel = player_channel_map[self.player_channel_id]
-            team_str = (
-                "home" if player_channel.player.team == Team.HOME else "away"
-            )
-            return f"(?P<player_{team_str}_{player_channel.player.jersey_no}_{player_channel.channel.channel_id}>{NON_SPLIT_CHAR_REGEX})"
+            return f"(?P<{player_channel.player.player_id}_{player_channel.channel.channel_id}>{NON_SPLIT_CHAR_REGEX})"
         else:
             return NON_SPLIT_CHAR_REGEX
 

--- a/kloppy/infra/serializers/tracking/epts/models.py
+++ b/kloppy/infra/serializers/tracking/epts/models.py
@@ -164,4 +164,3 @@ class EPTSMetaData(MetaData):
     player_channels: List[PlayerChannel]
     data_format_specifications: List[DataFormatSpecification]
     sensors: List[Sensor]
-    frame_rate: int

--- a/kloppy/infra/serializers/tracking/epts/models.py
+++ b/kloppy/infra/serializers/tracking/epts/models.py
@@ -77,7 +77,7 @@ class PlayerChannelRef:
     ) -> str:
         if self.player_channel_id in player_channel_map:
             player_channel = player_channel_map[self.player_channel_id]
-            return f"(?P<{player_channel.player.player_id}_{player_channel.channel.channel_id}>{NON_SPLIT_CHAR_REGEX})"
+            return f"(?P<player_{player_channel.player.player_id}_{player_channel.channel.channel_id}>{NON_SPLIT_CHAR_REGEX})"
         else:
             return NON_SPLIT_CHAR_REGEX
 

--- a/kloppy/infra/serializers/tracking/epts/serializer.py
+++ b/kloppy/infra/serializers/tracking/epts/serializer.py
@@ -9,7 +9,6 @@ from kloppy.domain import (
     Point,
     Team,
     Orientation,
-    attacking_direction_from_frame,
 )
 from kloppy.infra.utils import Readable, performance_logging
 
@@ -54,7 +53,7 @@ class EPTSSerializer(TrackingDataSerializer):
             ball_state=None,
             period=period,
             players_coordinates=players_coordinates,
-            ball_position=Point(x=row["ball_x"], y=row["ball_y"]),
+            ball_coordinates=Point(x=row["ball_x"], y=row["ball_y"]),
         )
 
     def deserialize(

--- a/kloppy/infra/serializers/tracking/epts/serializer.py
+++ b/kloppy/infra/serializers/tracking/epts/serializer.py
@@ -39,15 +39,13 @@ class EPTSSerializer(TrackingDataSerializer):
             period = None
 
         players_coordinates = {}
-        players_ground = {}
         for team in meta_data.teams:
             for player in team.players:
                 if f"player_{player.player_id}_x" in row:
-                    players_coordinates[player.player_id] = Point(
+                    players_coordinates[player] = Point(
                         x=row[f"player_{player.player_id}_x"],
                         y=row[f"player_{player.player_id}_y"],
                     )
-                    players_ground[player.player_id] = player.team.ground
 
         return Frame(
             frame_id=row["frame_id"],
@@ -56,7 +54,6 @@ class EPTSSerializer(TrackingDataSerializer):
             ball_state=None,
             period=period,
             players_coordinates=players_coordinates,
-            players_ground=players_ground,
             ball_position=Point(x=row["ball_x"], y=row["ball_y"]),
         )
 
@@ -127,29 +124,6 @@ class EPTSSerializer(TrackingDataSerializer):
                     limit=limit,
                 )
             ]
-
-        periods = meta_data.periods
-
-        if periods:
-            start_attacking_direction = periods[0].attacking_direction
-        elif frames:
-            start_attacking_direction = attacking_direction_from_frame(
-                frames[0]
-            )
-        else:
-            start_attacking_direction = None
-
-        orientation = (
-            (
-                Orientation.FIXED_HOME_AWAY
-                if start_attacking_direction == AttackingDirection.HOME_AWAY
-                else Orientation.FIXED_AWAY_HOME
-            )
-            if start_attacking_direction != AttackingDirection.NOT_SET
-            else None
-        )
-
-        meta_data.orientation = orientation
 
         return TrackingDataset(records=frames, meta_data=meta_data)
 

--- a/kloppy/infra/serializers/tracking/metrica.py
+++ b/kloppy/infra/serializers/tracking/metrica.py
@@ -179,8 +179,10 @@ class MetricaTrackingSerializer(TrackingDataSerializer):
         # consider reading this from data
         frame_rate = 25
 
+        # TODO: also used in Tracab, extract to a method
         home_team = Team(team_id="home", name="home", ground=Ground.HOME)
         away_team = Team(team_id="away", name="away", ground=Ground.AWAY)
+        teams = [home_team, away_team]
 
         with performance_logging("prepare", logger=logger):
             home_iterator = self.__create_iterator(
@@ -247,7 +249,7 @@ class MetricaTrackingSerializer(TrackingDataSerializer):
         )
 
         meta_data = MetaData(
-            teams=[home_team, away_team],
+            teams=teams,
             periods=periods,
             pitch_dimensions=PitchDimensions(
                 x_dim=Dimension(0, 1), y_dim=Dimension(0, 1)

--- a/kloppy/infra/serializers/tracking/tracab.py
+++ b/kloppy/infra/serializers/tracking/tracab.py
@@ -18,6 +18,7 @@ from kloppy.domain import (
     attacking_direction_from_frame,
     MetaData,
     Ground,
+    Player,
 )
 from kloppy.infra.utils import Readable, performance_logging
 
@@ -34,18 +35,34 @@ class TRACABSerializer(TrackingDataSerializer):
 
         players_coordinates = {}
 
-        for player in players.split(";")[:-1]:
-            team_id, target_id, jersey_no, x, y, speed = player.split(",")
+        for player_data in players.split(";")[:-1]:
+            team_id, target_id, jersey_no, x, y, speed = player_data.split(",")
             team_id = int(team_id)
 
             if team_id == 1:
-                players_coordinates[f"home_{jersey_no}"] = Point(
-                    float(x), float(y)
-                )
+                player = teams[0].get_player_by_jersey_number(jersey_no)
+
+                if player is None:
+                    player = Player(
+                        player_id=f"home_{jersey_no}",
+                        team=teams[0],
+                        jersey_no=jersey_no,
+                    )
+                    teams[0].players.append(player)
+
+                players_coordinates[player] = Point(float(x), float(y))
             elif team_id == 0:
-                players_coordinates[f"away_{jersey_no}"] = Point(
-                    float(x), float(y)
-                )
+                player = teams[1].get_player_by_jersey_number(jersey_no)
+
+                if player is None:
+                    player = Player(
+                        player_id=f"away_{jersey_no}",
+                        team=teams[1],
+                        jersey_no=jersey_no,
+                    )
+                    teams[1].players.append(player)
+
+                players_coordinates[player] = Point(float(x), float(y))
 
         (
             ball_x,

--- a/kloppy/tests/files/epts_meta.xml
+++ b/kloppy/tests/files/epts_meta.xml
@@ -54,8 +54,20 @@
 				<ShirtNumber>22</ShirtNumber>
 				<ProviderPlayerParameters>
 					<ProviderParameter>
-						<Name>position</Name>
+						<Name>position_type</Name>
 						<Value>Defender</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_index</Name>
+						<Value>1</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_x</Name>
+						<Value>0.11</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_y</Name>
+						<Value>0.65</Value>
 					</ProviderParameter>
 				</ProviderPlayerParameters>
 			</Player>
@@ -64,8 +76,20 @@
 				<ShirtNumber>10</ShirtNumber>
 				<ProviderPlayerParameters>
 					<ProviderParameter>
-						<Name>position</Name>
+						<Name>position_type</Name>
 						<Value>Midfielder</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_index</Name>
+						<Value>2</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_x</Name>
+						<Value>0.25</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_y</Name>
+						<Value>0.9</Value>
 					</ProviderParameter>
 				</ProviderPlayerParameters>
 			</Player>
@@ -74,8 +98,20 @@
 				<ShirtNumber>7</ShirtNumber>
 				<ProviderPlayerParameters>
 					<ProviderParameter>
-						<Name>position</Name>
-						<Value>Forward</Value>
+						<Name>position_type</Name>
+						<Value>Stricker</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_index</Name>
+						<Value>3</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_x</Name>
+						<Value>0.39</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_y</Name>
+						<Value>0.5</Value>
 					</ProviderParameter>
 				</ProviderPlayerParameters>
 			</Player>
@@ -84,8 +120,20 @@
 				<ShirtNumber>14</ShirtNumber>
 				<ProviderPlayerParameters>
 					<ProviderParameter>
-						<Name>position</Name>
+						<Name>position_type</Name>
 						<Value>Goalkeeper</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_index</Name>
+						<Value>0</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_x</Name>
+						<Value>0.02</Value>
+					</ProviderParameter>
+					<ProviderParameter>
+						<Name>position_y</Name>
+						<Value>0.5</Value>
 					</ProviderParameter>
 				</ProviderPlayerParameters>
 			</Player>

--- a/kloppy/tests/test_epts.py
+++ b/kloppy/tests/test_epts.py
@@ -110,4 +110,4 @@ class TestEPTSTracking:
             x=-769, y=-2013
         )
 
-        assert dataset.records[0].ball_position == Point(x=-2656, y=367)
+        assert dataset.records[0].ball_coordinates == Point(x=-2656, y=367)

--- a/kloppy/tests/test_epts.py
+++ b/kloppy/tests/test_epts.py
@@ -67,8 +67,8 @@ class TestEPTSTracking:
             )
             data_frame = DataFrame.from_records(records)
 
-        assert "player_home_22_max_heartbeat" in data_frame.columns
-        assert "player_home_22_x" in data_frame.columns
+        assert "player_1_max_heartbeat" in data_frame.columns
+        assert "player_1_x" in data_frame.columns
 
     def test_skip_sensors(self):
         base_dir = os.path.dirname(__file__)
@@ -84,8 +84,8 @@ class TestEPTSTracking:
             )
             data_frame = DataFrame.from_records(records)
 
-        assert "player_home_22_max_heartbeat" in data_frame.columns
-        assert "player_home_22_x" not in data_frame.columns
+        assert "player_1_max_heartbeat" in data_frame.columns
+        assert "player_1_x" not in data_frame.columns
 
     def test_correct_deserialization(self):
         base_dir = os.path.dirname(__file__)
@@ -100,12 +100,14 @@ class TestEPTSTracking:
                 inputs={"meta_data": meta_data, "raw_data": raw_data}
             )
 
-        assert len(dataset.records) == 2
-        assert len(dataset.periods) == 1
-        assert dataset.orientation is None
+        first_player = next(iter(dataset.records[0].players_coordinates))
 
-        assert dataset.records[0].home_team_player_positions["22"] == Point(
+        assert len(dataset.records) == 2
+        assert len(dataset.meta_data.periods) == 1
+        assert dataset.meta_data.orientation is None
+
+        assert dataset.records[0].players_coordinates[first_player] == Point(
             x=-769, y=-2013
         )
-        assert dataset.records[0].away_team_player_positions == {}
+
         assert dataset.records[0].ball_position == Point(x=-2656, y=367)

--- a/kloppy/tests/test_metrica.py
+++ b/kloppy/tests/test_metrica.py
@@ -25,15 +25,15 @@ class TestMetricaTracking:
             )
 
         assert len(dataset.records) == 6
-        assert len(dataset.periods) == 2
-        assert dataset.orientation == Orientation.FIXED_HOME_AWAY
-        assert dataset.periods[0] == Period(
+        assert len(dataset.meta_data.periods) == 2
+        assert dataset.meta_data.orientation == Orientation.FIXED_HOME_AWAY
+        assert dataset.meta_data.periods[0] == Period(
             id=1,
             start_timestamp=0.04,
             end_timestamp=0.12,
             attacking_direction=AttackingDirection.HOME_AWAY,
         )
-        assert dataset.periods[1] == Period(
+        assert dataset.meta_data.periods[1] == Period(
             id=2,
             start_timestamp=5800.16,
             end_timestamp=5800.24,
@@ -41,19 +41,19 @@ class TestMetricaTracking:
         )
 
         # make sure data is loaded correctly (including flip y-axis)
-        assert dataset.records[0].home_team_player_positions["11"] == Point(
+        assert dataset.records[0].players_coordinates["home_11"] == Point(
             x=0.00082, y=1 - 0.48238
         )
-        assert dataset.records[0].away_team_player_positions["25"] == Point(
+        assert dataset.records[0].players_coordinates["away_25"] == Point(
             x=0.90509, y=1 - 0.47462
         )
-        assert dataset.records[0].ball_position == Point(
+        assert dataset.records[0].ball_coordinates == Point(
             x=0.45472, y=1 - 0.38709
         )
 
         # make sure player data is only in the frame when the player is at the pitch
-        assert "14" not in dataset.records[0].home_team_player_positions
-        assert "14" in dataset.records[3].home_team_player_positions
+        assert "home_14" not in dataset.records[0].players_coordinates
+        assert "home_14" in dataset.records[3].players_coordinates
 
 
 #

--- a/kloppy/tests/test_metrica.py
+++ b/kloppy/tests/test_metrica.py
@@ -41,19 +41,29 @@ class TestMetricaTracking:
         )
 
         # make sure data is loaded correctly (including flip y-axis)
-        assert dataset.records[0].players_coordinates["home_11"] == Point(
+        home_player = dataset.meta_data.teams[0].players[0]
+        assert dataset.records[0].players_coordinates[home_player] == Point(
             x=0.00082, y=1 - 0.48238
         )
-        assert dataset.records[0].players_coordinates["away_25"] == Point(
+
+        away_player = dataset.meta_data.teams[1].players[0]
+        assert dataset.records[0].players_coordinates[away_player] == Point(
             x=0.90509, y=1 - 0.47462
         )
+
         assert dataset.records[0].ball_coordinates == Point(
             x=0.45472, y=1 - 0.38709
         )
 
         # make sure player data is only in the frame when the player is at the pitch
-        assert "home_14" not in dataset.records[0].players_coordinates
-        assert "home_14" in dataset.records[3].players_coordinates
+        assert "home_14" not in [
+            player.player_id
+            for player in dataset.records[0].players_coordinates.keys()
+        ]
+        assert "home_14" in [
+            player.player_id
+            for player in dataset.records[3].players_coordinates.keys()
+        ]
 
 
 #

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -19,17 +19,19 @@ class TestOpta:
             )
 
         assert len(dataset.events) == 17
-        assert len(dataset.periods) == 2
-        assert dataset.orientation == Orientation.ACTION_EXECUTING_TEAM
-        assert dataset.periods[0] == Period(
+        assert len(dataset.meta_data.periods) == 2
+        assert (
+            dataset.meta_data.orientation == Orientation.ACTION_EXECUTING_TEAM
+        )
+        assert dataset.meta_data.periods[0] == Period(
             id=1,
-            start_timestamp=1537707733.608,
-            end_timestamp=1537710501.222,
+            start_timestamp=1537725733.608,
+            end_timestamp=1537728501.222,
             attacking_direction=AttackingDirection.NOT_SET,
         )
-        assert dataset.periods[1] == Period(
+        assert dataset.meta_data.periods[1] == Period(
             id=2,
-            start_timestamp=1537711528.873,
-            end_timestamp=1537714537.788,
+            start_timestamp=1537729528.873,
+            end_timestamp=1537732537.788,
             attacking_direction=AttackingDirection.NOT_SET,
         )

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -24,15 +24,17 @@ class TestStatsbomb:
             )
 
         assert len(dataset.events) == 4002
-        assert len(dataset.periods) == 2
-        assert dataset.orientation == Orientation.ACTION_EXECUTING_TEAM
-        assert dataset.periods[0] == Period(
+        assert len(dataset.meta_data.periods) == 2
+        assert (
+            dataset.meta_data.orientation == Orientation.ACTION_EXECUTING_TEAM
+        )
+        assert dataset.meta_data.periods[0] == Period(
             id=1,
             start_timestamp=0.0,
             end_timestamp=2705.267,
             attacking_direction=AttackingDirection.NOT_SET,
         )
-        assert dataset.periods[1] == Period(
+        assert dataset.meta_data.periods[1] == Period(
             id=2,
             start_timestamp=2705.268,
             end_timestamp=5557.321,

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -8,6 +8,7 @@ from kloppy.domain import (
     Point,
     BallState,
     Team,
+    Ground,
 )
 
 
@@ -29,36 +30,40 @@ class TestTracabTracking:
             )
 
         assert len(dataset.records) == 6
-        assert len(dataset.periods) == 2
-        assert dataset.orientation == Orientation.FIXED_HOME_AWAY
-        assert dataset.periods[0] == Period(
+        assert len(dataset.meta_data.periods) == 2
+        assert dataset.meta_data.orientation == Orientation.FIXED_HOME_AWAY
+        assert dataset.meta_data.periods[0] == Period(
             id=1,
             start_timestamp=4.0,
             end_timestamp=4.08,
             attacking_direction=AttackingDirection.HOME_AWAY,
         )
 
-        assert dataset.periods[1] == Period(
+        assert dataset.meta_data.periods[1] == Period(
             id=2,
             start_timestamp=8.0,
             end_timestamp=8.08,
             attacking_direction=AttackingDirection.AWAY_HOME,
         )
 
-        assert dataset.records[0].home_team_player_positions["19"] == Point(
+        assert dataset.records[0].players_coordinates["home_19"] == Point(
             x=-1234.0, y=-294.0
         )
-        assert dataset.records[0].away_team_player_positions["19"] == Point(
+        assert dataset.records[0].players_coordinates["away_19"] == Point(
             x=8889, y=-666
         )
-        assert dataset.records[0].ball_position == Point(x=-27, y=25)
+        assert dataset.records[0].ball_coordinates == Point(x=-27, y=25)
         assert dataset.records[0].ball_state == BallState.ALIVE
-        assert dataset.records[0].ball_owning_team == Team.HOME
+        assert dataset.records[0].ball_owning_team == Team(
+            team_id="home", name="home", ground=Ground.HOME
+        )
 
-        assert dataset.records[1].ball_owning_team == Team.AWAY
+        assert dataset.records[1].ball_owning_team == Team(
+            team_id="away", name="away", ground=Ground.AWAY
+        )
 
         assert dataset.records[2].ball_state == BallState.DEAD
 
         # make sure player data is only in the frame when the player is at the pitch
-        assert "1337" not in dataset.records[0].away_team_player_positions
-        assert "1337" in dataset.records[3].away_team_player_positions
+        assert "away_1337" not in dataset.records[0].players_coordinates
+        assert "away_1337" in dataset.records[3].players_coordinates

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -46,10 +46,17 @@ class TestTracabTracking:
             attacking_direction=AttackingDirection.AWAY_HOME,
         )
 
-        assert dataset.records[0].players_coordinates["home_19"] == Point(
+        player_home_19 = dataset.meta_data.teams[
+            0
+        ].get_player_by_jersey_number("19")
+        assert dataset.records[0].players_coordinates[player_home_19] == Point(
             x=-1234.0, y=-294.0
         )
-        assert dataset.records[0].players_coordinates["away_19"] == Point(
+
+        player_away_19 = dataset.meta_data.teams[
+            1
+        ].get_player_by_jersey_number("19")
+        assert dataset.records[0].players_coordinates[player_away_19] == Point(
             x=8889, y=-666
         )
         assert dataset.records[0].ball_coordinates == Point(x=-27, y=25)
@@ -65,5 +72,11 @@ class TestTracabTracking:
         assert dataset.records[2].ball_state == BallState.DEAD
 
         # make sure player data is only in the frame when the player is at the pitch
-        assert "away_1337" not in dataset.records[0].players_coordinates
-        assert "away_1337" in dataset.records[3].players_coordinates
+        assert "away_1337" not in [
+            player.player_id
+            for player in dataset.records[0].players_coordinates.keys()
+        ]
+        assert "away_1337" in [
+            player.player_id
+            for player in dataset.records[3].players_coordinates.keys()
+        ]


### PR DESCRIPTION
In this pull request I have modified the Player, Team, MetaData dataclasses as discussed in #3. Having the metadata information as part of the dataset, now the pandas dataframe generated when calling `to_pandas(dataset)` has the player IDs provided by the data provider as columns names. 

The idea of this pull request is not to merge it, but to evaluate whether the approach taken and the modifications made are ok. If so, I'll extend the same changes to the other formats (tracab, metrica, etc).

Some questions/comments on my side are:

1. I changed the Team dataclass to be a standard dataclass (not an Enum). On what I did I don't see a reason to keep the Enum as we can base it on the team ID or "home" / "away" as IDs when no IDs are provided by the provider. However as I'm not familiar with all the code base I'm not sure whether we prefer to keep it that way. 
2. At the moment the column names are are `{players_id}_{channel_id}`. I didn't add a `player_` at the star because I thought it was redundant, but when checking the tests for the EPTS format I got an error because when compiling the regex group names can't start with a number, and for the example in the test the `player_id` is a number.
3. Taking about tests, I'll work on making them pass once we agree on the final implementation. 
4. In the metadata model I changes form having `home_team` and `away_team` to having `teams: List[Team]` with home team first and away team second, as I thin this makes it easier to work with the teams data afterwards and also allows for a third team (for example referees data sometimes present). 
5. The `Position` of players still needs working on. 
6. Before all players where listed together, now they are linked to a team, which I think is fine but just want to point this out.

Let me know what you think! 