### PR TITLE
Add support for corner shots

### DIFF
--- a/kloppy/tests/files/wyscout_events_v3.json
+++ b/kloppy/tests/files/wyscout_events_v3.json
@@ -363,6 +363,77 @@
         ]
       },
       "videoTimestamp": "8.148438"
+    },
+    {
+      "id": 663291840,
+      "type": {
+        "primary": "corner",
+        "secondary": [
+          "shot"
+        ]
+      },
+      "location": {
+        "x": 100,
+        "y": 0
+      },
+      "matchId": 2852835,
+      "matchPeriod": "1H",
+      "matchTimestamp": "00:00:08.295",
+      "minute": 0,
+      "opponentTeam": {
+        "formation": "3-4-3",
+        "id": 3185,
+        "name": "Torino"
+      },
+      "shot": {
+        "bodyPart": null,
+        "isGoal": false,
+        "onTarget": false,
+        "goalZone": "",
+        "xg": 0.00275,
+        "postShotXg": 0.001166,
+        "goalkeeperActionId": 1471069926,
+        "goalkeeper": {
+          "id": 776560,
+          "name": "E. Berisha"
+        }
+      },
+      "player": {
+        "id": 20583,
+        "name": "Danilo",
+        "position": "RCB"
+      },
+      "possession": {
+        "id": 663291837,
+        "duration": "1.261821",
+        "types": [
+          "corner",
+          "set_piece_attack"
+        ],
+        "eventsNumber": 1,
+        "eventIndex": 0,
+        "startLocation": {
+          "x": 100,
+          "y": 0
+        },
+        "endLocation": {
+          "x": 98,
+          "y": 55
+        },
+        "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+        "attack": null
+      },
+      "second": 8,
+      "team": {
+        "formation": "4-2-3-1",
+        "id": 3166,
+        "name": "Bologna"
+      },
+      "videoTimestamp": "8.148438"
     }
   ],
   "formations": {

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from kloppy.domain import Point
+from kloppy.domain import Point, SetPieceType, SetPieceQualifier
 
 from kloppy import wyscout
 
@@ -42,3 +42,12 @@ class TestWyscout:
     def test_correct_auto_recognize_deserialization(self, event_v2_data: str):
         dataset = wyscout.load(event_data=event_v2_data, coordinates="wyscout")
         assert dataset.records[2].coordinates == Point(29.0, 6.0)
+
+    def test_correct_handling_of_corner_shot(self, event_v3_data: str):
+        dataset = wyscout.load(
+            event_data=event_v3_data, data_version="V3", event_types=["shot"]
+        )
+        assert (
+            dataset.events[0].get_qualifier_value(SetPieceQualifier)
+            == SetPieceType.CORNER_KICK
+        )


### PR DESCRIPTION
The code used to break when a corner shot event was present in the events as we handled all corner events as passes, resulting in the following error: 
```
Traceback (most recent call last):
  File "/Users/driesdeprest/Documents/MyGamePlan/code/python/kloppy/kloppy/_providers/wyscout.py", line 45, in load
    return deserializer.deserialize(
  File "/Users/driesdeprest/Documents/MyGamePlan/code/python/kloppy/kloppy/infra/serializers/event/wyscout/deserializer_v3.py", line 369, in deserialize
    set_piece_event_args = _parse_set_piece(
  File "/Users/driesdeprest/Documents/MyGamePlan/code/python/kloppy/kloppy/infra/serializers/event/wyscout/deserializer_v3.py", line 229, in _parse_set_piece
    result = _parse_pass(raw_event, next_event, team)
  File "/Users/driesdeprest/Documents/MyGamePlan/code/python/kloppy/kloppy/infra/serializers/event/wyscout/deserializer_v3.py", line 147, in _parse_pass
    if raw_event["pass"]["accurate"] is True:
TypeError: 'NoneType' object is not subscriptable
```
This issue is now fixed by handling a corner as a pass or shot based on its secondary event type.
