### PR TITLE
Some bug fixes and improvements for Opta serializer

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -230,6 +230,7 @@ class SetPieceQualifier(EnumQualifier):
 
     value: SetPieceType
 
+
 @dataclass
 class CardQualifier(EnumQualifier):
     """
@@ -240,6 +241,7 @@ class CardQualifier(EnumQualifier):
     """
 
     value: CardType
+
 
 class PassType(Enum):
     """
@@ -281,6 +283,7 @@ class PassType(Enum):
 @dataclass
 class PassQualifier(EnumQualifier):
     value: PassType
+
 
 class BodyPart(Enum):
     """

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -39,6 +39,7 @@ class ShotResult(ResultType):
     POST = "POST"
     BLOCKED = "BLOCKED"
     SAVED = "SAVED"
+    OWN_GOAL = "OWN_GOAL"
 
     @property
     def is_success(self):
@@ -229,6 +230,16 @@ class SetPieceQualifier(EnumQualifier):
 
     value: SetPieceType
 
+@dataclass
+class CardQualifier(EnumQualifier):
+    """
+    CardQualifier
+
+    Attributes:
+        value: Specifies the type card
+    """
+
+    value: CardType
 
 class PassType(Enum):
     """
@@ -270,7 +281,6 @@ class PassType(Enum):
 @dataclass
 class PassQualifier(EnumQualifier):
     value: PassType
-
 
 class BodyPart(Enum):
     """
@@ -659,6 +669,7 @@ __all__ = [
     "PlayerOffEvent",
     "CardEvent",
     "CardType",
+    "CardQualifier",
     "EventDataset",
     "RecoveryEvent",
     "FoulCommittedEvent",

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -415,7 +415,8 @@ def _event_to_pandas_row_converter(event: Event) -> Dict:
         coordinates_x=event.coordinates.x if event.coordinates else None,
         coordinates_y=event.coordinates.y if event.coordinates else None,
     )
-    if isinstance(event, PassEvent) and event.result == PassResult.COMPLETE:
+    # if isinstance(event, PassEvent) and event.result == PassResult.COMPLETE:
+    if isinstance(event, PassEvent):
         row.update(
             {
                 "end_timestamp": event.receive_timestamp,

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -238,6 +238,7 @@ def _parse_take_on(outcome: int) -> Dict:
         result = TakeOnResult.INCOMPLETE
     return dict(result=result)
 
+
 def _parse_card(raw_qualifiers: List) -> Dict:
     qualifiers = _get_event_qualifiers(raw_qualifiers)
 
@@ -251,6 +252,7 @@ def _parse_card(raw_qualifiers: List) -> Dict:
         card_type = None
 
     return dict(result=None, qualifiers=qualifiers, card_type=card_type)
+
 
 def _parse_shot(
     raw_qualifiers: Dict[int, str], type_id: int, coordinates: Point
@@ -320,7 +322,7 @@ def _team_from_xml_elm(team_elm, f7_root) -> Team:
             last_name=team_players[player_elm.attrib["PlayerRef"]][
                 "last_name"
             ],
-            starting= True if player_elm.attrib["Status"] == "Start" else False,
+            starting=True if player_elm.attrib["Status"] == "Start" else False,
             position=Position(
                 position_id=player_elm.attrib["Formation_Place"],
                 name=player_elm.attrib["Position"],
@@ -395,6 +397,7 @@ def _get_event_bodypart_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
         qualifiers.append(BodyPartQualifier(value=BodyPart.OTHER))
     return qualifiers
 
+
 def _get_event_card_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
     qualifiers = []
     if EVENT_QUALIFIER_RED_CARD in raw_qualifiers:
@@ -405,6 +408,7 @@ def _get_event_card_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
         qualifiers.append(CardQualifier(value=CardType.SECOND_YELLOW))
 
     return qualifiers
+
 
 def _get_event_type_name(type_id: int) -> str:
     return event_type_names.get(type_id, "unknown")
@@ -469,7 +473,9 @@ class OptaSerializer(EventDataSerializer):
             options = {}
 
         from_coordinate_system = build_coordinate_system(
-            Provider.OPTA, length=100, width=100,
+            Provider.OPTA,
+            length=100,
+            width=100,
         )
 
         to_coordinate_system = build_coordinate_system(
@@ -520,8 +526,16 @@ class OptaSerializer(EventDataSerializer):
 
             game_elm = f24_root.find("Game")
             periods = [
-                Period(id=1, start_timestamp=None, end_timestamp=None,),
-                Period(id=2, start_timestamp=None, end_timestamp=None,),
+                Period(
+                    id=1,
+                    start_timestamp=None,
+                    end_timestamp=None,
+                ),
+                Period(
+                    id=2,
+                    start_timestamp=None,
+                    end_timestamp=None,
+                ),
             ]
             possession_team = None
             events = []
@@ -600,12 +614,14 @@ class OptaSerializer(EventDataSerializer):
                             raw_qualifiers, outcome
                         )
                         event = PassEvent.create(
-                            **pass_event_kwargs, **generic_event_kwargs,
+                            **pass_event_kwargs,
+                            **generic_event_kwargs,
                         )
                     elif type_id == EVENT_TYPE_OFFSIDE_PASS:
                         pass_event_kwargs = _parse_offside_pass(raw_qualifiers)
                         event = PassEvent.create(
-                            **pass_event_kwargs, **generic_event_kwargs,
+                            **pass_event_kwargs,
+                            **generic_event_kwargs,
                         )
                     elif type_id == EVENT_TYPE_TAKE_ON:
                         take_on_event_kwargs = _parse_take_on(outcome)
@@ -622,7 +638,14 @@ class OptaSerializer(EventDataSerializer):
                     ):
                         if type_id == EVENT_TYPE_SHOT_GOAL:
                             if 374 in raw_qualifiers.keys():
-                                generic_event_kwargs["timestamp"] = _parse_f24_datetime(raw_qualifiers.get(374).replace(" ", "T")) - period.start_timestamp
+                                generic_event_kwargs["timestamp"] = (
+                                    _parse_f24_datetime(
+                                        raw_qualifiers.get(374).replace(
+                                            " ", "T"
+                                        )
+                                    )
+                                    - period.start_timestamp
+                                )
                         shot_event_kwargs = _parse_shot(
                             raw_qualifiers,
                             type_id,
@@ -660,9 +683,9 @@ class OptaSerializer(EventDataSerializer):
                         card_event_kwargs = _parse_card(raw_qualifiers)
 
                         event = CardEvent.create(
-                                **card_event_kwargs,
-                                **generic_event_kwargs,
-                            )
+                            **card_event_kwargs,
+                            **generic_event_kwargs,
+                        )
 
                     else:
                         event = GenericEvent.create(
@@ -690,7 +713,10 @@ class OptaSerializer(EventDataSerializer):
             coordinate_system=to_coordinate_system,
         )
 
-        return EventDataset(metadata=metadata, records=events,)
+        return EventDataset(
+            metadata=metadata,
+            records=events,
+        )
 
     def serialize(self, data_set: EventDataset) -> Tuple[str, str]:
         raise NotImplementedError

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -292,6 +292,7 @@ def _team_from_xml_elm(team_elm, f7_root) -> Team:
             last_name=team_players[player_elm.attrib["PlayerRef"]][
                 "last_name"
             ],
+            starting= True if player_elm.attrib["Status"] == "Start" else False,
             position=Position(
                 position_id=player_elm.attrib["Formation_Place"],
                 name=player_elm.attrib["Position"],
@@ -429,9 +430,7 @@ class OptaSerializer(EventDataSerializer):
             options = {}
 
         from_coordinate_system = build_coordinate_system(
-            Provider.OPTA,
-            length=100,
-            width=100,
+            Provider.OPTA, length=100, width=100,
         )
 
         to_coordinate_system = build_coordinate_system(
@@ -482,16 +481,8 @@ class OptaSerializer(EventDataSerializer):
 
             game_elm = f24_root.find("Game")
             periods = [
-                Period(
-                    id=1,
-                    start_timestamp=None,
-                    end_timestamp=None,
-                ),
-                Period(
-                    id=2,
-                    start_timestamp=None,
-                    end_timestamp=None,
-                ),
+                Period(id=1, start_timestamp=None, end_timestamp=None,),
+                Period(id=2, start_timestamp=None, end_timestamp=None,),
             ]
             possession_team = None
             events = []
@@ -570,14 +561,12 @@ class OptaSerializer(EventDataSerializer):
                             raw_qualifiers, outcome
                         )
                         event = PassEvent.create(
-                            **pass_event_kwargs,
-                            **generic_event_kwargs,
+                            **pass_event_kwargs, **generic_event_kwargs,
                         )
                     elif type_id == EVENT_TYPE_OFFSIDE_PASS:
                         pass_event_kwargs = _parse_offside_pass(raw_qualifiers)
                         event = PassEvent.create(
-                            **pass_event_kwargs,
-                            **generic_event_kwargs,
+                            **pass_event_kwargs, **generic_event_kwargs,
                         )
                     elif type_id == EVENT_TYPE_TAKE_ON:
                         take_on_event_kwargs = _parse_take_on(outcome)
@@ -650,10 +639,7 @@ class OptaSerializer(EventDataSerializer):
             coordinate_system=to_coordinate_system,
         )
 
-        return EventDataset(
-            metadata=metadata,
-            records=events,
-        )
+        return EventDataset(metadata=metadata, records=events,)
 
     def serialize(self, data_set: EventDataset) -> Tuple[str, str]:
         raise NotImplementedError

--- a/kloppy/tests/files/opta_f24.xml
+++ b/kloppy/tests/files/opta_f24.xml
@@ -169,6 +169,50 @@
       <Q id="1982245989" qualifier_id="56" value="Back" />
       <Q id="1223973456" qualifier_id="167" />
     </Event>
+    <Event id="2318695229" event_id="292" type_id="16" period_id="2" min="47" sec="19" player_id="460842" team_id="2592" outcome="1" x="90.2" y="62.0" timestamp="2018-09-23T16:07:48.325" last_modified="2018-09-23T16:05:50" version="1629011564949">
+      <Q id="3037279881" qualifier_id="395" value="93.8" />
+      <Q id="3035784297" qualifier_id="103" value="2.5" />
+      <Q id="3038190069" qualifier_id="178" />
+      <Q id="3035782383" qualifier_id="17" />
+      <Q id="3035784303" qualifier_id="230" value="94.5" />
+      <Q id="3035782783" qualifier_id="374" value="2018-09-23 16:07:48.525" />
+      <Q id="3035784299" qualifier_id="214" />
+      <Q id="3035784285" qualifier_id="80" />
+      <Q id="3035784291" qualifier_id="55" value="291" />
+      <Q id="3035784295" qualifier_id="102" value="47.8" />
+      <Q id="3035784289" qualifier_id="154" />
+      <Q id="3035782385" qualifier_id="56" value="Center" />
+      <Q id="3035782777" qualifier_id="72" />
+      <Q id="3037279883" qualifier_id="396" value="60.7" />
+      <Q id="3035784287" qualifier_id="29" />
+      <Q id="3035784305" qualifier_id="231" value="57.0" />
+      <Q id="3035782785" qualifier_id="375" value="22:42.896" />
+      <Q id="3035784283" qualifier_id="23" />
+      <Q id="3035784301" qualifier_id="328" />
+    </Event>
+    <Event id="2318697001" event_id="319" type_id="16" period_id="2" min="49" sec="19" player_id="460842" team_id="2592" outcome="1" x="17.9" y="48.0" timestamp="2018-09-23T16:09:48.325" last_modified="2021-08-15T08:21:39" version="1629012098571">
+      <Q id="3035792903" qualifier_id="20" />
+      <Q id="3035792905" qualifier_id="374" value="2018-09-23 16:07:49.525" />
+      <Q id="3037294331" qualifier_id="395" value="96.5" />
+      <Q id="3038199221" qualifier_id="178" />
+      <Q id="3035791681" qualifier_id="56" value="Center" />
+      <Q id="3035791679" qualifier_id="28" />
+      <Q id="3035793869" qualifier_id="80" />
+      <Q id="3035793879" qualifier_id="231" value="50.4" />
+      <Q id="3035792907" qualifier_id="375" value="26:30.978" />
+      <Q id="3037294333" qualifier_id="396" value="47.3" />
+      <Q id="3035791677" qualifier_id="18" />
+      <Q id="3035793871" qualifier_id="102" value="45.6" />
+      <Q id="3035793877" qualifier_id="230" value="96.5" />
+      <Q id="3035791675" qualifier_id="22" />
+      <Q id="3035793875" qualifier_id="136" />
+      <Q id="3035793873" qualifier_id="103" value="1.9" />
+    </Event>
+    <Event id="2318454729" event_id="17" type_id="17" period_id="2" min="50" sec="19" player_id="460842" team_id="2592" outcome="1" x="0.0" y="0.0" timestamp="2018-09-23T16:10:48.325" last_modified="2021-08-15T05:10:21" version="1629000620887">
+      <Q id="3034536633" qualifier_id="33" />
+      <Q id="3034536635" qualifier_id="166" />
+      <Q id="3034536755" qualifier_id="343" value="3" />
+    </Event>
     <Event id="1484626979" event_id="710" type_id="30" period_id="2" min="95" sec="8" team_id="2592" outcome="1" x="0.0" y="0.0" timestamp="2018-09-23T16:55:37.250" last_modified="2018-09-23T16:55:37" version="1537718137253">
       <Q id="2119253310" qualifier_id="57" value="0" />
       <Q id="1331973943" qualifier_id="209" />

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -13,6 +13,7 @@ from kloppy.domain import (
     BodyPart,
     SetPieceType,
     PassType,
+    CardType,
 )
 from kloppy.domain.models.common import DatasetType
 
@@ -33,10 +34,14 @@ class TestOpta:
             )
         assert dataset.metadata.provider == Provider.OPTA
         assert dataset.dataset_type == DatasetType.EVENT
-        assert len(dataset.events) == 17
+        assert len(dataset.events) == 20
         assert len(dataset.metadata.periods) == 2
-        assert dataset.events[10].ball_owning_team == dataset.metadata.teams[1]
-        assert dataset.events[15].ball_owning_team == dataset.metadata.teams[0]
+        assert (
+            dataset.events[10].ball_owning_team == dataset.metadata.teams[1]
+        )  # 1594254267
+        assert (
+            dataset.events[15].ball_owning_team == dataset.metadata.teams[0]
+        )  # 2087733359
         assert (
             dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
         )
@@ -68,9 +73,29 @@ class TestOpta:
         assert dataset.events[0].coordinates == Point(50.1, 49.4)
 
         # Check the qualifiers
-        assert dataset.events[0].qualifiers[0].value == SetPieceType.KICK_OFF
-        assert dataset.events[6].qualifiers[0].value == BodyPart.HEAD
-        assert dataset.events[5].qualifiers[0].value == PassType.CHIPPED_PASS
+        assert (
+            dataset.events[0].qualifiers[0].value == SetPieceType.KICK_OFF
+        )  # 1510681159
+        assert (
+            dataset.events[6].qualifiers[0].value == BodyPart.HEAD
+        )  # 1101592119
+        assert (
+            dataset.events[5].qualifiers[0].value == PassType.CHIPPED_PASS
+        )  # 1444075194
+        assert (
+            dataset.events[19].qualifiers[0].value == CardType.RED
+        )  # 2318695229
+
+        # Check receiver coordinates for incomplete passes
+        assert dataset.events[6].receiver_coordinates.x == 45.5
+        assert dataset.events[6].receiver_coordinates.y == 68.2
+
+        # Check timestamp from qualifier in case of goal
+        assert dataset.events[17].timestamp == 139.65200018882751  # 2318695229
+        # assert dataset.events[17].coordinates_y == 12
+
+        # Check Own goal
+        assert dataset.events[18].result.value == "OWN_GOAL"  # 2318697001
 
     def test_correct_normalized_deserialization(self):
         base_dir = os.path.dirname(__file__)


### PR DESCRIPTION
Hi,



1. fixed a bug where for incomplete passes end coordinates got ignored (within serializer and when converting events to_pandas)
2. added a result type "OWN_GOAL" for own goals - before these were just counted as normal goals for a team. I am wondering whether it would make sense to set BALL_OWNING_TEAM for this shot event to the opponent.
3. for all shot events the event timestamp will correspond to the moment when the ball leaves the foot. However for goal events opta's event timestamp is the moment when the ball crosses the goal line and the timestamp when the ball leaves the foot is stored in a qualifier. I adjusted the code s.t. it'll take always the moment when the ball leaves the foot consistently. This might not be a big deal when working with event data only, but a big improvement when working with merged tracking data.
4. added a parser for card events with event_type = "card" and column card_type = ["RED", "FIRST_YELLOW", "SECOND_YELLOW"]
5. starting player information will now get parsed

Cheers
Thomas