### PR TITLE
Fix inputs of kloppy.helpers.transform

### DIFF
--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -129,6 +129,41 @@ class TestHelpers:
             )
         )
 
+    def test_transform_to_orientation(self):
+        tracking_data = self._get_tracking_dataset()
+
+        transformed_dataset = tracking_data.transform(
+            to_orientation=Orientation.AWAY_TEAM,
+        )
+        assert transformed_dataset.frames[0].ball_coordinates == Point3D(
+            x=0, y=50, z=0
+        )
+        assert (
+            transformed_dataset.metadata.orientation == Orientation.AWAY_TEAM
+        )
+
+    def test_transform_to_pitch_dimensions(self):
+        tracking_data = self._get_tracking_dataset()
+
+        transformed_dataset = tracking_data.transform(
+            to_pitch_dimensions=PitchDimensions(
+                x_dim=Dimension(min=0, max=1), y_dim=Dimension(min=0, max=1)
+            ),
+        )
+
+        assert transformed_dataset.frames[0].ball_coordinates == Point3D(
+            x=1, y=0, z=0
+        )
+        assert transformed_dataset.frames[1].ball_coordinates == Point3D(
+            x=0, y=1, z=1
+        )
+        assert (
+            transformed_dataset.metadata.pitch_dimensions
+            == PitchDimensions(
+                x_dim=Dimension(min=0, max=1), y_dim=Dimension(min=0, max=1)
+            )
+        )
+
     def test_transform_to_coordinate_system(self):
         base_dir = os.path.dirname(__file__)
 


### PR DESCRIPTION
- The `kloppy.helpers.transform` method now allows changing the orientation without having to specify `to_pitch_dimensions` or `to_coordinate_system`.
- The `kloppy.helpers.transform` method now allows that `to_pitch_dimensions` is specified as a `PitchDimensions` object
- The `kloppy.helpers.transform` method now allows that `to_coordinate_sytem` is specified as a data provider string
- Removes unused and duplicate code
- Additional typing and typing fixes
- Improved exception handling

Closes #177