### PR TITLE
Added end coordinates for offside passes within Opta deserializer

### DIFF
--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -251,7 +251,9 @@ def _parse_offside_pass(raw_qualifiers: List) -> Dict:
     qualifiers = _get_event_qualifiers(raw_qualifiers)
     return dict(
         result=PassResult.OFFSIDE,
-        receiver_coordinates=None,
+        receiver_coordinates=Point(
+            x=float(raw_qualifiers[140]), y=float(raw_qualifiers[141])
+        ),
         receiver_player=None,
         receive_timestamp=None,
         qualifiers=qualifiers,

--- a/kloppy/tests/files/opta_f24.xml
+++ b/kloppy/tests/files/opta_f24.xml
@@ -240,5 +240,16 @@
       <Q id="1933848030" qualifier_id="257" value="0" />
       <Q id="1447900026" qualifier_id="46" value="5" />
     </Event>
+    <Event id="2360555167" event_id="236" type_id="2" period_id="1" min="19" sec="13" player_id="99999" team_id="2592" outcome="1" x="77.8" y="8.3" timestamp="2018-09-23T17:08:01.850" last_modified="2018-09-23T17:08:02" version="1537718881823">
+      <Q id="3261954279" qualifier_id="225"/>
+      <Q id="3255788981" qualifier_id="1"/>
+      <Q id="3255788975" qualifier_id="141" value="61.2"/>
+      <Q id="3261954283" qualifier_id="72"/>
+      <Q id="3255788973" qualifier_id="140" value="89.3"/>
+      <Q id="3255790573" qualifier_id="2"/>
+      <Q id="3255790571" qualifier_id="7" value="471681"/>
+      <Q id="3261954281" qualifier_id="386"/>
+      <Q id="3255788971" qualifier_id="56" value="Center"/>
+    </Event>
   </Game>
 </Games>

--- a/kloppy/tests/test_adapter.py
+++ b/kloppy/tests/test_adapter.py
@@ -57,7 +57,7 @@ class TestAdapter:
             # Asserts borrowed from `test_opta.py`
             assert dataset.metadata.provider == Provider.OPTA
             assert dataset.dataset_type == DatasetType.EVENT
-            assert len(dataset.events) == 20
+            assert len(dataset.events) == 21
 
             # cleanup
             adapters.remove(custom_adapter)

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -109,7 +109,7 @@ class TestOpta:
         # Check Own goal
         assert dataset.events[18].result.value == "OWN_GOAL"  # 2318697001
         # Check OFFSIDE pass has end_coordinates
-        assert dataset.events[20].receiver_coordinates.x == 89.3  # 2360555167\
+        assert dataset.events[20].receiver_coordinates.x == 89.3  # 2360555167
 
     def test_correct_normalized_deserialization(
         self, f7_data: str, f24_data: str

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -40,7 +40,7 @@ class TestOpta:
 
         assert dataset.metadata.provider == Provider.OPTA
         assert dataset.dataset_type == DatasetType.EVENT
-        assert len(dataset.events) == 20
+        assert len(dataset.events) == 21
         assert len(dataset.metadata.periods) == 2
         assert (
             dataset.events[10].ball_owning_team == dataset.metadata.teams[1]
@@ -108,6 +108,8 @@ class TestOpta:
 
         # Check Own goal
         assert dataset.events[18].result.value == "OWN_GOAL"  # 2318697001
+        # Check OFFSIDE pass has end_coordinates
+        assert dataset.events[20].receiver_coordinates.x == 89.3  # 2360555167\
 
     def test_correct_normalized_deserialization(
         self, f7_data: str, f24_data: str


### PR DESCRIPTION
This Pull Request Includes:
- Opta deserializer now adds end coordinates to offside passes
- A test to check for end_coordinate_x value in Offside pass. (opta | type_id==2)

Fixes
Issue: #155 