### PR TITLE
Add body_part for pass events and shot events in Statsbomb's serializer.

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -263,14 +263,33 @@ class BodyPart(Enum):
     BodyPart
 
     Attributes:
-        RIGHT_FOOT (BodyPart):
-        LEFT_FOOT (BodyPart):
-        HEAD (BodyPart):
+        RIGHT_FOOT (BodyPart): Pass or Shot with right foot, save with right foot (for goalkeepers).
+        LEFT_FOOT (BodyPart): Pass or Shot with leftt foot, save with left foot (for goalkeepers).
+        HEAD (BodyPart): Pass or Shot with head, save with head (for goalkeepers).
+        BOTH_HANDS (BodyPart): Goalkeeper only. Save with both hands.
+        CHEST (BodyPart): Goalkeeper only. Save with chest.
+        LEFT_HAND (BodyPart): Goalkeeper only. Save with left hand.
+        RIGHT_HAND (BodyPart): Goalkeeper only. Save with right hand.
+        DROP_KICK (BodyPart): Pass is a keeper drop kick.
+        KEEPER_ARM (BodyPart): Pass thrown from keepers hands.
+        OTHER (BodyPart): Other body part (chest, back, etc.), for Pass and Shot.
+        NO_TOUCH (BodyPart): Pass only. A player deliberately let the pass go past him
+                             instead of receiving it to deliver to a teammate behind him.
+                             (Also known as a "dummy").
     """
 
     RIGHT_FOOT = "RIGHT_FOOT"
     LEFT_FOOT = "LEFT_FOOT"
     HEAD = "HEAD"
+
+    BOTH_HANDS = "BOTH_HANDS"
+    CHEST = "CHEST"
+    LEFT_HAND = "LEFT_HAND"
+    RIGHT_HAND = "RIGHT_HAND"
+    DROP_KICK = "DROP_KICK"
+    KEEPER_ARM = "KEEPER_ARM"
+    OTHER = "OTHER"
+    NO_TOUCH = "NO_TOUCH"
 
 
 @dataclass
@@ -383,6 +402,8 @@ class ShotEvent(Event):
         result (ShotResult): See [`ShotResult`][kloppy.domain.models.event.ShotResult]
     """
 
+    body_part: BodyPartQualifier
+
     result: ShotResult
     result_coordinates: Point = None
 
@@ -410,6 +431,8 @@ class PassEvent(Event):
     receiver_coordinates: Point
 
     result: PassResult
+
+    body_part: BodyPartQualifier
 
     event_type: EventType = EventType.PASS
     event_name: str = "pass"

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -400,15 +400,16 @@ class ShotEvent(Event):
         event_name (str): `"shot"`,
         result_coordinates (Point): See [`Point`][kloppy.domain.models.pitch.Point]
         result (ShotResult): See [`ShotResult`][kloppy.domain.models.event.ShotResult]
+        body_part (BodyPartQualifier): body part attributes.
     """
-
-    body_part: BodyPartQualifier
 
     result: ShotResult
     result_coordinates: Point = None
 
     event_type: EventType = EventType.SHOT
     event_name: str = "shot"
+
+    body_part: BodyPartQualifier = None
 
 
 @dataclass
@@ -424,6 +425,7 @@ class PassEvent(Event):
         receiver_coordinates (Point): See [`Point`][kloppy.domain.models.pitch.Point]
         receiver_player (Player): See [`Player`][kloppy.domain.models.common.Player]
         result (PassResult): See [`PassResult`][kloppy.domain.models.event.PassResult]
+        body_part (BodyPartQualifier): body part attributes.
     """
 
     receive_timestamp: float
@@ -432,10 +434,10 @@ class PassEvent(Event):
 
     result: PassResult
 
-    body_part: BodyPartQualifier
-
     event_type: EventType = EventType.PASS
     event_name: str = "pass"
+
+    body_part: BodyPartQualifier = None
 
 
 @dataclass

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -400,7 +400,6 @@ class ShotEvent(Event):
         event_name (str): `"shot"`,
         result_coordinates (Point): See [`Point`][kloppy.domain.models.pitch.Point]
         result (ShotResult): See [`ShotResult`][kloppy.domain.models.event.ShotResult]
-        body_part (BodyPartQualifier): body part attributes.
     """
 
     result: ShotResult
@@ -408,8 +407,6 @@ class ShotEvent(Event):
 
     event_type: EventType = EventType.SHOT
     event_name: str = "shot"
-
-    body_part: BodyPartQualifier = None
 
 
 @dataclass
@@ -425,7 +422,6 @@ class PassEvent(Event):
         receiver_coordinates (Point): See [`Point`][kloppy.domain.models.pitch.Point]
         receiver_player (Player): See [`Player`][kloppy.domain.models.common.Player]
         result (PassResult): See [`PassResult`][kloppy.domain.models.event.PassResult]
-        body_part (BodyPartQualifier): body part attributes.
     """
 
     receive_timestamp: float
@@ -436,8 +432,6 @@ class PassEvent(Event):
 
     event_type: EventType = EventType.PASS
     event_name: str = "pass"
-
-    body_part: BodyPartQualifier = None
 
 
 @dataclass

--- a/kloppy/infra/serializers/event/statsbomb/serializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/serializer.py
@@ -39,6 +39,7 @@ from kloppy.domain import (
     BallOutEvent,
     Event,
     BodyPart,
+    BodyPartQualifier,
 )
 from kloppy.infra.serializers.event import EventDataSerializer
 from kloppy.utils import Readable, performance_logging
@@ -121,34 +122,31 @@ def _parse_coordinates(
 
 
 def _parse_bodypart(event_dict: Dict) -> BodyPart:
-    if "body_part" in event_dict:
-        bodypart_id = event_dict["body_part"]["id"]
-        if bodypart_id == SB_BODYPART_BOTH_HANDS:
-            body_part = BodyPart.BOTH_HANDS
-        elif bodypart_id == SB_BODYPART_CHEST:
-            body_part = BodyPart.CHEST
-        elif bodypart_id == SB_BODYPART_HEAD:
-            body_part = BodyPart.HEAD
-        elif bodypart_id == SB_BODYPART_LEFT_FOOT:
-            body_part = BodyPart.LEFT_FOOT
-        elif bodypart_id == SB_BODYPART_LEFT_HAND:
-            body_part = BodyPart.LEFT_HAND
-        elif bodypart_id == SB_BODYPART_RIGHT_FOOT:
-            body_part = BodyPart.RIGHT_FOOT
-        elif bodypart_id == SB_BODYPART_RIGHT_HAND:
-            body_part = BodyPart.RIGHT_HAND
-        elif bodypart_id == SB_BODYPART_DROP_KICK:
-            body_part = BodyPart.DROP_KICK
-        elif bodypart_id == SB_BODYPART_KEEPER_ARM:
-            body_part = BodyPart.KEEPER_ARM
-        elif bodypart_id == SB_BODYPART_OTHER:
-            body_part = BodyPart.OTHER
-        elif bodypart_id == SB_BODYPART_NO_TOUCH:
-            body_part = BodyPart.NO_TOUCH
-        else:
-            raise Exception(f"Unknown body part: {body_part_id}")
+    bodypart_id = event_dict["body_part"]["id"]
+    if bodypart_id == SB_BODYPART_BOTH_HANDS:
+        body_part = BodyPart.BOTH_HANDS
+    elif bodypart_id == SB_BODYPART_CHEST:
+        body_part = BodyPart.CHEST
+    elif bodypart_id == SB_BODYPART_HEAD:
+        body_part = BodyPart.HEAD
+    elif bodypart_id == SB_BODYPART_LEFT_FOOT:
+        body_part = BodyPart.LEFT_FOOT
+    elif bodypart_id == SB_BODYPART_LEFT_HAND:
+        body_part = BodyPart.LEFT_HAND
+    elif bodypart_id == SB_BODYPART_RIGHT_FOOT:
+        body_part = BodyPart.RIGHT_FOOT
+    elif bodypart_id == SB_BODYPART_RIGHT_HAND:
+        body_part = BodyPart.RIGHT_HAND
+    elif bodypart_id == SB_BODYPART_DROP_KICK:
+        body_part = BodyPart.DROP_KICK
+    elif bodypart_id == SB_BODYPART_KEEPER_ARM:
+        body_part = BodyPart.KEEPER_ARM
+    elif bodypart_id == SB_BODYPART_OTHER:
+        body_part = BodyPart.OTHER
+    elif bodypart_id == SB_BODYPART_NO_TOUCH:
+        body_part = BodyPart.NO_TOUCH
     else:
-        body_part = None
+        raise Exception(f"Unknown body part: {body_part_id}")
 
     return body_part
 
@@ -180,14 +178,11 @@ def _parse_pass(pass_dict: Dict, team: Team, fidelity_version: int) -> Dict:
 
     qualifiers = _get_event_qualifiers(pass_dict)
 
-    body_part = _parse_bodypart(pass_dict)
-
     return dict(
         result=result,
         receiver_coordinates=receiver_coordinates,
         receiver_player=receiver_player,
         qualifiers=qualifiers,
-        body_part=body_part,
     )
 
 
@@ -208,6 +203,9 @@ def _get_event_qualifiers(qualifiers_dict: Dict) -> List[Qualifier]:
             qualifiers.append(SetPieceQualifier(value=SetPieceType.KICK_OFF))
         elif qualifiers_dict["type"]["id"] == SB_EVENT_TYPE_GOAL_KICK:
             qualifiers.append(SetPieceQualifier(value=SetPieceType.GOAL_KICK))
+
+    if "body_part" in qualifiers_dict:
+        qualifiers.append(BodyPartQualifier(_parse_bodypart(qualifiers_dict)))
 
     return qualifiers
 
@@ -231,12 +229,9 @@ def _parse_shot(shot_dict: Dict) -> Dict:
 
     qualifiers = _get_event_qualifiers(shot_dict)
 
-    body_part = _parse_bodypart(shot_dict)
-
     return dict(
         result=result,
         qualifiers=qualifiers,
-        body_part=body_part,
     )
 
 

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -7,6 +7,7 @@ from kloppy.domain import (
     Orientation,
     Provider,
     EventType,
+    BodyPartQualifier,
 )
 from kloppy.domain.models.common import DatasetType
 
@@ -68,9 +69,13 @@ class TestStatsbomb:
             attacking_direction=AttackingDirection.NOT_SET,
         )
 
-        assert dataset.events[791].body_part.value == "HEAD"
-        assert dataset.events[2231].body_part.value == "RIGHT_FOOT"
-        assert dataset.events[195].body_part is None
+        for qualifier in dataset.events[791].qualifiers:
+            if qualifier == BodyPartQualifier:
+                assert qualifier.value == "HEAD"
+
+        for qualifier in dataset.events[2231].qualifiers:
+            if qualifier == BodyPartQualifier:
+                assert qualifier.value == "RIGHT_FOOT"
 
     def test_substitution(self):
         """

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -8,6 +8,7 @@ from kloppy.domain import (
     Provider,
     EventType,
     BodyPartQualifier,
+    BodyPart,
 )
 from kloppy.domain.models.common import DatasetType
 
@@ -70,13 +71,13 @@ class TestStatsbomb:
         )
 
         assert (
-            dataset.events[791].get_qualifier_value(BodyPartQualifier).value
-            == "HEAD"
+            dataset.events[791].get_qualifier_value(BodyPartQualifier)
+            == BodyPart.HEAD
         )
 
         assert (
-            dataset.events[2231].get_qualifier_value(BodyPartQualifier).value
-            == "RIGHT_FOOT"
+            dataset.events[2231].get_qualifier_value(BodyPartQualifier)
+            == BodyPart.RIGHT_FOOT
         )
 
         assert (

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -69,13 +69,19 @@ class TestStatsbomb:
             attacking_direction=AttackingDirection.NOT_SET,
         )
 
-        for qualifier in dataset.events[791].qualifiers:
-            if qualifier == BodyPartQualifier:
-                assert qualifier.value == "HEAD"
+        assert (
+            dataset.events[791].get_qualifier_value(BodyPartQualifier).value
+            == "HEAD"
+        )
 
-        for qualifier in dataset.events[2231].qualifiers:
-            if qualifier == BodyPartQualifier:
-                assert qualifier.value == "RIGHT_FOOT"
+        assert (
+            dataset.events[2231].get_qualifier_value(BodyPartQualifier).value
+            == "RIGHT_FOOT"
+        )
+
+        assert (
+            dataset.events[195].get_qualifier_value(BodyPartQualifier) is None
+        )
 
     def test_substitution(self):
         """

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -68,6 +68,10 @@ class TestStatsbomb:
             attacking_direction=AttackingDirection.NOT_SET,
         )
 
+        assert dataset.events[791].body_part.value == "HEAD"
+        assert dataset.events[2231].body_part.value == "RIGHT_FOOT"
+        assert dataset.events[195].body_part is None
+
     def test_substitution(self):
         """
         Test substitution events


### PR DESCRIPTION
Add body_part feature for pass and shot events:

- Now, the _BodyPart_ class in event has more values: All values are taken from Statsbomb spec
- _PassEvent_ class and _ShotEvent_ class have a new attribute: `body_part`
- __parse_bodypart()_ function is new, and as the name suggests, parse bodypart from source file
- The returned Dict from __parse_pass()_ and __parse_shot()_ has a new key: `body_part`

Statsbomb also has body part for goalkeeper events but they're not yet implemented in kloppy.

Related issue: #82 