### PR TITLE
Retrieve data in browser as arraybuffer

### DIFF
--- a/kloppy/infra/io/adapters/http.py
+++ b/kloppy/infra/io/adapters/http.py
@@ -29,19 +29,32 @@ class HTTPAdapter(Adapter):
             _RUNS_IN_BROWSER = False
 
         if _RUNS_IN_BROWSER:
-            request = XMLHttpRequest.new()
+            xhr = XMLHttpRequest.new()
+            xhr.responseType = 'arraybuffer'
             if basic_authentication:
                 authentication = base64.b64encode(
                     basic_authentication.join(":")
                 )
-                request.setRequestHeader(
+                xhr.setRequestHeader(
                     "Authorization",
                     f"Basic {authentication}",
                 )
 
-            request.open("GET", url, False)
-            request.send(None)
-            output.write(request.responseText)
+            xhr.open("GET", url, False)
+            xhr.send(None)
+
+            # Borrowed from 'raise_for_status'
+            http_error_msg = ''
+            if 400 <= xhr.status < 500:
+                http_error_msg = f'{xhr.status} Client Error: url: {url}"
+
+            elif 500 <= xhr.status < 600:
+                http_error_msg = f'{xhr.status} Server Error: url: {url}"
+
+            if http_error_msg:
+                raise AdapterError(http_error_msg)
+
+            output.write(xhr.response.to_py().tobytes())
         else:
             auth = None
             if basic_authentication:

--- a/kloppy/infra/io/adapters/http.py
+++ b/kloppy/infra/io/adapters/http.py
@@ -30,7 +30,7 @@ class HTTPAdapter(Adapter):
 
         if _RUNS_IN_BROWSER:
             xhr = XMLHttpRequest.new()
-            xhr.responseType = 'arraybuffer'
+            xhr.responseType = "arraybuffer"
             if basic_authentication:
                 authentication = base64.b64encode(
                     basic_authentication.join(":")
@@ -44,12 +44,12 @@ class HTTPAdapter(Adapter):
             xhr.send(None)
 
             # Borrowed from 'raise_for_status'
-            http_error_msg = ''
+            http_error_msg = ""
             if 400 <= xhr.status < 500:
-                http_error_msg = f'{xhr.status} Client Error: url: {url}"
+                http_error_msg = f"{xhr.status} Client Error: url: {url}"
 
             elif 500 <= xhr.status < 600:
-                http_error_msg = f'{xhr.status} Server Error: url: {url}"
+                http_error_msg = f"{xhr.status} Server Error: url: {url}"
 
             if http_error_msg:
                 raise AdapterError(http_error_msg)


### PR DESCRIPTION
When running kloppy in JupyterLite or any other PyOdide backed system it must use `XMLHttpRequest` to retrieve data. This PR fixes an issue with the type of the response. This used to be `text` instead of `bytes`. This caused problems with writing to a `BytesIO` object.

More info:
- How to get the arraybuffer response in python: https://github.com/pyodide/pyodide/issues/1857
- How get the bytes from a memoryview: https://stackoverflow.com/questions/53229236/how-to-convert-memoryview-to-bytes
