### PR TITLE
Fix extraction of foul committed events

### DIFF
--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -179,12 +179,12 @@ def _parse_pass(pass_dict: Dict, team: Team, fidelity_version: int) -> Dict:
 
     qualifiers = _get_event_qualifiers(pass_dict)
 
-    return dict(
-        result=result,
-        receiver_coordinates=receiver_coordinates,
-        receiver_player=receiver_player,
-        qualifiers=qualifiers,
-    )
+    return {
+        "result": result,
+        "receiver_coordinates": receiver_coordinates,
+        "receiver_player": receiver_player,
+        "qualifiers": qualifiers,
+    }
 
 
 def _get_event_qualifiers(qualifiers_dict: Dict) -> List[Qualifier]:
@@ -211,6 +211,14 @@ def _get_event_qualifiers(qualifiers_dict: Dict) -> List[Qualifier]:
     return qualifiers
 
 
+def _get_event_setpiece_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
+    return []
+
+
+def _get_event_bodypart_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
+    return []
+
+
 def _parse_shot(shot_dict: Dict) -> Dict:
     outcome_id = shot_dict["outcome"]["id"]
     if outcome_id == SB_SHOT_OUTCOME_OFF_TARGET:
@@ -234,19 +242,19 @@ def _parse_shot(shot_dict: Dict) -> Dict:
 
     qualifiers = _get_event_qualifiers(shot_dict)
 
-    return dict(
-        result=result,
-        qualifiers=qualifiers,
-    )
+    return {
+        "result": result,
+        "qualifiers": qualifiers,
+    }
 
 
 def _parse_carry(carry_dict: Dict, fidelity_version: int) -> Dict:
-    return dict(
-        result=CarryResult.COMPLETE,
-        end_coordinates=_parse_coordinates(
+    return {
+        "result": CarryResult.COMPLETE,
+        "end_coordinates": _parse_coordinates(
             carry_dict["end_location"], fidelity_version
         ),
-    )
+    }
 
 
 def _parse_take_on(take_on_dict: Dict) -> Dict:
@@ -265,7 +273,9 @@ def _parse_take_on(take_on_dict: Dict) -> Dict:
     else:
         result = TakeOnResult.COMPLETE
 
-    return dict(result=result)
+    return {
+        "result": result,
+    }
 
 
 def _parse_substitution(substitution_dict: Dict, team: Team) -> Dict:
@@ -279,7 +289,9 @@ def _parse_substitution(substitution_dict: Dict, team: Team) -> Dict:
             f'Could not find replacement player {substitution_dict["replacement"]["id"]}'
         )
 
-    return dict(replacement_player=replacement_player)
+    return {
+        "replacement_player": replacement_player,
+    }
 
 
 def _parse_card(card_containing_dict: Dict) -> Dict:
@@ -296,7 +308,9 @@ def _parse_card(card_containing_dict: Dict) -> Dict:
     else:
         card_type = None
 
-    return dict(card_type=card_type)
+    return {
+        "card_type": card_type,
+    }
 
 
 def _determine_xy_fidelity_versions(events: List[Dict]) -> Tuple[int, int]:
@@ -449,25 +463,25 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
                     # TODO: Uh ohhhh.. don't know which one to pick
                     fidelity_version = xy_fidelity_version
 
-                generic_event_kwargs = dict(
+                generic_event_kwargs = {
                     # from DataRecord
-                    period=period,
-                    timestamp=timestamp,
-                    ball_owning_team=possession_team,
-                    ball_state=BallState.ALIVE,
+                    "period": period,
+                    "timestamp": timestamp,
+                    "ball_owning_team": possession_team,
+                    "ball_state": BallState.ALIVE,
                     # from Event
-                    event_id=raw_event["id"],
-                    team=team,
-                    player=player,
-                    coordinates=(
+                    "event_id": raw_event["id"],
+                    "team": team,
+                    "player": player,
+                    "coordinates": (
                         _parse_coordinates(
                             raw_event.get("location"), fidelity_version
                         )
                         if "location" in raw_event
                         else None
                     ),
-                    raw_event=raw_event,
-                )
+                    "raw_event": raw_event,
+                }
 
                 if event_type == SB_EVENT_TYPE_PASS:
                     pass_event_kwargs = _parse_pass(

--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -252,7 +252,8 @@ def _parse_carry(carry_dict: Dict, fidelity_version: int) -> Dict:
     return {
         "result": CarryResult.COMPLETE,
         "end_coordinates": _parse_coordinates(
-            carry_dict["end_location"], fidelity_version
+            carry_dict["end_location"],
+            fidelity_version,
         ),
     }
 
@@ -475,7 +476,8 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
                     "player": player,
                     "coordinates": (
                         _parse_coordinates(
-                            raw_event.get("location"), fidelity_version
+                            raw_event.get("location"),
+                            fidelity_version,
                         )
                         if "location" in raw_event
                         else None
@@ -489,7 +491,6 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
                         team=team,
                         fidelity_version=fidelity_version,
                     )
-
                     event = PassEvent.create(
                         # TODO: Consider moving this to _parse_pass
                         receive_timestamp=timestamp + raw_event["duration"],
@@ -498,10 +499,11 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
                     )
                 elif event_type == SB_EVENT_TYPE_SHOT:
                     shot_event_kwargs = _parse_shot(
-                        shot_dict=raw_event["shot"]
+                        shot_dict=raw_event["shot"],
                     )
                     event = ShotEvent.create(
-                        **shot_event_kwargs, **generic_event_kwargs
+                        **shot_event_kwargs,
+                        **generic_event_kwargs,
                     )
 
                 # For dribble and carry the definitions
@@ -531,7 +533,8 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
                     # lineup affecting events
                 elif event_type == SB_EVENT_TYPE_SUBSTITUTION:
                     substitution_event_kwargs = _parse_substitution(
-                        substitution_dict=raw_event["substitution"], team=team
+                        substitution_dict=raw_event["substitution"],
+                        team=team,
                     )
                     event = SubstitutionEvent.create(
                         result=None,
@@ -565,11 +568,15 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
                         )
                 elif event_type == SB_EVENT_TYPE_PLAYER_ON:
                     event = PlayerOnEvent.create(
-                        result=None, qualifiers=None, **generic_event_kwargs
+                        result=None,
+                        qualifiers=None,
+                        **generic_event_kwargs,
                     )
                 elif event_type == SB_EVENT_TYPE_PLAYER_OFF:
                     event = PlayerOffEvent.create(
-                        result=None, qualifiers=None, **generic_event_kwargs
+                        result=None,
+                        qualifiers=None,
+                        **generic_event_kwargs,
                     )
 
                 elif event_type == SB_EVENT_TYPE_RECOVERY:

--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -406,9 +406,9 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
             events = []
             for raw_event in raw_events:
                 if raw_event["team"]["id"] == home_lineup["team_id"]:
-                    team = teams[0]
+                    team = home_team
                 elif raw_event["team"]["id"] == away_lineup["team_id"]:
-                    team = teams[1]
+                    team = away_team
                 else:
                     raise DeserializationError(
                         f"Unknown team_id {raw_event['team']['id']}"
@@ -418,12 +418,12 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
                     raw_event["possession_team"]["id"]
                     == home_lineup["team_id"]
                 ):
-                    possession_team = teams[0]
+                    possession_team = home_team
                 elif (
                     raw_event["possession_team"]["id"]
                     == away_lineup["team_id"]
                 ):
-                    possession_team = teams[1]
+                    possession_team = away_team
                 else:
                     raise DeserializationError(
                         f"Unknown possession_team_id: {raw_event['possession_team']}"

--- a/kloppy/tests/test_state_builder.py
+++ b/kloppy/tests/test_state_builder.py
@@ -32,7 +32,7 @@ class TestStateBuilder:
             events_per_score[str(score)] = len(events)
 
         assert events_per_score == {
-            "0-0": 2897,
+            "0-0": 2898,
             "1-0": 717,
             "2-0": 405,
             "3-0": 3,
@@ -53,7 +53,7 @@ class TestStateBuilder:
             events_per_sequence[sequence_id] = len(events)
 
         assert events_per_sequence[0] == 4
-        assert events_per_sequence[50] == 14
+        assert events_per_sequence[51] == 14
 
     def test_lineup_state_builder(self):
         dataset = self._load_dataset("statsbomb_15986")

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -14,6 +14,8 @@ from kloppy.domain import (
 )
 
 from kloppy import statsbomb
+from kloppy.domain.models.event import CardType
+from kloppy.infra.serializers.event.wyscout.wyscout_tags import YELLOW_CARD
 
 
 class TestStatsbomb:
@@ -128,3 +130,30 @@ class TestStatsbomb:
             assert event.replacement_player == event.team.get_player_by_id(
                 replacement_player_id
             )
+
+    def test_card(self, lineup_data: str, event_data: str):
+        """
+        Test card events
+        """
+        dataset = statsbomb.load(
+            lineup_data=lineup_data,
+            event_data=event_data,
+            event_types=["card"],
+        )
+
+        assert len(dataset.events) == 2
+
+        for card in dataset.events:
+            assert card.card_type == CardType.FIRST_YELLOW
+
+    def test_foul_committed(self, lineup_data: str, event_data: str):
+        """
+        Test foul committed events
+        """
+        dataset = statsbomb.load(
+            lineup_data=lineup_data,
+            event_data=event_data,
+            event_types=["foul_committed"],
+        )
+
+        assert len(dataset.events) == 2

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -43,7 +43,7 @@ class TestStatsbomb:
 
         assert dataset.metadata.provider == Provider.STATSBOMB
         assert dataset.dataset_type == DatasetType.EVENT
-        assert len(dataset.events) == 4022
+        assert len(dataset.events) == 4023
         assert len(dataset.metadata.periods) == 2
         assert (
             dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
@@ -78,12 +78,12 @@ class TestStatsbomb:
         assert dataset.events[10].coordinates == Point(34.5, 20.5)
 
         assert (
-            dataset.events[791].get_qualifier_value(BodyPartQualifier)
+            dataset.events[792].get_qualifier_value(BodyPartQualifier)
             == BodyPart.HEAD
         )
 
         assert (
-            dataset.events[2231].get_qualifier_value(BodyPartQualifier)
+            dataset.events[2232].get_qualifier_value(BodyPartQualifier)
             == BodyPart.RIGHT_FOOT
         )
 
@@ -156,4 +156,4 @@ class TestStatsbomb:
             event_types=["foul_committed"],
         )
 
-        assert len(dataset.events) == 2
+        assert len(dataset.events) == 23

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -4,18 +4,17 @@ import pytest
 
 from kloppy.domain import (
     AttackingDirection,
-    Period,
-    Orientation,
-    Provider,
-    Point,
-    BodyPartQualifier,
     BodyPart,
+    BodyPartQualifier,
     DatasetType,
+    Orientation,
+    Period,
+    Point,
+    Provider,
 )
 
 from kloppy import statsbomb
 from kloppy.domain.models.event import CardType
-from kloppy.infra.serializers.event.wyscout.wyscout_tags import YELLOW_CARD
 
 
 class TestStatsbomb:


### PR DESCRIPTION
This pull request fixes an issue in the StatsBomb deserializer that prevents _foul committed_ events to be extracted from the StatsBomb event feed.

### Context
The StatsBomb deserializer attempts to convert each StatsBomb event into at most one corresponding `kloppy` event. The deserializer loops over the StatsBomb events (`raw_events`) and decides for each event (`raw_event`) whether it corresponds to one of the `kloppy` events. However, some StatsBomb events decompose into multiple `kloppy` events. For example, the _card_ event is a subtype of the _bad behaviour_ and _foul committed_ events in the StatsBomb event feed. Currently, the _card_ event is correctly extracted from the event feed, whereas the _foul committed_ event is ignored.

### Changes
1. The deserializer keeps a list of potentially new `kloppy` events while processing a `raw_event` from StatsBomb. This `new_events` list replaces the `event` variable that was used to keep a reference to the potentially new `kloppy` event. At the end of each iteration, the events that meet the inclusion criteria are added to the `kloppy` event feed.
2. The `event_type == SB_EVENT_TYPE_FOUL_COMMITTED` branch of the processing loop not only creates a _card_ event when a yellow or red card was given but also creates a _foul committed_ event.
3. The  `event_type == SB_EVENT_TYPE_BAD_BEHAVIOUR` and  `event_type == SB_EVENT_TYPE_FOUL_COMMITTED` branches of the processing loop have been refactored such that other properties could be extracted more conveniently.
4. The dict constructors have been replaced with dict literals, which are slightly faster and more flexible.