### PR TITLE
Infer ball_owning_team from Opta events

### DIFF
--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -246,7 +246,8 @@ event_type_names = {
     77: "player off pitch",
 }
 
-BALL_OWNING_EVENTS = (1,2,3,13,14,15,16,49)
+BALL_OWNING_EVENTS = (1, 2, 3, 13, 14, 15, 16, 49)
+
 
 def _get_event_type_name(type_id: int) -> str:
     return event_type_names.get(type_id, "unknown")
@@ -458,7 +459,7 @@ class OptaSerializer(EventDataSerializer):
                             result=None,
                             event_name=_get_event_type_name(type_id),
                         )
-                    
+
                     if (
                         not wanted_event_types
                         or event.event_type in wanted_event_types

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -406,7 +406,7 @@ class OptaSerializer(EventDataSerializer):
                             event_elm.attrib["player_id"]
                         )
 
-                    if event.type_id in BALL_OWNING_EVENTS:
+                    if type_id in BALL_OWNING_EVENTS:
                         possession_team = team
 
                     generic_event_kwargs = dict(

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -246,6 +246,7 @@ event_type_names = {
     77: "player off pitch",
 }
 
+BALL_OWNING_EVENTS = (1,2,3,13,14,15,16,49)
 
 def _get_event_type_name(type_id: int) -> str:
     return event_type_names.get(type_id, "unknown")
@@ -404,6 +405,9 @@ class OptaSerializer(EventDataSerializer):
                             event_elm.attrib["player_id"]
                         )
 
+                    if event.type_id in BALL_OWNING_EVENTS:
+                        possession_team = team
+
                     generic_event_kwargs = dict(
                         # from DataRecord
                         period=period,
@@ -455,10 +459,6 @@ class OptaSerializer(EventDataSerializer):
                             event_name=_get_event_type_name(type_id),
                         )
                     
-                    if event.event_type in [EventType.CARRY, EventType.PASS, EventType.SHOT, EventType.TAKE_ON]:
-                        possession_team = team
-                        event.ball_owning_team=possession_team
-
                     if (
                         not wanted_event_types
                         or event.event_type in wanted_event_types

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -28,6 +28,7 @@ class TestOpta:
         assert dataset.metadata.provider == Provider.OPTA
         assert len(dataset.events) == 17
         assert len(dataset.metadata.periods) == 2
+        assert dataset.events[10].ball_owning_team == dataset.metadata.teams[1]
         assert dataset.events[15].ball_owning_team == dataset.metadata.teams[0]
         assert (
             dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -28,6 +28,7 @@ class TestOpta:
         assert dataset.metadata.provider == Provider.OPTA
         assert len(dataset.events) == 17
         assert len(dataset.metadata.periods) == 2
+        assert dataset.events[15].ball_owning_team == dataset.metadata.teams[0]
         assert (
             dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
         )


### PR DESCRIPTION
Certain event types were defined as `BALL_OWNING_EVENTS` (discussion is needed over which types should be considered). Other events keep the `ball_owning_team` of the previous event.