### PR TITLE
Fix error in naming of inputs to metrica json serializer in helper

### DIFF
--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -110,7 +110,7 @@ def load_metrica_json_event_data(
     ) as raw_data:
 
         return serializer.deserialize(
-            inputs={"metadata": metadata, "raw_data": raw_data},
+            inputs={"metadata": metadata, "event_data": raw_data},
             options=options,
         )
 


### PR DESCRIPTION
in one of the alst commits we changes the name of the inputs the Metrica
Json serializer is expecting, but we didn't change it in the helper
method. This commit fixes that.