### PR TITLE
Fix metadata update after dataset transformation

### DIFF
--- a/kloppy/domain/services/transformers/__init__.py
+++ b/kloppy/domain/services/transformers/__init__.py
@@ -356,6 +356,11 @@ class Transformer:
                 to_pitch_dimensions=to_pitch_dimensions,
                 to_orientation=to_orientation,
             )
+            metadata = replace(
+                dataset.metadata,
+                pitch_dimensions=to_pitch_dimensions,
+                orientation=to_orientation,
+            )
 
         elif to_coordinate_system:
 
@@ -364,6 +369,12 @@ class Transformer:
                 from_orientation=dataset.metadata.orientation,
                 to_coordinate_system=to_coordinate_system,
                 to_orientation=to_orientation,
+            )
+            metadata = replace(
+                dataset.metadata,
+                coordinate_system=to_coordinate_system,
+                pitch_dimensions=to_coordinate_system.pitch_dimensions,
+                orientation=to_orientation,
             )
 
         else:
@@ -374,12 +385,11 @@ class Transformer:
                 to_coordinate_system=dataset.metadata.coordinate_system,
                 to_orientation=to_orientation,
             )
+            metadata = replace(
+                dataset.metadata,
+                orientation=to_orientation,
+            )
 
-        metadata = replace(
-            dataset.metadata,
-            pitch_dimensions=to_pitch_dimensions,
-            orientation=to_orientation,
-        )
         if isinstance(dataset, TrackingDataset):
             frames = [
                 transformer.transform_frame(record)

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -16,6 +16,7 @@ from kloppy.domain import (
     Provider,
     Frame,
     Metadata,
+    MetricaCoordinateSystem,
     Team,
     Ground,
     Player,
@@ -110,6 +111,16 @@ class TestHelpers:
         assert transformed_dataset.frames[1].ball_coordinates == Point(
             x=1, y=0
         )
+        assert (
+            transformed_dataset.metadata.orientation == Orientation.AWAY_TEAM
+        )
+        assert transformed_dataset.metadata.coordinate_system is None
+        assert (
+            transformed_dataset.metadata.pitch_dimensions
+            == PitchDimensions(
+                x_dim=Dimension(min=0, max=1), y_dim=Dimension(min=0, max=1)
+            )
+        )
 
     def test_transform_to_coordinate_system(self):
         base_dir = os.path.dirname(__file__)
@@ -129,12 +140,29 @@ class TestHelpers:
         ].coordinates == Point(x=-1234.0, y=-294.0)
 
         transformed_dataset = dataset.transform(
-            to_coordinate_system=Provider.METRICA,
+            to_coordinate_system=Provider.METRICA
+        )
+        transformerd_coordinate_system = MetricaCoordinateSystem(
+            normalized=True,
+            length=dataset.metadata.coordinate_system.length,
+            width=dataset.metadata.coordinate_system.width,
         )
 
         assert transformed_dataset.records[0].players_data[
             player_home_19
         ].coordinates == Point(x=0.3766, y=0.5489999999999999)
+        assert (
+            transformed_dataset.metadata.orientation
+            == dataset.metadata.orientation
+        )
+        assert (
+            transformed_dataset.metadata.coordinate_system
+            == transformerd_coordinate_system
+        )
+        assert (
+            transformed_dataset.metadata.pitch_dimensions
+            == transformerd_coordinate_system.pitch_dimensions
+        )
 
     def test_to_pandas(self):
         tracking_data = self._get_tracking_dataset()


### PR DESCRIPTION
The metadata was not correctly updated after a dataset transformation.

- Pitch dimensions were set to None when transforming the orientation
- The coordinate system was not updated