### PR TITLE
Improve sequence definition based on latest added generic events

### DIFF
--- a/kloppy/domain/services/state_builder/__init__.py
+++ b/kloppy/domain/services/state_builder/__init__.py
@@ -24,9 +24,16 @@ def add_state(dataset: EventDataset, *builder_keys: List[str]) -> EventDataset:
 
     events = []
     for event in dataset.events:
-        events.append(replace(event, state=state))
+
         state = {
-            builder_key: builder.reduce(state[builder_key], event)
+            builder_key: builder.reduce_before(state[builder_key], event)
+            for builder_key, builder in builders.items()
+        }
+
+        events.append(replace(event, state=state))
+
+        state = {
+            builder_key: builder.reduce_after(state[builder_key], event)
             for builder_key, builder in builders.items()
         }
 

--- a/kloppy/domain/services/state_builder/builder.py
+++ b/kloppy/domain/services/state_builder/builder.py
@@ -13,5 +13,9 @@ class StateBuilder(metaclass=RegisteredStateBuilder):
         pass
 
     @abstractmethod
-    def reduce(self, state: T, event: Event) -> T:
+    def reduce_before(self, state: T, event: Event) -> T:
+        pass
+
+    @abstractmethod
+    def reduce_after(self, state: T, event: Event) -> T:
         pass

--- a/kloppy/domain/services/state_builder/builders/lineup.py
+++ b/kloppy/domain/services/state_builder/builders/lineup.py
@@ -42,7 +42,10 @@ class LineupStateBuilder(StateBuilder):
             )
         )
 
-    def reduce(self, state: Lineup, event: Event) -> Lineup:
+    def reduce_before(self, state: Lineup, event: Event) -> Lineup:
+        return state
+
+    def reduce_after(self, state: Lineup, event: Event) -> Lineup:
         if isinstance(event, SubstitutionEvent):
             state = Lineup(
                 players=state.players - {event.player}

--- a/kloppy/domain/services/state_builder/builders/score.py
+++ b/kloppy/domain/services/state_builder/builders/score.py
@@ -17,7 +17,10 @@ class ScoreStateBuilder(StateBuilder):
     def initial_state(self, dataset: EventDataset) -> Score:
         return Score(home=0, away=0)
 
-    def reduce(self, state: Score, event: Event) -> Score:
+    def reduce_before(self, state: Score, event: Event) -> Score:
+        return state
+
+    def reduce_after(self, state: Score, event: Event) -> Score:
         if isinstance(event, ShotEvent):
             if event.result == ShotResult.GOAL:
                 if event.team.ground == Ground.HOME:

--- a/kloppy/domain/services/state_builder/builders/sequence.py
+++ b/kloppy/domain/services/state_builder/builders/sequence.py
@@ -24,26 +24,25 @@ class Sequence:
 
 
 class SequenceStateBuilder(StateBuilder):
-    def __init__(self):
-        self.sequence_open = False
-
     def initial_state(self, dataset: EventDataset) -> Sequence:
         for event in dataset.events:
             if isinstance(event, OPEN_SEQUENCE):
-                self.sequence_open = True
                 return Sequence(sequence_id=0, team=event.team)
         return Sequence(sequence_id=0, team=None)
 
-    def reduce(self, state: Sequence, event: Event) -> Sequence:
-
-        if self.sequence_open and isinstance(event, CLOSE_SEQUENCE):
-            state = replace(
-                state, sequence_id=state.sequence_id + 1, team=None
-            )
-
-        if not self.sequence_open and isinstance(event, OPEN_SEQUENCE):
+    def reduce_before(self, state: Sequence, event: Event) -> Sequence:
+        if isinstance(event, OPEN_SEQUENCE) and state.team != event.team:
             state = replace(
                 state, sequence_id=state.sequence_id + 1, team=event.team
+            )
+
+        return state
+
+    def reduce_after(self, state: Sequence, event: Event) -> Sequence:
+
+        if isinstance(event, CLOSE_SEQUENCE):
+            state = replace(
+                state, sequence_id=state.sequence_id + 1, team=None
             )
 
         return state

--- a/kloppy/domain/services/state_builder/builders/sequence.py
+++ b/kloppy/domain/services/state_builder/builders/sequence.py
@@ -1,7 +1,20 @@
 from dataclasses import replace, dataclass
 
-from kloppy.domain import Event, Team, EventDataset, PassEvent
+from kloppy.domain import (
+    Event,
+    Team,
+    EventDataset,
+    PassEvent,
+    CarryEvent,
+    RecoveryEvent,
+    BallOutEvent,
+    FoulCommittedEvent,
+    ShotEvent,
+)
 from ..builder import StateBuilder
+
+OPEN_SEQUENCE = (PassEvent, CarryEvent, RecoveryEvent)
+CLOSE_SEQUENCE = (BallOutEvent, FoulCommittedEvent, ShotEvent)
 
 
 @dataclass
@@ -11,15 +24,26 @@ class Sequence:
 
 
 class SequenceStateBuilder(StateBuilder):
+    def __init__(self):
+        self.sequence_open = False
+
     def initial_state(self, dataset: EventDataset) -> Sequence:
         for event in dataset.events:
-            if isinstance(event, PassEvent):
+            if isinstance(event, OPEN_SEQUENCE):
+                self.sequence_open = True
                 return Sequence(sequence_id=0, team=event.team)
         return Sequence(sequence_id=0, team=None)
 
     def reduce(self, state: Sequence, event: Event) -> Sequence:
-        if state.team != event.team:
+
+        if self.sequence_open and isinstance(event, CLOSE_SEQUENCE):
+            state = replace(
+                state, sequence_id=state.sequence_id + 1, team=None
+            )
+
+        if not self.sequence_open and isinstance(event, OPEN_SEQUENCE):
             state = replace(
                 state, sequence_id=state.sequence_id + 1, team=event.team
             )
+
         return state


### PR DESCRIPTION
In this commit, as proposed in #72 I implemented and improvement on the
definition of sequences so that they are opened by a pass, carry or
recovery, and closed by a ball out, fould committed or shot on target.

This results also in sequences in which the team is None, whixh I think
is interesting so you can look at events or tracking data when no team
is in possession.