### PR TITLE
Moved other players data to PlayerData model

### DIFF
--- a/kloppy/domain/models/tracking.py
+++ b/kloppy/domain/models/tracking.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Dict, Optional
 
 from kloppy.domain.models.common import DatasetType
@@ -12,13 +12,14 @@ class PlayerData:
     coordinates: Point
     distance: Optional[float] = None
     speed: Optional[float] = None
+    other_data: Dict[Player, Dict] = field(default_factory=dict)
 
 
 @dataclass
 class Frame(DataRecord):
     frame_id: int
     players_data: Dict[Player, PlayerData]
-    other_data: Dict[Player, Dict]
+    other_data: Dict
     ball_coordinates: Point
 
     @property

--- a/kloppy/domain/services/transformers/__init__.py
+++ b/kloppy/domain/services/transformers/__init__.py
@@ -171,6 +171,7 @@ class Transformer:
                     ),
                     distance=player_data.distance,
                     speed=player_data.speed,
+                    other_data=player_data.other_data,
                 )
                 for key, player_data in frame.players_data.items()
             },
@@ -197,6 +198,7 @@ class Transformer:
                     ),
                     distance=player_data.distance,
                     speed=player_data.speed,
+                    other_data=player_data.other_data,
                 )
                 for key, player_data in frame.players_data.items()
             },
@@ -238,6 +240,7 @@ class Transformer:
                 coordinates=self.flip_point(data.coordinates),
                 distance=data.distance,
                 speed=data.speed,
+                other_data=data.other_data,
             )
 
         return Frame(

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -373,14 +373,22 @@ def _frame_to_pandas_row_converter(frame: Frame) -> Dict:
             }
         )
 
+        if player_data.other_data:
+            for player, other_data in player_data.other_data.items():
+                for name, value in other_data.items():
+                    row.update(
+                        {
+                            f"{player.player_id}_{name}": value,
+                        }
+                    )
+
     if frame.other_data:
-        for player, other_data in frame.other_data.items():
-            for name, value in other_data.items():
-                row.update(
-                    {
-                        name: value,
-                    }
-                )
+        for name, value in frame.other_data.items():
+            row.update(
+                {
+                    name: value,
+                }
+            )
 
     return row
 

--- a/kloppy/infra/serializers/tracking/metrica_csv.py
+++ b/kloppy/infra/serializers/tracking/metrica_csv.py
@@ -257,7 +257,7 @@ class MetricaCsvTrackingSerializer(TrackingDataSerializer):
                     period=period,
                     ball_state=None,
                     ball_owning_team=None,
-                    other_data=None,
+                    other_data={},
                 )
 
                 frame = transformer.transform_frame(frame)

--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -130,7 +130,7 @@ class SkillCornerTrackingSerializer(TrackingDataSerializer):
             period=periods[frame_period],
             ball_state=None,
             ball_owning_team=ball_owning_team,
-            other_data=None,
+            other_data={},
         )
 
     @classmethod

--- a/kloppy/infra/serializers/tracking/tracab.py
+++ b/kloppy/infra/serializers/tracking/tracab.py
@@ -103,7 +103,7 @@ class TRACABSerializer(TrackingDataSerializer):
             ball_owning_team=ball_owning_team,
             players_data=players_data,
             period=period,
-            other_data=None,
+            other_data={},
         )
 
     @staticmethod

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -127,13 +127,16 @@ class TestHelpers:
                             coordinates=Point(x=15, y=35),
                             distance=0.03,
                             speed=10.5,
+                            other_data={
+                                Player(
+                                    team=home_team,
+                                    player_id="home_1",
+                                    jersey_no=1,
+                                ): {"extra_data": 1}
+                            },
                         )
                     },
-                    other_data={
-                        Player(
-                            team=home_team, player_id="home_1", jersey_no=1
-                        ): {"extra_data": 1}
-                    },
+                    other_data={"extra_data": 1},
                     ball_coordinates=Point(x=0, y=50),
                 ),
             ],
@@ -208,6 +211,7 @@ class TestHelpers:
                 "home_1_y": {0: None, 1: 35.0},
                 "home_1_d": {0: None, 1: 0.03},
                 "home_1_s": {0: None, 1: 10.5},
+                "home_1_extra_data": {0: None, 1: 1},
                 "extra_data": {0: None, 1: 1},
             }
         )
@@ -254,6 +258,7 @@ class TestHelpers:
                 "home_1_y": [None, 35],
                 "home_1_d": [None, 0.03],
                 "home_1_s": [None, 10.5],
+                "home_1_extra_data": [None, 1],
                 "extra_data": [None, 1],
             }
         )

--- a/kloppy/tests/test_metrica_epts.py
+++ b/kloppy/tests/test_metrica_epts.py
@@ -154,4 +154,7 @@ class TestMetricaEPTSTracking:
 
         first_player = next(iter(dataset.records[0].players_data))
 
-        assert dataset.records[0].other_data[first_player]["mapping"] == 5.0
+        assert (
+            dataset.records[0].players_data[first_player].other_data["mapping"]
+            == 5.0
+        )


### PR DESCRIPTION
In the first implementation of other_data we added it to the Frame
model. However, in the use cased needed for the Metrica EPTS format all
other data was associated with a specific player, thus it made more
sense to add it to the PlayerData model. In this PR we have moved it
there.

Since it could also be that there are other_data relevant at the frame
level, like for example the ball alive/dead of Tracab, we also left the
other_data at the Frame level as well.