### PR TITLE
Fix datatype of SkillCorner metadata.periods

### DIFF
--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -388,7 +388,7 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
 
         metadata = Metadata(
             teams=teams,
-            periods=periods,
+            periods=sorted(periods.values(), key=lambda p: p.id),
             pitch_dimensions=transformer.get_to_coordinate_system().pitch_dimensions,
             score=Score(
                 home=metadata["home_team_score"],

--- a/kloppy/tests/test_skillcorner.py
+++ b/kloppy/tests/test_skillcorner.py
@@ -36,13 +36,13 @@ class TestSkillCornerTracking:
         assert len(dataset.records) == 34783
         assert len(dataset.metadata.periods) == 2
         assert dataset.metadata.orientation == Orientation.AWAY_TEAM
-        assert dataset.metadata.periods[1] == Period(
+        assert dataset.metadata.periods[0] == Period(
             id=1,
             start_timestamp=0.0,
             end_timestamp=2753.3,
             attacking_direction=AttackingDirection.AWAY_HOME,
         )
-        assert dataset.metadata.periods[2] == Period(
+        assert dataset.metadata.periods[1] == Period(
             id=2,
             start_timestamp=2700.0,
             end_timestamp=5509.7,


### PR DESCRIPTION
The SkillCorner deserializer stored the `metadata.periods` attribute as a dictionary. According to the spec, it should be stored as a list of periods.