### PR TITLE
Bug fix when working with Opta Pass Qualifiers / converting those to_pandas

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -230,6 +230,7 @@ class SetPieceQualifier(EnumQualifier):
 
     value: SetPieceType
 
+
 @dataclass
 class CardQualifier(EnumQualifier):
     """
@@ -240,6 +241,7 @@ class CardQualifier(EnumQualifier):
     """
 
     value: CardType
+
 
 class PassType(Enum):
     """
@@ -281,6 +283,7 @@ class PassType(Enum):
 @dataclass
 class PassQualifier(EnumQualifier):
     value: PassType
+
 
 class BodyPart(Enum):
     """

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -39,6 +39,7 @@ class ShotResult(ResultType):
     POST = "POST"
     BLOCKED = "BLOCKED"
     SAVED = "SAVED"
+    OWN_GOAL = "OWN_GOAL"
 
     @property
     def is_success(self):
@@ -229,6 +230,16 @@ class SetPieceQualifier(EnumQualifier):
 
     value: SetPieceType
 
+@dataclass
+class CardQualifier(EnumQualifier):
+    """
+    CardQualifier
+
+    Attributes:
+        value: Specifies the type card
+    """
+
+    value: CardType
 
 class PassType(Enum):
     """
@@ -270,7 +281,6 @@ class PassType(Enum):
 @dataclass
 class PassQualifier(EnumQualifier):
     value: PassType
-
 
 class BodyPart(Enum):
     """
@@ -659,6 +669,7 @@ __all__ = [
     "PlayerOffEvent",
     "CardEvent",
     "CardType",
+    "CardQualifier",
     "EventDataset",
     "RecoveryEvent",
     "FoulCommittedEvent",

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -27,6 +27,7 @@ from .domain import (
     Orientation,
     PassEvent,
     PassResult,
+    PassType,
     PitchDimensions,
     ShotEvent,
     TrackingDataset,
@@ -459,9 +460,23 @@ def _event_to_pandas_row_converter(event: Event) -> Dict:
             {"card_type": event.card_type.value if event.card_type else None}
         )
 
+    # init dict with all possible values for PassType (mapping all values to False)
+    list_pass_types = [f"pass_type_{p.value.lower()}" for p in PassType]
+    dict_pass_types = dict.fromkeys(list_pass_types, False)
+
     if event.qualifiers:
         for qualifier in event.qualifiers:
-            row.update(qualifier.to_dict())
+
+            # check for pass type qualifiers and set corresponding dict value to True
+            if isinstance(qualifier.value, PassType):
+                dict_pass_types[
+                    f"pass_type_{qualifier.value.name.lower()}"
+                ] = True
+            else:
+                row.update(qualifier.to_dict())
+
+    # update with pass types
+    row.update(dict_pass_types)
 
     return row
 

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -1,3 +1,5 @@
+import s3fs
+
 from typing import Callable, Dict, List, Optional, TypeVar, Union, Any
 
 from . import (
@@ -212,7 +214,7 @@ def load_statsbomb_event_data(
 
 
 def load_opta_event_data(
-    f24_data_filename: str, f7_data_filename: str, options: dict = None
+    f24_data_filename: str, f7_data_filename: str, s3_fs: s3fs.S3FileSystem = None, options: dict = None
 ) -> EventDataset:
     """
     Load Opta event data into a [`EventDataset`][kloppy.domain.models.event.EventDataset]
@@ -220,17 +222,29 @@ def load_opta_event_data(
     Parameters:
         f24_data_filename: filename of the f24 XML file containing the events
         f7_data_filename: filename of the f7 XML file containing metadata
+        s3_fs: S3FileSystem. Default: None --> local
         options:
     """
     serializer = OptaSerializer()
-    with open(f24_data_filename, "rb") as f24_data, open(
-        f7_data_filename, "rb"
-    ) as f7_data:
 
-        return serializer.deserialize(
-            inputs={"f24_data": f24_data, "f7_data": f7_data},
-            options=options,
-        )
+    if not s3_fs is None:
+        with s3_fs.open(f24_data_filename, "rb") as f24_data, s3_fs.open(
+            f7_data_filename, "rb"
+        ) as f7_data:
+
+            return serializer.deserialize(
+                inputs={"f24_data": f24_data, "f7_data": f7_data},
+                options=options,
+            )
+    else:
+        with open(f24_data_filename, "rb") as f24_data, open(
+            f7_data_filename, "rb"
+        ) as f7_data:
+
+            return serializer.deserialize(
+                inputs={"f24_data": f24_data, "f7_data": f7_data},
+                options=options,
+            )
 
 
 def load_metrica_json_event_data(
@@ -278,7 +292,7 @@ def load_sportec_event_data(
 
 
 def load_wyscout_event_data(
-    event_data_filename: str, options: dict = None
+    event_data_filename: str, s3_fs: s3fs.S3FileSystem = None, options: dict = None
 ) -> EventDataset:
     """
     Load Wyscout event data into a [`EventDataset`][kloppy.domain.models.event.EventDataset]
@@ -288,16 +302,28 @@ def load_wyscout_event_data(
         options:
     """
     serializer = WyscoutSerializer()
-    with open(event_data_filename, "rb") as event_data:
-        return serializer.deserialize(
-            inputs={"event_data": event_data}, options=options
-        )
+
+    if not s3_fs is None:
+        with s3_fs.open(event_data_filename, "rb") as event_data:
+            return serializer.deserialize(
+                inputs={"event_data": event_data}, options=options
+            )
+    else:
+        with open(event_data_filename, "rb") as event_data:
+            return serializer.deserialize(
+                inputs={"event_data": event_data}, options=options
+            )
 
 
-def load_xml_code_data(xml_filename: str) -> CodeDataset:
+def load_xml_code_data(xml_filename: str, s3_fs: s3fs.S3FileSystem = None) -> CodeDataset:
     serializer = XMLCodeSerializer()
-    with open(xml_filename, "rb") as xml_file:
-        return serializer.deserialize(inputs={"xml_file": xml_file})
+
+    if not s3_fs is None:
+        with s3_fs.open(xml_filename, "rb") as xml_file:
+            return serializer.deserialize(inputs={"xml_file": xml_file})
+    else:
+        with open(xml_filename, "rb") as xml_file:
+            return serializer.deserialize(inputs={"xml_file": xml_file})
 
 
 def write_xml_code_data(dataset: CodeDataset, xml_filename: str):

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -460,6 +460,11 @@ def _event_to_pandas_row_converter(event: Event) -> Dict:
             {"card_type": event.card_type.value if event.card_type else None}
         )
 
+    # parse qualifiers
+    if event.qualifiers:
+        for qualifier in event.qualifiers:
+            row.update(qualifier.to_dict())
+
     # # init dict with all possible values for PassType (mapping all values to False)
     # list_pass_types = [f"pass_type_{p.value.lower()}" for p in PassType]
     # dict_pass_types = dict.fromkeys(list_pass_types, False)

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -460,23 +460,23 @@ def _event_to_pandas_row_converter(event: Event) -> Dict:
             {"card_type": event.card_type.value if event.card_type else None}
         )
 
-    # init dict with all possible values for PassType (mapping all values to False)
-    list_pass_types = [f"pass_type_{p.value.lower()}" for p in PassType]
-    dict_pass_types = dict.fromkeys(list_pass_types, False)
+    # # init dict with all possible values for PassType (mapping all values to False)
+    # list_pass_types = [f"pass_type_{p.value.lower()}" for p in PassType]
+    # dict_pass_types = dict.fromkeys(list_pass_types, False)
 
-    if event.qualifiers:
-        for qualifier in event.qualifiers:
+    # if event.qualifiers:
+    #     for qualifier in event.qualifiers:
 
-            # check for pass type qualifiers and set corresponding dict value to True
-            if isinstance(qualifier.value, PassType):
-                dict_pass_types[
-                    f"pass_type_{qualifier.value.name.lower()}"
-                ] = True
-            else:
-                row.update(qualifier.to_dict())
+    #         # check for pass type qualifiers and set corresponding dict value to True
+    #         if isinstance(qualifier.value, PassType):
+    #             dict_pass_types[
+    #                 f"pass_type_{qualifier.value.name.lower()}"
+    #             ] = True
+    #         else:
+    #             row.update(qualifier.to_dict())
 
-    # update with pass types
-    row.update(dict_pass_types)
+    # # update with pass types
+    # row.update(dict_pass_types)
 
     return row
 

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -415,7 +415,8 @@ def _event_to_pandas_row_converter(event: Event) -> Dict:
         coordinates_x=event.coordinates.x if event.coordinates else None,
         coordinates_y=event.coordinates.y if event.coordinates else None,
     )
-    if isinstance(event, PassEvent) and event.result == PassResult.COMPLETE:
+    # if isinstance(event, PassEvent) and event.result == PassResult.COMPLETE:
+    if isinstance(event, PassEvent):
         row.update(
             {
                 "end_timestamp": event.receive_timestamp,

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -352,20 +352,20 @@ def _get_event_pass_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
     qualifiers = []
     if EVENT_QUALIFIER_CROSS in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.CROSS))
-    if EVENT_QUALIFIER_LONG_BALL in raw_qualifiers:
+    elif EVENT_QUALIFIER_LONG_BALL in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.LONG_BALL))
-    if EVENT_QUALIFIER_CHIPPED_BALL in raw_qualifiers:
+    elif EVENT_QUALIFIER_CHIPPED_BALL in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.CHIPPED_PASS))
-    if EVENT_QUALIFIER_THROUGH_BALL in raw_qualifiers:
+    elif EVENT_QUALIFIER_THROUGH_BALL in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.THROUGH_BALL))
-    if EVENT_QUALIFIER_LAUNCH in raw_qualifiers:
+    elif EVENT_QUALIFIER_LAUNCH in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.LAUNCH))
-    if EVENT_QUALIFIER_FLICK_ON in raw_qualifiers:
+    elif EVENT_QUALIFIER_FLICK_ON in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.FLICK_ON))
-    # if EVENT_QUALIFIER_ASSIST in raw_qualifiers:
-    #     qualifiers.append(PassQualifier(value=PassType.ASSIST))
-    # if EVENT_QUALIFIER_ASSIST_2ND in raw_qualifiers:
-    #     qualifiers.append(PassQualifier(value=PassType.ASSIST_2ND))
+    elif EVENT_QUALIFIER_ASSIST in raw_qualifiers:
+        qualifiers.append(PassQualifier(value=PassType.ASSIST))
+    elif EVENT_QUALIFIER_ASSIST_2ND in raw_qualifiers:
+        qualifiers.append(PassQualifier(value=PassType.ASSIST_2ND))
     return qualifiers
 
 

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -1,3 +1,4 @@
+from curses import raw
 from typing import Tuple, Dict, List
 import logging
 from datetime import datetime
@@ -86,6 +87,8 @@ EVENT_QUALIFIER_THROW_IN = 107
 EVENT_QUALIFIER_CORNER_KICK = 6
 EVENT_QUALIFIER_PENALTY = 9
 EVENT_QUALIFIER_KICK_OFF = 279
+EVENT_QUALIFIER_FREE_KICK_SHOT = 26
+
 
 EVENT_QUALIFIER_HEAD_PASS = 3
 EVENT_QUALIFIER_HEAD = 15
@@ -370,7 +373,7 @@ def _get_event_setpiece_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
     qualifiers = []
     if EVENT_QUALIFIER_CORNER_KICK in raw_qualifiers:
         qualifiers.append(SetPieceQualifier(value=SetPieceType.CORNER_KICK))
-    elif EVENT_QUALIFIER_FREE_KICK in raw_qualifiers:
+    elif (EVENT_QUALIFIER_FREE_KICK in raw_qualifiers) | (EVENT_QUALIFIER_FREE_KICK_SHOT in raw_qualifiers):
         qualifiers.append(SetPieceQualifier(value=SetPieceType.FREE_KICK))
     elif EVENT_QUALIFIER_PENALTY in raw_qualifiers:
         qualifiers.append(SetPieceQualifier(value=SetPieceType.PENALTY))
@@ -380,6 +383,7 @@ def _get_event_setpiece_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
         qualifiers.append(SetPieceQualifier(value=SetPieceType.KICK_OFF))
     elif EVENT_QUALIFIER_GOAL_KICK in raw_qualifiers:
         qualifiers.append(SetPieceQualifier(value=SetPieceType.GOAL_KICK))
+    
     return qualifiers
 
 

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -349,19 +349,19 @@ def _get_event_pass_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
     qualifiers = []
     if EVENT_QUALIFIER_CROSS in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.CROSS))
-    elif EVENT_QUALIFIER_LONG_BALL in raw_qualifiers:
+    if EVENT_QUALIFIER_LONG_BALL in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.LONG_BALL))
-    elif EVENT_QUALIFIER_CHIPPED_BALL in raw_qualifiers:
+    if EVENT_QUALIFIER_CHIPPED_BALL in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.CHIPPED_PASS))
-    elif EVENT_QUALIFIER_THROUGH_BALL in raw_qualifiers:
+    if EVENT_QUALIFIER_THROUGH_BALL in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.THROUGH_BALL))
-    elif EVENT_QUALIFIER_LAUNCH in raw_qualifiers:
+    if EVENT_QUALIFIER_LAUNCH in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.LAUNCH))
-    elif EVENT_QUALIFIER_FLICK_ON in raw_qualifiers:
+    if EVENT_QUALIFIER_FLICK_ON in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.FLICK_ON))
-    elif EVENT_QUALIFIER_ASSIST in raw_qualifiers:
+    if EVENT_QUALIFIER_ASSIST in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.ASSIST))
-    elif EVENT_QUALIFIER_ASSIST_2ND in raw_qualifiers:
+    if EVENT_QUALIFIER_ASSIST_2ND in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.ASSIST_2ND))
     return qualifiers
 

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -362,10 +362,10 @@ def _get_event_pass_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
         qualifiers.append(PassQualifier(value=PassType.LAUNCH))
     if EVENT_QUALIFIER_FLICK_ON in raw_qualifiers:
         qualifiers.append(PassQualifier(value=PassType.FLICK_ON))
-    if EVENT_QUALIFIER_ASSIST in raw_qualifiers:
-        qualifiers.append(PassQualifier(value=PassType.ASSIST))
-    if EVENT_QUALIFIER_ASSIST_2ND in raw_qualifiers:
-        qualifiers.append(PassQualifier(value=PassType.ASSIST_2ND))
+    # if EVENT_QUALIFIER_ASSIST in raw_qualifiers:
+    #     qualifiers.append(PassQualifier(value=PassType.ASSIST))
+    # if EVENT_QUALIFIER_ASSIST_2ND in raw_qualifiers:
+    #     qualifiers.append(PassQualifier(value=PassType.ASSIST_2ND))
     return qualifiers
 
 

--- a/kloppy/infra/serializers/event/opta/serializer.py
+++ b/kloppy/infra/serializers/event/opta/serializer.py
@@ -238,6 +238,7 @@ def _parse_take_on(outcome: int) -> Dict:
         result = TakeOnResult.INCOMPLETE
     return dict(result=result)
 
+
 def _parse_card(raw_qualifiers: List) -> Dict:
     qualifiers = _get_event_qualifiers(raw_qualifiers)
 
@@ -251,6 +252,7 @@ def _parse_card(raw_qualifiers: List) -> Dict:
         card_type = None
 
     return dict(result=None, qualifiers=qualifiers, card_type=card_type)
+
 
 def _parse_shot(
     raw_qualifiers: Dict[int, str], type_id: int, coordinates: Point
@@ -320,7 +322,7 @@ def _team_from_xml_elm(team_elm, f7_root) -> Team:
             last_name=team_players[player_elm.attrib["PlayerRef"]][
                 "last_name"
             ],
-            starting= True if player_elm.attrib["Status"] == "Start" else False,
+            starting=True if player_elm.attrib["Status"] == "Start" else False,
             position=Position(
                 position_id=player_elm.attrib["Formation_Place"],
                 name=player_elm.attrib["Position"],
@@ -395,6 +397,7 @@ def _get_event_bodypart_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
         qualifiers.append(BodyPartQualifier(value=BodyPart.OTHER))
     return qualifiers
 
+
 def _get_event_card_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
     qualifiers = []
     if EVENT_QUALIFIER_RED_CARD in raw_qualifiers:
@@ -405,6 +408,7 @@ def _get_event_card_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
         qualifiers.append(CardQualifier(value=CardType.SECOND_YELLOW))
 
     return qualifiers
+
 
 def _get_event_type_name(type_id: int) -> str:
     return event_type_names.get(type_id, "unknown")
@@ -469,7 +473,9 @@ class OptaSerializer(EventDataSerializer):
             options = {}
 
         from_coordinate_system = build_coordinate_system(
-            Provider.OPTA, length=100, width=100,
+            Provider.OPTA,
+            length=100,
+            width=100,
         )
 
         to_coordinate_system = build_coordinate_system(
@@ -520,8 +526,16 @@ class OptaSerializer(EventDataSerializer):
 
             game_elm = f24_root.find("Game")
             periods = [
-                Period(id=1, start_timestamp=None, end_timestamp=None,),
-                Period(id=2, start_timestamp=None, end_timestamp=None,),
+                Period(
+                    id=1,
+                    start_timestamp=None,
+                    end_timestamp=None,
+                ),
+                Period(
+                    id=2,
+                    start_timestamp=None,
+                    end_timestamp=None,
+                ),
             ]
             possession_team = None
             events = []
@@ -600,12 +614,14 @@ class OptaSerializer(EventDataSerializer):
                             raw_qualifiers, outcome
                         )
                         event = PassEvent.create(
-                            **pass_event_kwargs, **generic_event_kwargs,
+                            **pass_event_kwargs,
+                            **generic_event_kwargs,
                         )
                     elif type_id == EVENT_TYPE_OFFSIDE_PASS:
                         pass_event_kwargs = _parse_offside_pass(raw_qualifiers)
                         event = PassEvent.create(
-                            **pass_event_kwargs, **generic_event_kwargs,
+                            **pass_event_kwargs,
+                            **generic_event_kwargs,
                         )
                     elif type_id == EVENT_TYPE_TAKE_ON:
                         take_on_event_kwargs = _parse_take_on(outcome)
@@ -622,7 +638,14 @@ class OptaSerializer(EventDataSerializer):
                     ):
                         if type_id == EVENT_TYPE_SHOT_GOAL:
                             if 374 in raw_qualifiers.keys():
-                                generic_event_kwargs["timestamp"] = _parse_f24_datetime(raw_qualifiers.get(374).replace(" ", "T")) - period.start_timestamp
+                                generic_event_kwargs["timestamp"] = (
+                                    _parse_f24_datetime(
+                                        raw_qualifiers.get(374).replace(
+                                            " ", "T"
+                                        )
+                                    )
+                                    - period.start_timestamp
+                                )
                         shot_event_kwargs = _parse_shot(
                             raw_qualifiers,
                             type_id,
@@ -660,9 +683,9 @@ class OptaSerializer(EventDataSerializer):
                         card_event_kwargs = _parse_card(raw_qualifiers)
 
                         event = CardEvent.create(
-                                **card_event_kwargs,
-                                **generic_event_kwargs,
-                            )
+                            **card_event_kwargs,
+                            **generic_event_kwargs,
+                        )
 
                     else:
                         event = GenericEvent.create(
@@ -690,7 +713,10 @@ class OptaSerializer(EventDataSerializer):
             coordinate_system=to_coordinate_system,
         )
 
-        return EventDataset(metadata=metadata, records=events,)
+        return EventDataset(
+            metadata=metadata,
+            records=events,
+        )
 
     def serialize(self, data_set: EventDataset) -> Tuple[str, str]:
         raise NotImplementedError

--- a/kloppy/tests/files/opta_f24.xml
+++ b/kloppy/tests/files/opta_f24.xml
@@ -169,6 +169,50 @@
       <Q id="1982245989" qualifier_id="56" value="Back" />
       <Q id="1223973456" qualifier_id="167" />
     </Event>
+    <Event id="2318695229" event_id="292" type_id="16" period_id="2" min="47" sec="19" player_id="460842" team_id="2592" outcome="1" x="90.2" y="62.0" timestamp="2018-09-23T16:07:48.325" last_modified="2018-09-23T16:05:50" version="1629011564949">
+      <Q id="3037279881" qualifier_id="395" value="93.8" />
+      <Q id="3035784297" qualifier_id="103" value="2.5" />
+      <Q id="3038190069" qualifier_id="178" />
+      <Q id="3035782383" qualifier_id="17" />
+      <Q id="3035784303" qualifier_id="230" value="94.5" />
+      <Q id="3035782783" qualifier_id="374" value="2018-09-23 16:07:48.525" />
+      <Q id="3035784299" qualifier_id="214" />
+      <Q id="3035784285" qualifier_id="80" />
+      <Q id="3035784291" qualifier_id="55" value="291" />
+      <Q id="3035784295" qualifier_id="102" value="47.8" />
+      <Q id="3035784289" qualifier_id="154" />
+      <Q id="3035782385" qualifier_id="56" value="Center" />
+      <Q id="3035782777" qualifier_id="72" />
+      <Q id="3037279883" qualifier_id="396" value="60.7" />
+      <Q id="3035784287" qualifier_id="29" />
+      <Q id="3035784305" qualifier_id="231" value="57.0" />
+      <Q id="3035782785" qualifier_id="375" value="22:42.896" />
+      <Q id="3035784283" qualifier_id="23" />
+      <Q id="3035784301" qualifier_id="328" />
+    </Event>
+    <Event id="2318697001" event_id="319" type_id="16" period_id="2" min="49" sec="19" player_id="460842" team_id="2592" outcome="1" x="17.9" y="48.0" timestamp="2018-09-23T16:09:48.325" last_modified="2021-08-15T08:21:39" version="1629012098571">
+      <Q id="3035792903" qualifier_id="20" />
+      <Q id="3035792905" qualifier_id="374" value="2018-09-23 16:07:49.525" />
+      <Q id="3037294331" qualifier_id="395" value="96.5" />
+      <Q id="3038199221" qualifier_id="178" />
+      <Q id="3035791681" qualifier_id="56" value="Center" />
+      <Q id="3035791679" qualifier_id="28" />
+      <Q id="3035793869" qualifier_id="80" />
+      <Q id="3035793879" qualifier_id="231" value="50.4" />
+      <Q id="3035792907" qualifier_id="375" value="26:30.978" />
+      <Q id="3037294333" qualifier_id="396" value="47.3" />
+      <Q id="3035791677" qualifier_id="18" />
+      <Q id="3035793871" qualifier_id="102" value="45.6" />
+      <Q id="3035793877" qualifier_id="230" value="96.5" />
+      <Q id="3035791675" qualifier_id="22" />
+      <Q id="3035793875" qualifier_id="136" />
+      <Q id="3035793873" qualifier_id="103" value="1.9" />
+    </Event>
+    <Event id="2318454729" event_id="17" type_id="17" period_id="2" min="50" sec="19" player_id="460842" team_id="2592" outcome="1" x="0.0" y="0.0" timestamp="2018-09-23T16:10:48.325" last_modified="2021-08-15T05:10:21" version="1629000620887">
+      <Q id="3034536633" qualifier_id="33" />
+      <Q id="3034536635" qualifier_id="166" />
+      <Q id="3034536755" qualifier_id="343" value="3" />
+    </Event>
     <Event id="1484626979" event_id="710" type_id="30" period_id="2" min="95" sec="8" team_id="2592" outcome="1" x="0.0" y="0.0" timestamp="2018-09-23T16:55:37.250" last_modified="2018-09-23T16:55:37" version="1537718137253">
       <Q id="2119253310" qualifier_id="57" value="0" />
       <Q id="1331973943" qualifier_id="209" />

--- a/kloppy/tests/files/opta_f24.xml
+++ b/kloppy/tests/files/opta_f24.xml
@@ -127,6 +127,8 @@
       <Q id="1540725732" qualifier_id="279" value="S" />
     </Event>
     <Event id="1594254267" event_id="329" type_id="1" period_id="2" min="45" sec="4" player_id="248479" team_id="2592" outcome="0" x="35.6" y="80.5" timestamp="2018-09-23T16:05:32.873" last_modified="2018-09-23T17:14:58" version="1537719297885">
+      <Q id="1241809254" qualifier_id="2" />
+      <Q id="1241809255" qualifier_id="210" />
       <Q id="1241809256" qualifier_id="212" value="15.6" />
       <Q id="1754788999" qualifier_id="213" value="1.9" />
       <Q id="1865376227" qualifier_id="140" value="30.3" />

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -16,6 +16,7 @@ from kloppy.domain import (
     CardType,
 )
 from kloppy.domain.models.common import DatasetType
+from kloppy.helpers import to_pandas
 
 
 class TestOpta:
@@ -96,6 +97,11 @@ class TestOpta:
 
         # Check Own goal
         assert dataset.events[18].result.value == "OWN_GOAL"  # 2318697001
+
+        # Check to_pandas conversion for multiple pass qualifier
+        df = to_pandas(dataset.events)
+        assert df.loc[10, "pass_type_assist"] == True
+        assert df.loc[10, "pass_type_cross"] == True
 
     def test_correct_normalized_deserialization(self):
         base_dir = os.path.dirname(__file__)

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -13,6 +13,7 @@ from kloppy.domain import (
     BodyPart,
     SetPieceType,
     PassType,
+    CardType,
 )
 from kloppy.domain.models.common import DatasetType
 
@@ -33,10 +34,14 @@ class TestOpta:
             )
         assert dataset.metadata.provider == Provider.OPTA
         assert dataset.dataset_type == DatasetType.EVENT
-        assert len(dataset.events) == 17
+        assert len(dataset.events) == 20
         assert len(dataset.metadata.periods) == 2
-        assert dataset.events[10].ball_owning_team == dataset.metadata.teams[1]
-        assert dataset.events[15].ball_owning_team == dataset.metadata.teams[0]
+        assert (
+            dataset.events[10].ball_owning_team == dataset.metadata.teams[1]
+        )  # 1594254267
+        assert (
+            dataset.events[15].ball_owning_team == dataset.metadata.teams[0]
+        )  # 2087733359
         assert (
             dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
         )
@@ -68,9 +73,29 @@ class TestOpta:
         assert dataset.events[0].coordinates == Point(50.1, 49.4)
 
         # Check the qualifiers
-        assert dataset.events[0].qualifiers[0].value == SetPieceType.KICK_OFF
-        assert dataset.events[6].qualifiers[0].value == BodyPart.HEAD
-        assert dataset.events[5].qualifiers[0].value == PassType.CHIPPED_PASS
+        assert (
+            dataset.events[0].qualifiers[0].value == SetPieceType.KICK_OFF
+        )  # 1510681159
+        assert (
+            dataset.events[6].qualifiers[0].value == BodyPart.HEAD
+        )  # 1101592119
+        assert (
+            dataset.events[5].qualifiers[0].value == PassType.CHIPPED_PASS
+        )  # 1444075194
+        assert (
+            dataset.events[19].qualifiers[0].value == CardType.RED
+        )  # 2318695229
+
+        # Check receiver coordinates for incomplete passes
+        assert dataset.events[6].receiver_coordinates.x == 45.5
+        assert dataset.events[6].receiver_coordinates.y == 68.2
+
+        # Check timestamp from qualifier in case of goal
+        assert dataset.events[17].timestamp == 139.65200018882751  # 2318695229
+        # assert dataset.events[17].coordinates_y == 12
+
+        # Check Own goal
+        assert dataset.events[18].result.value == "OWN_GOAL"  # 2318697001
 
     def test_correct_normalized_deserialization(self):
         base_dir = os.path.dirname(__file__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ networkx>=2.4
 pytest
 pandas>=1.0.0
 pre-commit
+s3fs==0.4.0


### PR DESCRIPTION
Hi,

based on some feedback I made some changes:

- opta pass_type wasn't working for a pass with multiple qualifiers (those got overwritten). Fixed this bug.
- Converting parsed events to pd.DataFrame using to_pandas() was also only able to keep the last pass type qualifier (in case there are multiple). Changed this similar to what you would get from [pd.get_dummies ](https://pandas.pydata.org/docs/reference/api/pandas.get_dummies.html), i.e. one column for each pass_type containing True/False, thus allowing one pass event to be a CROSS and ASSIST at the same time.
- added tests for both cases.

Cheers
Thomas