### PR TITLE
Add pass qualifiers to StatsBomb deserializer

### DIFF
--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -1,4 +1,3 @@
-from ast import Pass
 import os
 
 import pytest
@@ -18,7 +17,6 @@ from kloppy.domain import (
 from kloppy import statsbomb
 from kloppy.domain.models.event import (
     CardType,
-    PassEvent,
     PassQualifier,
     PassType,
 )

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -1,3 +1,4 @@
+from ast import Pass
 import os
 
 import pytest
@@ -15,7 +16,12 @@ from kloppy.domain import (
 )
 
 from kloppy import statsbomb
-from kloppy.domain.models.event import CardType
+from kloppy.domain.models.event import (
+    CardType,
+    PassEvent,
+    PassQualifier,
+    PassType,
+)
 
 
 class TestStatsbomb:
@@ -96,6 +102,48 @@ class TestStatsbomb:
         assert (
             dataset.events[195].get_qualifier_value(BodyPartQualifier) is None
         )
+
+        assert (
+            dataset.events[1433].get_qualifier_value(PassQualifier)
+            == PassType.CROSS
+        )
+
+        assert (
+            dataset.events[1552].get_qualifier_value(PassQualifier)
+            == PassType.THROUGH_BALL
+        )
+
+        assert (
+            dataset.events[443].get_qualifier_value(PassQualifier)
+            == PassType.SWITCH_OF_PLAY
+        )
+
+        assert (
+            dataset.events[3438].get_qualifier_value(PassQualifier)
+            == PassType.LONG_BALL
+        )
+
+        assert (
+            dataset.events[2266].get_qualifier_value(PassQualifier)
+            == PassType.HIGH_PASS
+        )
+
+        assert (
+            dataset.events[653].get_qualifier_value(PassQualifier)
+            == PassType.HEAD_PASS
+        )
+
+        assert (
+            dataset.events[3134].get_qualifier_value(PassQualifier)
+            == PassType.HAND_PASS
+        )
+
+        assert (
+            dataset.events[3611].get_qualifier_value(PassQualifier)
+            == PassType.ASSIST
+        )
+
+        assert dataset.events[3392].get_qualifier_value(PassQualifier) is None
 
     def test_correct_normalized_deserialization(
         self, lineup_data: str, event_data: str


### PR DESCRIPTION
This pull request adds several pass qualifiers to the StatsBomb deserializer.

### Context
The StatsBomb deserializer currently does not support pass qualifiers (#97). The StatsBomb deserializer currently also assigns set-piece qualifiers to shots that should only be assigned to passes.

### Changes
1. The `_get_event_qualifiers` method in the StatsBomb deserializer has been decomposed into separate methods for extracting body part qualifiers (`_get_body_part_qualifiers`) and set-piece qualifiers (`_get_set_piece_qualifiers`). The latter method is only invoked for passes and no longer for shots.
2. The `_get_pass_qualifiers` method is added to the StatsBomb deserializer. This method supports the following eight qualifiers: Cross, Through Ball, Switch of Play, High Pass, Long Ball, Head Pass, Hand Pass and Assist.

This pull request assumes that multiple pass qualifiers can be assigned to a pass despite the `get_qualifier_value` method in the `Event` class only returning the first qualifier. However, this issue should be solved once #120 has been merged.