### PR TITLE
Add related events and next/prev with more easy filtering

### DIFF
--- a/docs/examples/navigating.ipynb
+++ b/docs/examples/navigating.ipynb
@@ -1,0 +1,512 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d5e58e18",
+   "metadata": {},
+   "source": [
+    "# Navigating\n",
+    "\n",
+    "Kloppy 3.2 adds some powerfull tools to navigate through you event data. In this tutorial you will learn how to use them.\n",
+    "\n",
+    "\n",
+    "## Dataset\n",
+    "\n",
+    "On dataset level it's possible to use `filter`, `find` and `find_all`. All these functions access the same argument for finding the right events.\n",
+    "You can pass a string or a function. In case of a string is must be either 'event_type', 'event_type.result' or '.result'. Some examples: 'shot.goal', 'pass' or '.complete'.\n",
+    "\n",
+    "Lets have a look at how these work.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c910dd35",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/koen/Developer/Projects/PySport/kloppy/.venv/lib/python3.8/site-packages/kloppy-3.2.0-py3.8.egg/kloppy/_providers/statsbomb.py:46: UserWarning: \n",
+      "\n",
+      "You are about to use StatsBomb public data.\n",
+      "By using this data, you are agreeing to the user agreement. \n",
+      "The user agreement can be found here: https://github.com/statsbomb/open-data/blob/master/LICENSE.pdf\n",
+      "\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>event_id</th>\n",
+       "      <th>event_type</th>\n",
+       "      <th>result</th>\n",
+       "      <th>success</th>\n",
+       "      <th>period_id</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>end_timestamp</th>\n",
+       "      <th>ball_state</th>\n",
+       "      <th>ball_owning_team</th>\n",
+       "      <th>team_id</th>\n",
+       "      <th>player_id</th>\n",
+       "      <th>coordinates_x</th>\n",
+       "      <th>coordinates_y</th>\n",
+       "      <th>end_coordinates_x</th>\n",
+       "      <th>end_coordinates_y</th>\n",
+       "      <th>body_part_type</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>4c7c4ab1-6b9f-4504-a237-249c2e0c549f</td>\n",
+       "      <td>SHOT</td>\n",
+       "      <td>GOAL</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1091.954</td>\n",
+       "      <td>None</td>\n",
+       "      <td>alive</td>\n",
+       "      <td>217</td>\n",
+       "      <td>217</td>\n",
+       "      <td>5503</td>\n",
+       "      <td>0.800417</td>\n",
+       "      <td>0.563125</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>LEFT_FOOT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>683c6752-13bc-4892-94ed-22e1c938f1f7</td>\n",
+       "      <td>SHOT</td>\n",
+       "      <td>GOAL</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2261.578</td>\n",
+       "      <td>None</td>\n",
+       "      <td>alive</td>\n",
+       "      <td>217</td>\n",
+       "      <td>217</td>\n",
+       "      <td>3501</td>\n",
+       "      <td>0.875417</td>\n",
+       "      <td>0.388125</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>RIGHT_FOOT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>55d71847-9511-4417-aea9-6f415e279011</td>\n",
+       "      <td>SHOT</td>\n",
+       "      <td>GOAL</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2802.770</td>\n",
+       "      <td>None</td>\n",
+       "      <td>alive</td>\n",
+       "      <td>217</td>\n",
+       "      <td>217</td>\n",
+       "      <td>5503</td>\n",
+       "      <td>0.932917</td>\n",
+       "      <td>0.431875</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>LEFT_FOOT</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               event_id event_type result  success  period_id  \\\n",
+       "0  4c7c4ab1-6b9f-4504-a237-249c2e0c549f       SHOT   GOAL     True          2   \n",
+       "1  683c6752-13bc-4892-94ed-22e1c938f1f7       SHOT   GOAL     True          2   \n",
+       "2  55d71847-9511-4417-aea9-6f415e279011       SHOT   GOAL     True          2   \n",
+       "\n",
+       "   timestamp end_timestamp ball_state ball_owning_team team_id player_id  \\\n",
+       "0   1091.954          None      alive              217     217      5503   \n",
+       "1   2261.578          None      alive              217     217      3501   \n",
+       "2   2802.770          None      alive              217     217      5503   \n",
+       "\n",
+       "   coordinates_x  coordinates_y end_coordinates_x end_coordinates_y  \\\n",
+       "0       0.800417       0.563125              None              None   \n",
+       "1       0.875417       0.388125              None              None   \n",
+       "2       0.932917       0.431875              None              None   \n",
+       "\n",
+       "  body_part_type  \n",
+       "0      LEFT_FOOT  \n",
+       "1     RIGHT_FOOT  \n",
+       "2      LEFT_FOOT  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from kloppy import statsbomb\n",
+    "\n",
+    "# Load a Statsbomb open data dataset\n",
+    "dataset = statsbomb.load_open_data()\n",
+    "\n",
+    "# Create a new dataset which contains all goals\n",
+    "filtered_dataset = dataset.filter('shot.goal')\n",
+    "\n",
+    "# Show the results\n",
+    "filtered_dataset.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fe919e7",
+   "metadata": {},
+   "source": [
+    "The filtered dataset doesn't contain any events other than goals. Lets validate that. When we try to find all passes we should get an empty list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "57aac560",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "passes = filtered_dataset.find_all('pass')\n",
+    "len(passes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cd3edb8",
+   "metadata": {},
+   "source": [
+    "The original dataset does contain passes, right?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "45de2f06",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1132"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "passes = dataset.find_all('pass')\n",
+    "len(passes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3239a684",
+   "metadata": {},
+   "source": [
+    "Now we already touched the `find_all` method. This method accepts the same argument. The difference is that `find_all` returns a list of events, where `filter` returns a new Dataset. The `find` method return the first matching event or None when it cannot find one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "2df283f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ShotEvent event_id='65f16e50-7c5d-4293-b2fc-d20887a772f9' time='P1T02:29' player='Lionel Andrés Messi Cuccittini' result='OFF_TARGET'>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.find('shot')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "7c432ca0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(filtered_dataset.find('pass'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b5120a9",
+   "metadata": {},
+   "source": [
+    "## Event\n",
+    "\n",
+    "On Event level there are also some new methods for navigating. The `prev` and `next` methods are added. These allow you to quickly find previous or next events. But those two methods also accept the filter argument like the Dataset methods do. This makes useful to find a certain type of event instead of just the one before/after.\n",
+    "\n",
+    "Lets have look at how this works"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "31fd93a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ShotEvent event_id='4c7c4ab1-6b9f-4504-a237-249c2e0c549f' time='P2T18:12' player='Lionel Andrés Messi Cuccittini' result='GOAL'>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load a Statsbomb open data dataset\n",
+    "dataset = statsbomb.load_open_data()\n",
+    "\n",
+    "first_goal = dataset.find('shot.goal')\n",
+    "first_goal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "98dda35c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<GenericEvent:Foul Won event_id='eed04441-624f-4f23-9843-7bd069c16232' time='P2T17:02' player='Lionel Andrés Messi Cuccittini' result='None'>\n",
+      "<ShotEvent event_id='4c7c4ab1-6b9f-4504-a237-249c2e0c549f' time='P2T18:12' player='Lionel Andrés Messi Cuccittini' result='GOAL'>\n",
+      "<GenericEvent:Goal Keeper event_id='5080ad86-383c-40c5-b718-508d8c9be454' time='P2T18:13' player='Fernando Pacheco Flores' result='None'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Lets previous and next events\n",
+    "print(first_goal.prev())\n",
+    "print(first_goal)\n",
+    "print(first_goal.next())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9be4a6a1",
+   "metadata": {},
+   "source": [
+    "But what if we want to find the last complete pass before the goal?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "841fa959",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<PassEvent event_id='df4a42e4-e5d3-4573-853a-604e46a588d4' time='P2T16:58' player='Ivan Rakitić' result='COMPLETE'>"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_goal.prev('pass.complete')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7026192",
+   "metadata": {},
+   "source": [
+    "Or when we don't care about the event type, but want to make sure it's complete.."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "16aad417",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CarryEvent event_id='95bded73-4861-4374-99cf-2a278ff07ea6' time='P2T17:02' player='Lionel Andrés Messi Cuccittini' result='COMPLETE'>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_goal.prev('.complete')\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b5514bd",
+   "metadata": {},
+   "source": [
+    "## Related events\n",
+    "\n",
+    "Some vendors include `related_events` in their data. The related events can be accessed via `get_related_events` method, or by `related_pass`, `related_carry`, etc for each event type.\n",
+    "\n",
+    "The `get_related_events` returns a list which can be empty. The `related_pass` methods return an Event or None when that type is not specified."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "963e687d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<TakeOnEvent event_id='a1b51bfb-9198-4180-966a-91937f399d2d' time='P2T17:02' player='Lionel Andrés Messi Cuccittini' result='COMPLETE'>,\n",
+       " <GenericEvent:Dribbled Past event_id='a1b860e4-71b4-4366-b1bf-7290a82a380f' time='P2T17:02' player='Rubén Duarte Sánchez' result='None'>,\n",
+       " <FoulCommittedEvent event_id='e44eea88-d7ae-4806-b322-04134755e187' time='P2T17:02' player='Daniel Alejandro Torres Rojas' result='None'>,\n",
+       " <GenericEvent:Foul Won event_id='eed04441-624f-4f23-9843-7bd069c16232' time='P2T17:02' player='Lionel Andrés Messi Cuccittini' result='None'>]"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "carry_event = first_goal.prev('carry')\n",
+    "carry_event.get_related_events()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "7d2c3377",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(carry_event.related_pass())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "3e53ee99",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<TakeOnEvent event_id='a1b51bfb-9198-4180-966a-91937f399d2d' time='P2T17:02' player='Lionel Andrés Messi Cuccittini' result='COMPLETE'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(carry_event.related_take_on())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ed402bd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "kloppy-venv",
+   "language": "python",
+   "name": "kloppy-venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/state.ipynb
+++ b/docs/examples/state.ipynb
@@ -1373,8 +1373,16 @@
     }
    ],
    "source": [
-    "dataframe_stats = dataframe.groupby(['Team', 'Formation'])['success'].agg(['sum', 'count'])\n",
-    "dataframe_stats['Percentage'] = dataframe_stats['sum'] / dataframe_stats['count'] * 100\n",
+    "dataframe_stats = (\n",
+    "    dataframe\n",
+    "    .groupby(['Team', 'Formation'])['success']\n",
+    "    .agg(['sum', 'count'])\n",
+    ")\n",
+    "dataframe_stats['Percentage'] = (\n",
+    "    dataframe_stats['sum'] \n",
+    "    / dataframe_stats['count'] \n",
+    "    * 100\n",
+    ")\n",
     "dataframe_stats.rename(\n",
     "    columns={\n",
     "        'sum': 'Goals',\n",

--- a/kloppy/__init__.py
+++ b/kloppy/__init__.py
@@ -13,4 +13,4 @@ except NameError:
 #     )
 #     from .domain.services.state_builder import add_state
 
-__version__ = "3.1.1"
+__version__ = "3.2.0"

--- a/kloppy/domain/models/code.py
+++ b/kloppy/domain/models/code.py
@@ -27,6 +27,10 @@ class Code(DataRecord):
     labels: Dict[str, str] = field(default_factory=dict)
 
     @property
+    def record_id(self) -> str:
+        return self.record_id
+
+    @property
     def start_timestamp(self):
         return self.timestamp
 

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -670,6 +670,11 @@ class DataRecord(ABC):
         prev: Optional["DataRecord"],
         next_: Optional["DataRecord"],
     ):
+        if hasattr(self, "dataset"):
+            # TODO: determine if next/prev record should be affected
+            # by Dataset.filter
+            return
+
         self.dataset = dataset
         self.prev_record = prev
         self.next_record = next_
@@ -705,6 +710,11 @@ class DataRecord(ABC):
                 return self.next_record.next(
                     filter_, search_depth=search_depth - 1
                 )
+
+    def __str__(self):
+        return f"<{self.__class__.__name__}>"
+
+    __repr__ = __str__
 
 
 @dataclass
@@ -817,7 +827,7 @@ class Dataset(ABC, Generic[T]):
             records=self.find_all(filter_),
         )
 
-    def find_all(self, filter_) -> List["DataRecord"]:
+    def find_all(self, filter_) -> List[T]:
         return [record for record in self.records if record.matches(filter_)]
 
     @classmethod

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -687,29 +687,21 @@ class DataRecord(ABC):
         else:
             raise InvalidFilterError()
 
-    def prev(self, filter_=None, search_depth=50) -> Optional["DataRecord"]:
-        if search_depth == 0:
-            return None
-
+    def prev(self, filter_=None) -> Optional["DataRecord"]:
         if self.prev_record:
-            if self.prev_record.matches(filter_):
-                return self.prev_record
-            else:
-                return self.prev_record.prev(
-                    filter_, search_depth=search_depth - 1
-                )
+            prev_record = self.prev_record
+            while prev_record:
+                if prev_record.matches(filter_):
+                    return prev_record
+                prev_record = prev_record.prev_record
 
-    def next(self, filter_=None, search_depth=50) -> Optional["DataRecord"]:
-        if search_depth == 0:
-            return None
-
+    def next(self, filter_=None) -> Optional["DataRecord"]:
         if self.next_record:
-            if self.next_record.matches(filter_):
-                return self.next_record
-            else:
-                return self.next_record.next(
-                    filter_, search_depth=search_depth - 1
-                )
+            next_record = self.next_record
+            while next_record:
+                if next_record.matches(filter_):
+                    return next_record
+                next_record = next_record.next_record
 
     def __str__(self):
         return f"<{self.__class__.__name__}>"
@@ -829,6 +821,11 @@ class Dataset(ABC, Generic[T]):
 
     def find_all(self, filter_) -> List[T]:
         return [record for record in self.records if record.matches(filter_)]
+
+    def find(self, filter_) -> Optional[T]:
+        for record in self.records:
+            if record.matches(filter_):
+                return record
 
     @classmethod
     def from_dataset(

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -2,7 +2,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from functools import partial
 from typing import Dict, List, Type, Union, Any, Callable, Optional
 
 from kloppy.domain.models.common import DatasetType
@@ -480,19 +479,31 @@ class Event(DataRecord, ABC):
         elif callable(filter_):
             return filter_(self)
         elif isinstance(filter_, str):
-            parts = filter_.upper().split(" ")
-            for part in parts:
-                if part in EventType._member_names_:
-                    if self.event_type != EventType[part]:
-                        return False
-                elif (
-                    self.result
-                    and part in self.result.__class__._member_names_
-                ):
-                    if self.result != self.result.__class__[part]:
-                        return False
-                else:
+            """
+            Allowed formats:
+            1. <event_type>
+            2. <event_type>.<result>
+
+            This format always us to go to css selectors without breaking existing code.
+            """
+            parts = filter_.upper().split(".")
+            if len(parts) == 2:
+                event_type, result = parts
+            elif len(parts) == 1:
+                event_type = parts[0]
+                result = None
+            else:
+                raise InvalidFilterError(
+                    f"Don't know how to apply filter {filter_}"
+                )
+
+            if self.event_type != EventType[event_type]:
+                return False
+
+            if result:
+                if self.result != self.result.__class__[result]:
                     return False
+
             return True
 
     def __str__(self):
@@ -512,8 +523,11 @@ class Event(DataRecord, ABC):
             f"result='{self.result}'>"
         )
 
+    def __repr__(self):
+        return str(self)
 
-@dataclass
+
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class GenericEvent(Event):
     """
@@ -528,7 +542,7 @@ class GenericEvent(Event):
     event_name: str = "generic"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class ShotEvent(Event):
     """
@@ -548,7 +562,7 @@ class ShotEvent(Event):
     event_name: str = "shot"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class PassEvent(Event):
     """
@@ -573,7 +587,7 @@ class PassEvent(Event):
     event_name: str = "pass"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class TakeOnEvent(Event):
     """
@@ -591,7 +605,7 @@ class TakeOnEvent(Event):
     event_name: str = "take_on"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class CarryEvent(Event):
     """
@@ -614,7 +628,7 @@ class CarryEvent(Event):
     event_name: str = "carry"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class SubstitutionEvent(Event):
     """
@@ -632,7 +646,7 @@ class SubstitutionEvent(Event):
     event_name: str = "substitution"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class PlayerOffEvent(Event):
     """
@@ -647,7 +661,7 @@ class PlayerOffEvent(Event):
     event_name: str = "player_off"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class PlayerOnEvent(Event):
     """
@@ -662,7 +676,7 @@ class PlayerOnEvent(Event):
     event_name: str = "player_on"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class CardEvent(Event):
     """
@@ -680,7 +694,7 @@ class CardEvent(Event):
     event_name: str = "card"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class FormationChangeEvent(Event):
     """
@@ -698,7 +712,7 @@ class FormationChangeEvent(Event):
     event_name: str = "formation_change"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class RecoveryEvent(Event):
     """
@@ -713,7 +727,7 @@ class RecoveryEvent(Event):
     event_name: str = "recovery"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class BallOutEvent(Event):
     """
@@ -728,7 +742,7 @@ class BallOutEvent(Event):
     event_name: str = "ball_out"
 
 
-@dataclass
+@dataclass(repr=False)
 @docstring_inherit_attributes(Event)
 class FoulCommittedEvent(Event):
     """
@@ -743,7 +757,7 @@ class FoulCommittedEvent(Event):
     event_name: str = "foul_committed"
 
 
-@dataclass
+@dataclass(repr=False)
 class EventDataset(Dataset[Event]):
     """
     EventDataset

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -497,11 +497,25 @@ class Event(DataRecord, ABC):
                     f"Don't know how to apply filter {filter_}"
                 )
 
-            if self.event_type != EventType[event_type]:
-                return False
+            if event_type:
+                try:
+                    if self.event_type != EventType[event_type]:
+                        return False
+                except KeyError:
+                    raise InvalidFilterError(
+                        f"Cannot find event type {event_type}. Possible options: {[e.value.lower() for e in EventType]}"
+                    )
 
             if result:
-                if self.result != self.result.__class__[result]:
+                if not self.result:
+                    return False
+
+                try:
+                    if self.result != self.result.__class__[result]:
+                        return False
+                except KeyError:
+                    # result isn't applicable for this event
+                    # example: result='GOAL' event=<Pass>
                     return False
 
             return True

--- a/kloppy/domain/models/tracking.py
+++ b/kloppy/domain/models/tracking.py
@@ -15,7 +15,7 @@ class PlayerData:
     other_data: Dict[str, Any] = field(default_factory=dict)
 
 
-@dataclass
+@dataclass(repr=False)
 class Frame(DataRecord):
     frame_id: int
     players_data: Dict[Player, PlayerData]

--- a/kloppy/domain/models/tracking.py
+++ b/kloppy/domain/models/tracking.py
@@ -23,6 +23,10 @@ class Frame(DataRecord):
     ball_coordinates: Point
 
     @property
+    def record_id(self) -> int:
+        return self.frame_id
+
+    @property
     def players_coordinates(self):
         return {
             player: player_data.coordinates

--- a/kloppy/domain/services/matchers/css.py
+++ b/kloppy/domain/services/matchers/css.py
@@ -1,0 +1,36 @@
+from typing import List
+from lxml import etree
+
+from cssselect import GenericTranslator
+
+from kloppy.domain import Event, EventType
+
+
+class CSSPatternMatcher:
+    def __init__(self, pattern: str):
+        self.expression = GenericTranslator().css_to_xpath([pattern])
+
+    def match(self, events: List[Event]) -> List[List[Event]]:
+        elm = etree.Element("start")
+        root = elm
+        for i, event in enumerate(events):
+            if event.event_type != EventType.GENERIC:
+                elm = etree.SubElement(
+                    elm,
+                    event.event_name.lower()
+                    .replace(" ", "_")
+                    .replace("*", ""),
+                    index=i,
+                    result=str(event.result).lower(),
+                    team=str(event.team.ground).lower(),
+                    attrib={
+                        "class": str(event.result).lower()
+                        + " "
+                        + str(event.team.ground).lower()
+                    },
+                )
+
+        matching_events = []
+        for elm in root.xpath(self.expression):
+            matching_events.append(events[elm.attrib["index"]])
+        return matching_events

--- a/kloppy/exceptions.py
+++ b/kloppy/exceptions.py
@@ -8,3 +8,11 @@ class DeserializationError(KloppyError):
 
 class OrientationError(KloppyError):
     pass
+
+
+class OrphanedRecordError(KloppyError):
+    pass
+
+
+class InvalidFilterError(KloppyError):
+    pass

--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -83,6 +83,7 @@ EVENT_QUALIFIER_THROW_IN = 107
 EVENT_QUALIFIER_CORNER_KICK = 6
 EVENT_QUALIFIER_PENALTY = 9
 EVENT_QUALIFIER_KICK_OFF = 279
+EVENT_QUALIFIER_FREE_KICK_SHOT = 26
 
 EVENT_QUALIFIER_HEAD_PASS = 3
 EVENT_QUALIFIER_HEAD = 15
@@ -405,7 +406,10 @@ def _get_event_setpiece_qualifiers(raw_qualifiers: List) -> List[Qualifier]:
     qualifiers = []
     if EVENT_QUALIFIER_CORNER_KICK in raw_qualifiers:
         qualifiers.append(SetPieceQualifier(value=SetPieceType.CORNER_KICK))
-    elif EVENT_QUALIFIER_FREE_KICK in raw_qualifiers:
+    elif (
+        EVENT_QUALIFIER_FREE_KICK in raw_qualifiers
+        or EVENT_QUALIFIER_FREE_KICK_SHOT in raw_qualifiers
+    ):
         qualifiers.append(SetPieceQualifier(value=SetPieceType.FREE_KICK))
     elif EVENT_QUALIFIER_PENALTY in raw_qualifiers:
         qualifiers.append(SetPieceQualifier(value=SetPieceType.PENALTY))

--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -589,6 +589,7 @@ class StatsBombDeserializer(EventDataDeserializer[StatsbombInputs]):
                         if "location" in raw_event
                         else None
                     ),
+                    "related_event_ids": raw_event.get("related_events", []),
                     "raw_event": raw_event,
                 }
 

--- a/kloppy/tests/test_event.py
+++ b/kloppy/tests/test_event.py
@@ -32,45 +32,46 @@ class TestEvent:
         """
         Test navigating (next/prev) through events
         """
-        passes = dataset.find_all('pass')
-        assert passes[0].next('pass') == passes[1]
-        assert passes[1].prev('pass') == passes[0]
-        assert passes[0].next() == dataset.get_event_by_id('61da36dc-d862-416c-8ee3-1a0cd24dc086')
+        passes = dataset.find_all("pass")
+        assert passes[0].next("pass") == passes[1]
+        assert passes[1].prev("pass") == passes[0]
+        assert passes[0].next() == dataset.get_event_by_id(
+            "61da36dc-d862-416c-8ee3-1a0cd24dc086"
+        )
 
-        goals = dataset.find_all('shot.goal')
+        goals = dataset.find_all("shot.goal")
         assert len(goals) == 3
-        assert goals[0].prev('shot.goal') is None
-        assert goals[0].next('shot.goal') == goals[1]
-        assert goals[0].next('shot.goal') == goals[2].prev('shot.goal')
-        assert goals[2].next('shot.goal') is None
+        assert goals[0].prev("shot.goal") is None
+        assert goals[0].next("shot.goal") == goals[1]
+        assert goals[0].next("shot.goal") == goals[2].prev("shot.goal")
+        assert goals[2].next("shot.goal") is None
 
-        first_goal = dataset.find('shot.goal')
+        first_goal = dataset.find("shot.goal")
         assert first_goal == goals[0]
-        assert first_goal.next('.goal') == goals[1]
-        assert first_goal.next('.goal').next('.goal') == goals[2]
-        assert first_goal.next('.goal').next('.goal').next('.goal') is None
+        assert first_goal.next(".goal") == goals[1]
+        assert first_goal.next(".goal").next(".goal") == goals[2]
+        assert first_goal.next(".goal").next(".goal").next(".goal") is None
 
     def test_filter(self, dataset: EventDataset):
         """
         Test filtering allows simple 'css selector' (<event_type>.<result>)
         """
-        goals_dataset = dataset.filter('shot.goal')
+        goals_dataset = dataset.filter("shot.goal")
 
         df = goals_dataset.to_pandas()
-        assert df['event_id'].to_list() == [
-            '4c7c4ab1-6b9f-4504-a237-249c2e0c549f',
-            '683c6752-13bc-4892-94ed-22e1c938f1f7',
-            '55d71847-9511-4417-aea9-6f415e279011'
+        assert df["event_id"].to_list() == [
+            "4c7c4ab1-6b9f-4504-a237-249c2e0c549f",
+            "683c6752-13bc-4892-94ed-22e1c938f1f7",
+            "55d71847-9511-4417-aea9-6f415e279011",
         ]
 
     def test_find_all(self, dataset: EventDataset):
         """
         Test find_all allows simple 'css selector' (<event_type>.<result>)
         """
-        goals = dataset.find_all('shot.goal')
+        goals = dataset.find_all("shot.goal")
         assert len(goals) == 3
-        assert goals[0].prev('shot.goal') is None
-        assert goals[0].next('shot.goal') == goals[1]
-        assert goals[0].next('shot.goal') == goals[2].prev('shot.goal')
-        assert goals[2].next('shot.goal') is None
-
+        assert goals[0].prev("shot.goal") is None
+        assert goals[0].next("shot.goal") == goals[1]
+        assert goals[0].next("shot.goal") == goals[2].prev("shot.goal")
+        assert goals[2].next("shot.goal") is None

--- a/kloppy/tests/test_event.py
+++ b/kloppy/tests/test_event.py
@@ -1,0 +1,76 @@
+import os
+
+import pytest
+
+
+from kloppy import statsbomb
+from kloppy.domain import EventDataset
+
+
+class TestEvent:
+    """"""
+
+    @pytest.fixture
+    def event_data(self) -> str:
+        base_dir = os.path.dirname(__file__)
+        return f"{base_dir}/files/statsbomb_event.json"
+
+    @pytest.fixture
+    def lineup_data(self) -> str:
+        base_dir = os.path.dirname(__file__)
+        return f"{base_dir}/files/statsbomb_lineup.json"
+
+    @pytest.fixture()
+    def dataset(self, lineup_data: str, event_data: str) -> EventDataset:
+        return statsbomb.load(
+            lineup_data=lineup_data,
+            event_data=event_data,
+            coordinates="statsbomb",
+        )
+
+    def test_navigation(self, dataset: EventDataset):
+        """
+        Test navigating (next/prev) through events
+        """
+        passes = dataset.find_all('pass')
+        assert passes[0].next('pass') == passes[1]
+        assert passes[1].prev('pass') == passes[0]
+        assert passes[0].next() == dataset.get_event_by_id('61da36dc-d862-416c-8ee3-1a0cd24dc086')
+
+        goals = dataset.find_all('shot.goal')
+        assert len(goals) == 3
+        assert goals[0].prev('shot.goal') is None
+        assert goals[0].next('shot.goal') == goals[1]
+        assert goals[0].next('shot.goal') == goals[2].prev('shot.goal')
+        assert goals[2].next('shot.goal') is None
+
+        first_goal = dataset.find('shot.goal')
+        assert first_goal == goals[0]
+        assert first_goal.next('.goal') == goals[1]
+        assert first_goal.next('.goal').next('.goal') == goals[2]
+        assert first_goal.next('.goal').next('.goal').next('.goal') is None
+
+    def test_filter(self, dataset: EventDataset):
+        """
+        Test filtering allows simple 'css selector' (<event_type>.<result>)
+        """
+        goals_dataset = dataset.filter('shot.goal')
+
+        df = goals_dataset.to_pandas()
+        assert df['event_id'].to_list() == [
+            '4c7c4ab1-6b9f-4504-a237-249c2e0c549f',
+            '683c6752-13bc-4892-94ed-22e1c938f1f7',
+            '55d71847-9511-4417-aea9-6f415e279011'
+        ]
+
+    def test_find_all(self, dataset: EventDataset):
+        """
+        Test find_all allows simple 'css selector' (<event_type>.<result>)
+        """
+        goals = dataset.find_all('shot.goal')
+        assert len(goals) == 3
+        assert goals[0].prev('shot.goal') is None
+        assert goals[0].next('shot.goal') == goals[1]
+        assert goals[0].next('shot.goal') == goals[2].prev('shot.goal')
+        assert goals[2].next('shot.goal') is None
+

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -226,4 +226,3 @@ class TestStatsbomb:
 
         assert carry_event.get_related_events() == [receipt_event, pass_event]
         assert carry_event.related_pass() == pass_event
-        assert pass_event.related_carry() == carry_event

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -209,3 +209,19 @@ class TestStatsbomb:
         )
 
         assert len(dataset.events) == 23
+
+    def test_related_events(self, lineup_data: str, event_data: str):
+        print("")
+        dataset = statsbomb.load(
+            lineup_data=lineup_data, event_data=event_data
+        )
+        for shot in dataset.find_all("saved shot"):
+            print(shot)
+            print(shot.prev("incomplete"))
+            print("----")
+
+        #
+        # event = dataset.get_event_by_id("8e3dacc2-7a39-4301-9053-e78cfec1aa95")
+        #
+        # print(event)
+        # print(event.next("shot"))

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -211,17 +211,19 @@ class TestStatsbomb:
         assert len(dataset.events) == 23
 
     def test_related_events(self, lineup_data: str, event_data: str):
-        print("")
         dataset = statsbomb.load(
             lineup_data=lineup_data, event_data=event_data
         )
-        for shot in dataset.find_all("saved shot"):
-            print(shot)
-            print(shot.prev("incomplete"))
-            print("----")
+        carry_event = dataset.get_event_by_id(
+            "8e3dacc2-7a39-4301-9053-e78cfec1aa95"
+        )
+        pass_event = dataset.get_event_by_id(
+            "d1cccb73-c7ef-4b02-8267-ebd7f149904b"
+        )
+        receipt_event = dataset.get_event_by_id(
+            "61da36dc-d862-416c-8ee3-1a0cd24dc086"
+        )
 
-        #
-        # event = dataset.get_event_by_id("8e3dacc2-7a39-4301-9053-e78cfec1aa95")
-        #
-        # print(event)
-        # print(event.next("shot"))
+        assert carry_event.get_related_events() == [receipt_event, pass_event]
+        assert carry_event.related_pass() == pass_event
+        assert pass_event.related_carry() == carry_event

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: kloppy 3.1.1
+site_name: kloppy 3.2.0
 site_url: https://kloppy.pysport.org
 repo_url: https://github.com/PySport/kloppy
 repo_name: 'GitHub'
@@ -31,7 +31,8 @@ nav:
     - Broadcast Tracking Data: examples/broadcast_tracking_data.ipynb
     - Code data: examples/code_data.ipynb
     - State: examples/state.ipynb
-    - Plotting2: examples/plotting.ipynb
+    - Navigating: examples/navigating.ipynb
+    - Plotting: examples/plotting.ipynb
   - API Reference:
     - Domain:
       - Common: api/domain/common.md


### PR DESCRIPTION
This pull request adds some functionally to make it easier to navigate through a dataset.



## Context

## Changes

1. Add related events to statsbomb
2. Add next/prev to events
3. Add find_all to dataset
4. Make filter accept string instead of only callback