### PR TITLE
Fix S3Adapter.read_to_stream

### DIFF
--- a/kloppy/infra/io/adapters/s3.py
+++ b/kloppy/infra/io/adapters/s3.py
@@ -34,4 +34,4 @@ class S3Adapter(Adapter):
         s3_fs = self._get_s3fs()
 
         with s3_fs.open(url, "rb") as fp:
-            shutil.copyfile(fp, output)
+            shutil.copyfileobj(fp, output)


### PR DESCRIPTION
The S3Adapter used shutil.copyfile to copy the contents of an open file handle to a buffer. However, the arguments to copyfile() should be file names. The correct method is shutil.copyfileobj() which operates on open file handles.