### PR TITLE
Add pandas pyarrow support + better performance on to_df

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/examples/datasets/metrica.py
+++ b/examples/datasets/metrica.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 from kloppy import metrica
+from kloppy.utils import performance_logging
 
 
 def main():
@@ -22,8 +23,16 @@ def main():
     # We can pass additional keyword arguments to the loaders to specify a different dataset
     dataset = metrica.load_open_data(limit=1000, match_id="2")
 
-    data_frame = dataset.to_df()
-    print(data_frame)
+    with performance_logging("to_df(engine='polars')", logger=logging):
+        data_frame = dataset.to_df(engine="polars")
+
+    with performance_logging("to_df(engine='pandas')", logger=logging):
+        data_frame = dataset.to_df(engine="pandas")
+
+    with performance_logging(
+        "to_df(engine='pandas[pyarrow]')", logger=logging
+    ):
+        data_frame = dataset.to_df(engine="pandas[pyarrow]")
 
     # Also load dataset in new metrica format
     dataset = metrica.load_open_data(limit=10_000, match_id="3")

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -980,8 +980,28 @@ class Dataset(ABC, Generic[T]):
             engine = get_config("dataframe.engine")
 
         if engine == "pandas[pyarrow]":
-            import pyarrow as pa
-            from pandas import ArrowDtype
+            try:
+                import pandas
+            except ImportError:
+                raise ImportError(
+                    "Seems like you don't have pandas installed. Please"
+                    " install it using: pip install pandas"
+                )
+            try:
+                from pandas import ArrowDtype
+            except ImportError:
+                raise ImportError(
+                    "Seems like you have an older version of pandas installed. Please"
+                    " update using: pip install pandas>=2.0"
+                )
+
+            try:
+                import pyarrow as pa
+            except ImportError:
+                raise ImportError(
+                    "Seems like you don't have pyarrow installed. Please"
+                    " install it using: pip install pyarrow"
+                )
 
             table = pa.Table.from_pydict(
                 self.to_dict(*columns, **named_columns)
@@ -989,11 +1009,23 @@ class Dataset(ABC, Generic[T]):
             return table.to_pandas(types_mapper=ArrowDtype)
 
         elif engine == "pandas":
-            from pandas import DataFrame
+            try:
+                from pandas import DataFrame
+            except ImportError:
+                raise ImportError(
+                    "Seems like you don't have pandas installed. Please"
+                    " install it using: pip install pandas"
+                )
 
             return DataFrame.from_dict(self.to_dict(*columns, **named_columns))
         elif engine == "polars":
-            from polars import from_dict
+            try:
+                from polars import from_dict
+            except ImportError:
+                raise ImportError(
+                    "Seems like you don't have polars installed. Please"
+                    " install it using: pip install polars"
+                )
 
             return from_dict(self.to_dict(*columns, **named_columns))
         else:

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -378,6 +378,11 @@ class TestHelpers:
             df = dataset.to_df()
             assert isinstance(df, pl.DataFrame)
 
+        with config_context("dataframe.engine", "pandas[pyarrow]"):
+            df = dataset.to_df()
+            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df.dtypes["ball_x"], pd.ArrowDtype)
+
 
 class TestOpenAsFile:
     def test_path(self):

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -381,10 +381,10 @@ class TestHelpers:
             df = dataset.to_df()
             assert isinstance(df, pl.DataFrame)
 
-    @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8")
+    # @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8")
     def test_to_df_pyarrow(self):
         """
-        Make sure we can export to pandas[pyarrow]. Only works for Python > 3.7
+        Make sure we can export to pandas[pyarrow].
         """
         import pandas as pd
 

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -1,5 +1,8 @@
 import os
+import sys
 from pathlib import Path
+
+import pytest
 
 from kloppy.config import config_context
 from pandas import DataFrame
@@ -378,10 +381,17 @@ class TestHelpers:
             df = dataset.to_df()
             assert isinstance(df, pl.DataFrame)
 
-        with config_context("dataframe.engine", "pandas[pyarrow]"):
-            df = dataset.to_df()
-            assert isinstance(df, pd.DataFrame)
-            assert isinstance(df.dtypes["ball_x"], pd.ArrowDtype)
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8")
+    def test_to_df_pyarrow(self):
+        """
+        Make sure we can export to pandas[pyarrow]. Only works for Python > 3.7
+        """
+        import pandas as pd
+
+        dataset = self._get_tracking_dataset()
+        df = dataset.to_df(engine="pandas[pyarrow]")
+        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df.dtypes["ball_x"], pd.ArrowDtype)
 
 
 class TestOpenAsFile:

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -381,10 +381,13 @@ class TestHelpers:
             df = dataset.to_df()
             assert isinstance(df, pl.DataFrame)
 
-    # @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8")
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8")
     def test_to_df_pyarrow(self):
         """
-        Make sure we can export to pandas[pyarrow].
+        Make sure we can export to pandas[pyarrow]. Only works for Python > 3.7.
+
+        The pyarrow engine is part of pandas >=1.5. Pandas 1.3 was the last
+        version that supports python 3.7, and does not support pyarrow.
         """
         import pandas as pd
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ def setup_package():
             "lxml>=4.4.0,<5",
             "requests>=2.0.0,<3",
             "pytz>=2020.1",
-            'dataclasses==0.8;python_version<"3.7"',
             'mypy_extensions;python_version<"3.8"',
             'typing_extensions;python_version<"3.8"',
             "python-dateutil>=2.8.1,<3",
@@ -49,10 +48,11 @@ def setup_package():
         extras_require={
             "test": [
                 "pytest>=6.2.5,<7",
-                "pandas>=2.0",
+                'pandas>=2;python_version>"3.7"',
+                'pandas>=1.0,<2;python_version<"3.8"',
                 "black==22.3.0",
                 "polars>=0.16.6",
-                "pyarrow==11.0.0",
+                'pyarrow==11.0.0;python_version>"3.7"',
             ],
             "development": ["pre-commit==2.6.0"],
             "query": ["networkx>=2.4,<3"],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ def setup_package():
                 "pandas>=1.0.0,<2",
                 "black==22.3.0",
                 "polars>=0.16.6",
-                "pyarrow==11.0.0"
+                "pyarrow==11.0.0",
             ],
             "development": ["pre-commit==2.6.0"],
             "query": ["networkx>=2.4,<3"],

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,13 @@ def setup_package():
             "test": [
                 "pytest>=6.2.5,<7",
                 'pandas>=2;python_version>"3.7"',
-                'pandas>=1.5,<2;python_version<"3.8"',
+                'pandas>=1.0,<2;python_version<"3.8"',
                 "black==22.3.0",
                 "polars>=0.16.6",
-                "pyarrow>=11.0.0",
+                # We could install pyarrow as it's compatible with
+                # python 3.7. But the python 3.7 compatible version
+                # of Pandas (1.3) does not support pyarrow
+                'pyarrow==11.0.0;python_version>"3.7"',
             ],
             "development": ["pre-commit==2.6.0"],
             "query": ["networkx>=2.4,<3"],

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,10 @@ def setup_package():
             "test": [
                 "pytest>=6.2.5,<7",
                 'pandas>=2;python_version>"3.7"',
-                'pandas>=1.0,<2;python_version<"3.8"',
+                'pandas>=1.5,<2;python_version<"3.8"',
                 "black==22.3.0",
                 "polars>=0.16.6",
-                'pyarrow==11.0.0;python_version>"3.7"',
+                "pyarrow>=11.0.0",
             ],
             "development": ["pre-commit==2.6.0"],
             "query": ["networkx>=2.4,<3"],

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def setup_package():
         extras_require={
             "test": [
                 "pytest>=6.2.5,<7",
-                "pandas>=1.0.0,<2",
+                "pandas>=2.0",
                 "black==22.3.0",
                 "polars>=0.16.6",
                 "pyarrow==11.0.0",

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ def setup_package():
                 "pandas>=1.0.0,<2",
                 "black==22.3.0",
                 "polars>=0.16.6",
+                "pyarrow==11.0.0"
             ],
             "development": ["pre-commit==2.6.0"],
             "query": ["networkx>=2.4,<3"],


### PR DESCRIPTION
This PR has two main changes:
1. The `Dataset.to_df` formats the data as `Dict[str, List[Any]]` instead of `List[Dict[str, Any]]` before passing it to the DataFrame constructors. This makes it a lot more performant to create a DataFrame, as the schema is already known (?)
2. Added support for `pandas[pyarrow]` engine.