### PR TITLE
refactor: improve code readability on kloppy-query cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ env
 .ipynb_checkpoints
 .DS_Store
 kloppy/.DS_Store
+
+# Downloaded data files
+examples/pattern_matching/repository/*.json

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,14 +43,14 @@ Other pull requests merged:
 
 - Code formatting & typos in docs ([#39](https://github.com/PySport/kloppy/pull/39), [#40](https://github.com/PySport/kloppy/pull/40))
 - Add Metrica Json event serializer ([#44](https://github.com/PySport/kloppy/pull/44))
-- Infer ball_owning_team from Opta events ([#49](https://github.com/PySport/kloppy/pull/49)                      
+- Infer ball_owning_team from Opta events ([#49](https://github.com/PySport/kloppy/pull/49)
 
 ## 1.0.0 (2020-07-26)
 In this major release we introduce metadata. The metadata is part of a dataset and can be accessed via `Dataset.metadata`.
 There are a couple of breaking changes:
 
-1. All attributes except `records` / `frames` are moved from `Dataset` to `Metadata` class. 
-2. All `position` properties are renamed to `coordinates`. 
+1. All attributes except `records` / `frames` are moved from `Dataset` to `Metadata` class.
+2. All `position` properties are renamed to `coordinates`.
 3. The `players_coordinates` property is indexed by `Player` instances instead of by `jersey_number` strings.
 4. On the `Event` class the `player_jersey_number` is replaced by `player` which is a `Player` instance.
 5. `to_pandas` changes:
@@ -96,7 +96,7 @@ Other pull requests merged:
 ## 0.5.0 (2020-06-13)
 - Add pattern matching based on regular expressions
 - Add kloppy-query: command line tool to search for patterns
-  
+
 ## 0.4.1 (2020-06-05)
 - Fix for StatsBomb Serializer when location contains z coordinate
 
@@ -111,7 +111,7 @@ Other pull requests merged:
 - Add FIFA EPTS Tracking Serializer
 - Add some examples
 - Add datasets loader to directly load dataset from your python code
-- Add limit argument to all loaders               
+- Add limit argument to all loaders
 
 ## 0.2.1 (2020-05-12)
 - Add some helpers functions to directly load a dataset by filenames

--- a/kloppy/cmdline.py
+++ b/kloppy/cmdline.py
@@ -1,17 +1,14 @@
 import argparse
-import sys
 import logging
+import sys
+import textwrap
 from collections import Counter
 from dataclasses import dataclass
 from typing import List
-
 from xml.etree import ElementTree as ET
 
-from kloppy import (
-    load_statsbomb_event_data,
-    load_opta_event_data,
-    event_pattern_matching as pm,
-)
+from kloppy import event_pattern_matching as pm
+from kloppy import load_opta_event_data, load_statsbomb_event_data
 from kloppy.utils import performance_logging
 
 sys.path.append(".")
@@ -80,8 +77,7 @@ def run_query(argv=sys.argv[1:]):
         help="StatsBomb event input files (events.json,lineup.json)",
     )
     parser.add_argument(
-        "--input-opta",
-        help="Opta event input files (f24.xml,f7.xml)",
+        "--input-opta", help="Opta event input files (f24.xml,f7.xml)"
     )
     parser.add_argument("--output-xml", help="Output file")
     parser.add_argument(
@@ -206,23 +202,41 @@ def run_query(argv=sys.argv[1:]):
         logger.info(f"Wrote {len(video_fragments)} video fragments to file")
 
     if opts.stats == "text":
-        print("Home:")
-        print(f"  total count: {counter['home_total']}")
-        print(
-            f"    success: {counter['home_success']} ({counter['home_success'] / counter['home_total'] * 100:.0f}%)"
+        text_stats = """\
+        Home:
+          total count: {home_total}
+            success: {home_success} ({home_success_rate:.0f}%)
+            no success: {home_failure} ({home_failure_rate:.0f}%)
+
+        Away:
+          total count: {away_total}
+            success: {away_success} ({away_success_rate:.0f}%)
+            no success: {away_failure} ({away_failure_rate:.0f}%)
+        """.format(
+            home_total=counter["home_total"],
+            home_success=counter["home_success"],
+            home_success_rate=(
+                counter["home_success"] / counter["home_total"] * 100
+            ),
+            home_failure=counter["home_total"] - counter["home_success"],
+            home_failure_rate=(
+                (counter["home_total"] - counter["home_success"])
+                / counter["home_total"]
+                * 100
+            ),
+            away_total=counter["away_total"],
+            away_success=counter["away_success"],
+            away_success_rate=(
+                counter["away_success"] / counter["away_total"] * 100
+            ),
+            away_failure=counter["away_total"] - counter["away_success"],
+            away_failure_rate=(
+                (counter["away_total"] - counter["away_success"])
+                / counter["away_total"]
+                * 100
+            ),
         )
-        print(
-            f"    no success: {counter['home_total'] - counter['home_success']} ({(counter['home_total'] - counter['home_success']) / counter['home_total'] * 100:.0f}%)"
-        )
-        print("")
-        print("Away:")
-        print(f"  total count: {counter['away_total']}")
-        print(
-            f"    success: {counter['away_success']} ({counter['away_success'] / counter['away_total'] * 100:.0f}%)"
-        )
-        print(
-            f"    no success: {counter['away_total'] - counter['away_success']} ({(counter['away_total'] - counter['away_success']) / counter['away_total'] * 100:.0f}%)"
-        )
+        print(textwrap.dedent(text_stats))
     elif opts.stats == "json":
         import json
 

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -96,7 +96,8 @@ def load_opta_event_data(
     ) as f7_data:
 
         return serializer.deserialize(
-            inputs={"f24_data": f24_data, "f7_data": f7_data}, options=options,
+            inputs={"f24_data": f24_data, "f7_data": f7_data},
+            options=options,
         )
 
 

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -1,30 +1,28 @@
-from typing import Callable, TypeVar, Dict, Union, List
+from typing import Callable, Dict, List, TypeVar, Union
 
 from . import (
-    TRACABSerializer,
-    MetricaTrackingSerializer,
-    MetricaEventsJsonSerializer,
     EPTSSerializer,
-    StatsBombSerializer,
+    MetricaEventsJsonSerializer,
+    MetricaTrackingSerializer,
     OptaSerializer,
+    StatsBombSerializer,
+    TRACABSerializer,
 )
 from .domain import (
+    CarryEvent,
+    DataRecord,
     Dataset,
-    Frame,
+    Dimension,
     Event,
+    EventDataset,
+    EventType,
+    Frame,
+    Orientation,
+    PassEvent,
+    PassResult,
+    PitchDimensions,
     TrackingDataset,
     Transformer,
-    Orientation,
-    PitchDimensions,
-    Dimension,
-    EventDataset,
-    PassEvent,
-    CarryEvent,
-    PassResult,
-    EventType,
-    Player,
-    DataRecord,
-    SetPieceType,
 )
 
 
@@ -98,8 +96,7 @@ def load_opta_event_data(
     ) as f7_data:
 
         return serializer.deserialize(
-            inputs={"f24_data": f24_data, "f7_data": f7_data},
-            options=options,
+            inputs={"f24_data": f24_data, "f7_data": f7_data}, options=options,
         )
 
 

--- a/kloppy/utils.py
+++ b/kloppy/utils.py
@@ -40,14 +40,14 @@ _first_cap_re = re.compile("(.)([A-Z][a-z0-9]+)")
 _all_cap_re = re.compile("([a-z0-9])([A-Z])")
 
 
-def camelcase_to_snakecase(name):
+def camelcase_to_snakecase(name: str) -> str:
     """Convert camel-case string to snake-case."""
     s1 = _first_cap_re.sub(r"\1_\2", name)
     return _all_cap_re.sub(r"\1_\2", s1).lower()
 
 
-def removes_suffix(string, suffix):
-    if string[-len(suffix) :] == suffix:
+def removes_suffix(string: str, suffix: str) -> str:
+    if string[-len(suffix):] == suffix:
         return string[: -len(suffix)]
     else:
         return string

--- a/kloppy/utils.py
+++ b/kloppy/utils.py
@@ -47,7 +47,7 @@ def camelcase_to_snakecase(name: str) -> str:
 
 
 def removes_suffix(string: str, suffix: str) -> str:
-    if string[-len(suffix):] == suffix:
+    if string[-len(suffix) :] == suffix:
         return string[: -len(suffix)]
     else:
         return string


### PR DESCRIPTION
I was just exploring, so I didn't make any real improvement in terms of performance, only readability... There are too many changes and I'm not sure everybody agrees with me that that print is more readable, so I'll understand if it's rejected.

Changes :zap: :
- Ignore files that are recommended to be downloaded by the examples.
- Remove trailing spaces (this was not on purpose)
- Sort imports on `cmdfile.py` and `helpers.py`
- Refactor stats print on `kloppy-query` CLI code.