### PR TITLE
Fix sequences reset at set pieces

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -161,14 +161,6 @@ class Event(DataRecord, ABC):
                     return qualifier.value
         return None
 
-    @property
-    def is_set_piece(self):
-        if self.qualifiers:
-            for qualifier in self.qualifiers:
-                if isinstance(qualifier, SetPieceQualifier):
-                    return True
-        return False
-
 
 @dataclass
 class GenericEvent(Event):

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -161,6 +161,14 @@ class Event(DataRecord, ABC):
                     return qualifier.value
         return None
 
+    @property
+    def is_set_piece(self):
+        if self.qualifiers:
+            for qualifier in self.qualifiers:
+                if isinstance(qualifier, SetPieceQualifier):
+                    return True
+        return False
+
 
 @dataclass
 class GenericEvent(Event):

--- a/kloppy/domain/services/state_builder/builders/sequence.py
+++ b/kloppy/domain/services/state_builder/builders/sequence.py
@@ -31,7 +31,9 @@ class SequenceStateBuilder(StateBuilder):
         return Sequence(sequence_id=0, team=None)
 
     def reduce_before(self, state: Sequence, event: Event) -> Sequence:
-        if isinstance(event, OPEN_SEQUENCE) and state.team != event.team:
+        if isinstance(event, OPEN_SEQUENCE) and (
+            state.team != event.team or event.is_set_piece
+        ):
             state = replace(
                 state, sequence_id=state.sequence_id + 1, team=event.team
             )

--- a/kloppy/domain/services/state_builder/builders/sequence.py
+++ b/kloppy/domain/services/state_builder/builders/sequence.py
@@ -10,6 +10,7 @@ from kloppy.domain import (
     BallOutEvent,
     FoulCommittedEvent,
     ShotEvent,
+    SetPieceQualifier,
 )
 from ..builder import StateBuilder
 
@@ -32,7 +33,8 @@ class SequenceStateBuilder(StateBuilder):
 
     def reduce_before(self, state: Sequence, event: Event) -> Sequence:
         if isinstance(event, OPEN_SEQUENCE) and (
-            state.team != event.team or event.is_set_piece
+            state.team != event.team
+            or event.get_qualifier_value(SetPieceQualifier)
         ):
             state = replace(
                 state, sequence_id=state.sequence_id + 1, team=event.team

--- a/kloppy/tests/test_state_builder.py
+++ b/kloppy/tests/test_state_builder.py
@@ -58,8 +58,8 @@ class TestStateBuilder:
             events = list(events)
             events_per_sequence[sequence_id] = len(events)
 
-        assert events_per_sequence[0] == 9
-        assert events_per_sequence[50] == 2
+        assert events_per_sequence[0] == 4
+        assert events_per_sequence[50] == 14
 
     def test_lineup_state_builder(self):
         dataset = self._load_dataset("statsbomb_15986")


### PR DESCRIPTION
It is difficult to contemplate all the possible ways in which different
providers code for a ball out. This could lead to sequences not being
ended / started properly, leading to a se piece in the middle of a
sequence. In this commit we changed that so that we always start a new
sequence whenever a set piece event occurs.