### PR TITLE
Include z-coordinate for ball

### DIFF
--- a/docs/api/domain/pitch.md
+++ b/docs/api/domain/pitch.md
@@ -1,5 +1,7 @@
 :::kloppy.domain.models.pitch.Point
 
+:::kloppy.domain.models.pitch.Point3D
+
 :::kloppy.domain.models.pitch.PitchDimensions
 
 :::kloppy.domain.models.pitch.Dimension

--- a/kloppy/domain/models/pitch.py
+++ b/kloppy/domain/models/pitch.py
@@ -79,3 +79,15 @@ class Point:
             other: See [`Point`][kloppy.domain.models.pitch.Point]
         """
         return sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2)
+
+
+@dataclass(frozen=True)
+class Point3D(Point):
+    """
+    Point on the pitch that includes the z coordinate for height (e.g. of the ball).
+
+    Attributes:
+        z: z coordinate in unit of [`PitchDimensions`][kloppy.domain.models.pitch.PitchDimensions]
+    """
+
+    z: float

--- a/kloppy/infra/serializers/tracking/epts/serializer.py
+++ b/kloppy/infra/serializers/tracking/epts/serializer.py
@@ -7,6 +7,7 @@ from kloppy.domain import (
     AttackingDirection,
     Frame,
     Point,
+    Point3D,
     Team,
     Orientation,
 )
@@ -53,7 +54,9 @@ class EPTSSerializer(TrackingDataSerializer):
             ball_state=None,
             period=period,
             players_coordinates=players_coordinates,
-            ball_coordinates=Point(x=row["ball_x"], y=row["ball_y"]),
+            ball_coordinates=Point3D(
+                x=row["ball_x"], y=row["ball_y"], z=row["ball_z"]
+            ),
         )
 
     def deserialize(

--- a/kloppy/infra/serializers/tracking/tracab.py
+++ b/kloppy/infra/serializers/tracking/tracab.py
@@ -9,6 +9,7 @@ from kloppy.domain import (
     AttackingDirection,
     Frame,
     Point,
+    Point3D,
     Team,
     BallState,
     Period,
@@ -88,7 +89,9 @@ class TRACABSerializer(TrackingDataSerializer):
         return Frame(
             frame_id=frame_id,
             timestamp=frame_id / frame_rate - period.start_timestamp,
-            ball_coordinates=Point(float(ball_x), float(ball_y)),
+            ball_coordinates=Point3D(
+                float(ball_x), float(ball_y), float(ball_z)
+            ),
             ball_state=ball_state,
             ball_owning_team=ball_owning_team,
             players_coordinates=players_coordinates,

--- a/kloppy/tests/test_epts.py
+++ b/kloppy/tests/test_epts.py
@@ -10,6 +10,7 @@ from kloppy.domain import (
     AttackingDirection,
     Orientation,
     Point,
+    Point3D,
     BallState,
     Team,
     Provider,
@@ -122,4 +123,6 @@ class TestEPTSTracking:
             x=-769, y=-2013
         )
 
-        assert dataset.records[0].ball_coordinates == Point(x=-2656, y=367)
+        assert dataset.records[0].ball_coordinates == Point3D(
+            x=-2656, y=367, z=100
+        )

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -7,6 +7,7 @@ from kloppy.domain import (
     Orientation,
     Provider,
     Point,
+    Point3D,
     BallState,
     Team,
     Ground,
@@ -61,7 +62,7 @@ class TestTracabTracking:
         assert dataset.records[0].players_coordinates[player_away_19] == Point(
             x=8889, y=-666
         )
-        assert dataset.records[0].ball_coordinates == Point(x=-27, y=25)
+        assert dataset.records[0].ball_coordinates == Point3D(x=-27, y=25, z=0)
         assert dataset.records[0].ball_state == BallState.ALIVE
         assert dataset.records[0].ball_owning_team == Team(
             team_id="home", name="home", ground=Ground.HOME


### PR DESCRIPTION
This change concerns #91 .

I did the following:
Added Point3D class inheriting from Point. 
Added z-coordinate of ball for epts and tracab tracking data. 
Adjusted tests for epts and tracab to the new behavior.
Added the documentation.