### PR TITLE
Fix transform orientation

### DIFF
--- a/examples/datasets/statsbomb.py
+++ b/examples/datasets/statsbomb.py
@@ -25,7 +25,7 @@ def main():
     with performance_logging("transform", logger=logger):
         # convert to TRACAB coordinates
         dataset = dataset.transform(
-            to_orientation="FIXED_HOME_AWAY",
+            to_orientation="STATIC_HOME_AWAY",
             to_pitch_dimensions=[(-5500, 5500), (-3300, 3300)],
         )
 

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -273,13 +273,13 @@ class Orientation(Enum):
             The away team plays from left to right in the second period.
         AWAY_HOME: The away team plays from left to right in the first period.
             The home team plays from left to right in the second period.
-        FIXED_HOME_AWAY: The home team plays from left to right in both periods.
-        FIXED_AWAY_HOME: The away team plays from left to right in both periods.
+        STATIC_HOME_AWAY: The home team plays from left to right in both periods.
+        STATIC_AWAY_HOME: The away team plays from left to right in both periods.
         NOT_SET: The attacking direction is not defined.
 
     Notes:
         The attacking direction is not defined for penalty shootouts in the
-        `HOME_AWAY`, `AWAY_HOME`, `FIXED_HOME_AWAY`, and `FIXED_AWAY_HOME`
+        `HOME_AWAY`, `AWAY_HOME`, `STATIC_HOME_AWAY`, and `STATIC_AWAY_HOME`
         orientations. This period is ignored in orientation transforms
         involving one of these orientations and keeps its original
         attacking direction.
@@ -296,8 +296,8 @@ class Orientation(Enum):
     AWAY_HOME = "away-home"
 
     # won't change during match
-    FIXED_HOME_AWAY = "fixed-home-away"
-    FIXED_AWAY_HOME = "fixed-away-home"
+    STATIC_HOME_AWAY = "fixed-home-away"
+    STATIC_AWAY_HOME = "fixed-away-home"
 
     # Not set in dataset
     NOT_SET = "not-set"
@@ -342,9 +342,9 @@ class AttackingDirection(Enum):
         Returns:
             The attacking direction for the given data record.
         """
-        if orientation == Orientation.FIXED_HOME_AWAY:
+        if orientation == Orientation.STATIC_HOME_AWAY:
             return AttackingDirection.LTR
-        if orientation == Orientation.FIXED_AWAY_HOME:
+        if orientation == Orientation.STATIC_AWAY_HOME:
             return AttackingDirection.RTL
         if orientation == Orientation.HOME_AWAY:
             if period is None:

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -294,8 +294,8 @@ class Orientation(Enum):
     ACTION_EXECUTING_TEAM = "action-executing-team"
 
     # changes during half-time
-    HOME_TEAM = "home-team"
-    AWAY_TEAM = "away-team"
+    HOME_AWAY = "home-away"
+    AWAY_HOME = "away-home"
 
     # won't change during match
     FIXED_HOME_AWAY = "fixed-home-away"
@@ -309,7 +309,7 @@ class Orientation(Enum):
             return AttackingDirection.HOME_AWAY
         if self == Orientation.FIXED_AWAY_HOME:
             return AttackingDirection.AWAY_HOME
-        if self == Orientation.HOME_TEAM:
+        if self == Orientation.HOME_AWAY:
             dirmap = {
                 1: AttackingDirection.HOME_AWAY,
                 2: AttackingDirection.AWAY_HOME,
@@ -317,7 +317,7 @@ class Orientation(Enum):
                 4: AttackingDirection.AWAY_HOME,
             }
             return dirmap.get(period.id, period.attacking_direction)
-        if self == Orientation.AWAY_TEAM:
+        if self == Orientation.AWAY_HOME:
             dirmap = {
                 1: AttackingDirection.AWAY_HOME,
                 2: AttackingDirection.HOME_AWAY,
@@ -339,7 +339,7 @@ class Orientation(Enum):
             return 1
         if self == Orientation.FIXED_AWAY_HOME:
             return -1
-        if self == Orientation.HOME_TEAM:
+        if self == Orientation.HOME_AWAY:
             if period.id == 1 or period.id == 3:
                 return 1
             if period.id == 2 or period.id == 4:
@@ -347,7 +347,7 @@ class Orientation(Enum):
             raise OrientationError(
                 f"AttackingDirection not defined for period with id {period.id}"
             )
-        if self == Orientation.AWAY_TEAM:
+        if self == Orientation.AWAY_HOME:
             if period.id == 1 or period.id == 3:
                 return -1
             if period.id == 2 or period.id == 4:

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -12,7 +12,11 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from kloppy.domain.models.common import DatasetType
+from kloppy.domain.models.common import (
+    DatasetType,
+    AttackingDirection,
+    OrientationError,
+)
 from kloppy.utils import (
     camelcase_to_snakecase,
     removes_suffix,
@@ -529,6 +533,24 @@ class Event(DataRecord, ABC):
     @abstractmethod
     def event_name(self) -> str:
         raise NotImplementedError
+
+    @property
+    def attacking_direction(self):
+        if (
+            self.dataset
+            and self.dataset.metadata
+            and self.dataset.metadata.orientation is not None
+        ):
+            try:
+                return AttackingDirection.from_orientation(
+                    self.dataset.metadata.orientation,
+                    period=self.period,
+                    ball_owning_team=self.ball_owning_team,
+                    action_executing_team=self.team,
+                )
+            except OrientationError:
+                return AttackingDirection.NOT_SET
+        return AttackingDirection.NOT_SET
 
     def get_qualifier_value(self, qualifier_type: Type[Qualifier]):
         """

--- a/kloppy/domain/services/__init__.py
+++ b/kloppy/domain/services/__init__.py
@@ -15,7 +15,7 @@ def avg(items: List[float]) -> float:
 
 
 def attacking_direction_from_frame(frame: Frame) -> AttackingDirection:
-    """This method should only be called for the first frame of a"""
+    """This method should only be called for the first frame of a period."""
     avg_x_home = avg(
         [
             player_data.coordinates.x
@@ -32,6 +32,6 @@ def attacking_direction_from_frame(frame: Frame) -> AttackingDirection:
     )
 
     if avg_x_home < avg_x_away:
-        return AttackingDirection.HOME_AWAY
+        return AttackingDirection.LTR
     else:
-        return AttackingDirection.AWAY_HOME
+        return AttackingDirection.RTL

--- a/kloppy/infra/serializers/event/datafactory/deserializer.py
+++ b/kloppy/infra/serializers/event/datafactory/deserializer.py
@@ -416,9 +416,6 @@ class DatafactoryDeserializer(EventDataDeserializer[DatafactoryInputs]):
                     id=half,
                     start_timestamp=start_ts[half],
                     end_timestamp=end_ts,
-                    attacking_direction=AttackingDirection.HOME_AWAY
-                    if half % 2 == 1
-                    else AttackingDirection.AWAY_HOME,
                 )
 
             # exclude goals, already listed as shots too
@@ -576,7 +573,7 @@ class DatafactoryDeserializer(EventDataDeserializer[DatafactoryInputs]):
             periods=sorted(periods.values(), key=lambda p: p.id),
             pitch_dimensions=transformer.get_to_coordinate_system().pitch_dimensions,
             frame_rate=None,
-            orientation=Orientation.HOME_TEAM,
+            orientation=Orientation.HOME_AWAY,
             flags=DatasetFlag.BALL_OWNING_TEAM,
             score=score,
             provider=Provider.DATAFACTORY,

--- a/kloppy/infra/serializers/event/sportec/deserializer.py
+++ b/kloppy/infra/serializers/event/sportec/deserializer.py
@@ -112,7 +112,10 @@ def sportec_metadata_from_xml_elm(match_root) -> SportecMetadata:
     if not away_team:
         raise DeserializationError("Away team is missing from metadata")
 
-    (home_score, away_score,) = match_root.MatchInformation.General.attrib[
+    (
+        home_score,
+        away_score,
+    ) = match_root.MatchInformation.General.attrib[
         "Result"
     ].split(":")
     score = Score(home=int(home_score), away=int(away_score))
@@ -412,25 +415,10 @@ class SportecEventDataDeserializer(
                         team_left = event_chain[SPORTEC_EVENT_NAME_KICKOFF][
                             "TeamLeft"
                         ]
-                        if team_left == home_team.team_id:
-                            # goal of home team is on the left side.
-                            # this means they attack from left to right
-                            orientation = Orientation.FIXED_HOME_AWAY
-                            period.set_attacking_direction(
-                                AttackingDirection.HOME_AWAY
-                            )
-                        else:
-                            orientation = Orientation.FIXED_AWAY_HOME
-                            period.set_attacking_direction(
-                                AttackingDirection.AWAY_HOME
-                            )
-                    else:
-                        last_period = periods[-1]
-                        period.set_attacking_direction(
-                            AttackingDirection.AWAY_HOME
-                            if last_period.attacking_direction
-                            == AttackingDirection.HOME_AWAY
-                            else AttackingDirection.HOME_AWAY
+                        orientation = (
+                            Orientation.HOME_AWAY
+                            if team_left == home_team.team_id
+                            else Orientation.AWAY_HOME
                         )
 
                     periods.append(period)

--- a/kloppy/infra/serializers/event/sportec/deserializer.py
+++ b/kloppy/infra/serializers/event/sportec/deserializer.py
@@ -112,10 +112,7 @@ def sportec_metadata_from_xml_elm(match_root) -> SportecMetadata:
     if not away_team:
         raise DeserializationError("Away team is missing from metadata")
 
-    (
-        home_score,
-        away_score,
-    ) = match_root.MatchInformation.General.attrib[
+    (home_score, away_score,) = match_root.MatchInformation.General.attrib[
         "Result"
     ].split(":")
     score = Score(home=int(home_score), away=int(away_score))

--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -228,7 +228,7 @@ class StatsBombDeserializer(EventDataDeserializer[StatsBombInputs]):
             ::2
         ]  # recorded for each team, take every other
         periods = []
-        for (start_event, end_event) in zip_longest(
+        for start_event, end_event in zip_longest(
             half_start_and_end_events[::2], half_start_and_end_events[1::2]
         ):
             if (

--- a/kloppy/infra/serializers/tracking/metrica_csv.py
+++ b/kloppy/infra/serializers/tracking/metrica_csv.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from collections import namedtuple
 from typing import Tuple, Dict, Iterator, IO, NamedTuple
 
@@ -204,13 +205,6 @@ class MetricaCSVTrackingDataDeserializer(
                 if not periods or period.id != periods[-1].id:
                     periods.append(period)
 
-                if not period.attacking_direction_set:
-                    period.set_attacking_direction(
-                        attacking_direction=attacking_direction_from_frame(
-                            frame
-                        )
-                    )
-
                 if n == 0:
                     teams = [home_partial_frame.team, away_partial_frame.team]
 
@@ -218,11 +212,21 @@ class MetricaCSVTrackingDataDeserializer(
                 if self.limit and n >= self.limit:
                     break
 
-        orientation = (
-            Orientation.FIXED_HOME_AWAY
-            if periods[0].attacking_direction == AttackingDirection.HOME_AWAY
-            else Orientation.FIXED_AWAY_HOME
-        )
+        try:
+            first_frame = next(
+                frame for frame in frames if frame.period.id == 1
+            )
+            orientation = (
+                Orientation.HOME_AWAY
+                if attacking_direction_from_frame(first_frame)
+                == AttackingDirection.LTR
+                else Orientation.AWAY_HOME
+            )
+        except StopIteration:
+            warnings.warn(
+                "Could not determine orientation of dataset, defaulting to NOT_SET"
+            )
+            orientation = Orientation.NOT_SET
 
         metadata = Metadata(
             teams=teams,

--- a/kloppy/infra/serializers/tracking/metrica_epts/metadata.py
+++ b/kloppy/infra/serializers/tracking/metrica_epts/metadata.py
@@ -62,33 +62,26 @@ def _load_periods(
     ]
 
     periods = []
+    start_attacking_direction = AttackingDirection.NOT_SET
 
     for idx, period_name in enumerate(period_names):
         # the attacking direction is only defined for the first period
         # and alternates between periods
-        invert = idx % 2
-        if (
-            provider_teams_params[Ground.HOME].get(
-                "attack_direction_first_half"
-            )
-            == "left_to_right"
-        ):
-            attacking_direction = [
-                AttackingDirection.HOME_AWAY,
-                AttackingDirection.AWAY_HOME,
-            ][invert]
-        elif (
-            provider_teams_params[Ground.HOME].get(
-                "attack_direction_first_half"
-            )
-            == "right_to_left"
-        ):
-            attacking_direction = [
-                AttackingDirection.AWAY_HOME,
-                AttackingDirection.HOME_AWAY,
-            ][invert]
-        else:
-            attacking_direction = AttackingDirection.NOT_SET
+        if idx == 0:
+            if (
+                provider_teams_params[Ground.HOME].get(
+                    "attack_direction_first_half"
+                )
+                == "left_to_right"
+            ):
+                start_attacking_direction = AttackingDirection.LTR
+            elif (
+                provider_teams_params[Ground.HOME].get(
+                    "attack_direction_first_half"
+                )
+                == "right_to_left"
+            ):
+                start_attacking_direction = AttackingDirection.RTL
 
         start_key = f"{period_name}_start"
         end_key = f"{period_name}_end"
@@ -99,14 +92,13 @@ def _load_periods(
                     start_timestamp=float(provider_params[start_key])
                     / frame_rate,
                     end_timestamp=float(provider_params[end_key]) / frame_rate,
-                    attacking_direction=attacking_direction,
                 )
             )
         else:
             # done
             break
 
-    return periods
+    return periods, start_attacking_direction
 
 
 def _load_players(players_elm, team: Team) -> List[Player]:
@@ -293,24 +285,21 @@ def load_metadata(
 
     frame_rate = int(metadata.find("GlobalConfig").find("FrameRate"))
     pitch_dimensions = _load_pitch_dimensions(metadata, sensors)
-    periods = _load_periods(metadata, _team_map, frame_rate)
-
-    if periods:
-        start_attacking_direction = periods[0].attacking_direction
-    else:
-        start_attacking_direction = None
-
-    orientation = (
-        (
-            Orientation.HOME_TEAM
-            if start_attacking_direction == AttackingDirection.HOME_AWAY
-            else Orientation.AWAY_TEAM
-        )
-        if start_attacking_direction != AttackingDirection.NOT_SET
-        else Orientation.NOT_SET
+    periods, start_attacking_direction = _load_periods(
+        metadata, _team_map, frame_rate
     )
 
-    metadata.orientation = orientation
+    if start_attacking_direction != AttackingDirection.NOT_SET:
+        orientation = (
+            Orientation.HOME_AWAY
+            if start_attacking_direction == AttackingDirection.LTR
+            else Orientation.AWAY_HOME
+        )
+    else:
+        warnings.warn(
+            "Could not determine orientation of dataset, defaulting to NOT_SET"
+        )
+        orientation = Orientation.NOT_SET
 
     if provider and pitch_dimensions:
         from_coordinate_system = build_coordinate_system(

--- a/kloppy/infra/serializers/tracking/secondspectrum.py
+++ b/kloppy/infra/serializers/tracking/secondspectrum.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import warnings
 from typing import Tuple, Dict, Optional, Union, NamedTuple, IO
 
 from lxml import objectify
@@ -261,21 +262,24 @@ class SecondSpectrumDeserializer(
                 frame = transformer.transform_frame(frame)
                 frames.append(frame)
 
-                if not period.attacking_direction_set:
-                    period.set_attacking_direction(
-                        attacking_direction=attacking_direction_from_frame(
-                            frame
-                        )
-                    )
-
                 if self.limit and n + 1 >= self.limit:
                     break
 
-        orientation = (
-            Orientation.FIXED_HOME_AWAY
-            if periods[0].attacking_direction == AttackingDirection.HOME_AWAY
-            else Orientation.FIXED_AWAY_HOME
-        )
+        try:
+            first_frame = next(
+                frame for frame in frames if frame.period.id == 1
+            )
+            orientation = (
+                Orientation.HOME_AWAY
+                if attacking_direction_from_frame(first_frame)
+                == AttackingDirection.LTR
+                else Orientation.AWAY_HOME
+            )
+        except StopIteration:
+            warnings.warn(
+                "Could not determine orientation of dataset, defaulting to NOT_SET"
+            )
+            orientation = Orientation.NOT_SET
 
         metadata = Metadata(
             teams=teams,

--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import List, Dict, Tuple, NamedTuple, IO, Optional, Union
 from enum import Enum, Flag
 from collections import Counter
@@ -151,35 +152,33 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
         return 60 * float(m) + float(s)
 
     @classmethod
-    def _set_skillcorner_attacking_directions(cls, frames, periods):
+    def _get_skillcorner_attacking_directions(cls, frames, periods):
         """
         with only partial tracking data we cannot rely on a single frame to
         infer the attacking directions as a simple average of only some players
         x-coords might not reflect the attacking direction.
         """
-        attacking_directions = []
+        attacking_directions = {}
+        frame_period_ids = np.array([_frame.period.id for _frame in frames])
+        frame_attacking_directions = np.array(
+            [
+                attacking_direction_from_frame(frame)
+                if len(frame.players_data) > 0
+                else AttackingDirection.NOT_SET
+                for frame in frames
+            ]
+        )
 
-        for frame in frames:
-            if len(frame.players_data) > 0:
-                attacking_directions.append(
-                    attacking_direction_from_frame(frame)
-                )
-            else:
-                attacking_directions.append(AttackingDirection.NOT_SET)
-
-        frame_periods = np.array([_frame.period.id for _frame in frames])
-
-        for period in periods.keys():
-            if period in frame_periods:
+        for period_id in periods.keys():
+            if period_id in frame_period_ids:
                 count = Counter(
-                    np.array(attacking_directions)[frame_periods == period]
+                    frame_attacking_directions[frame_period_ids == period_id]
                 )
-                att_direction = count.most_common()[0][0]
-                periods[period].attacking_direction = att_direction
+                attacking_directions[period_id] = count.most_common()[0][0]
             else:
-                periods[
-                    period
-                ].attacking_direction = AttackingDirection.NOT_SET
+                attacking_directions[period_id] = AttackingDirection.NOT_SET
+
+        return attacking_directions
 
     def __load_json(self, file):
         return json.load(file)
@@ -376,15 +375,18 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
                 if self.limit and n_frames >= self.limit:
                     break
 
-        self._set_skillcorner_attacking_directions(frames, periods)
-
-        frame_rate = 10
-
-        orientation = (
-            Orientation.HOME_TEAM
-            if periods[1].attacking_direction == AttackingDirection.HOME_AWAY
-            else Orientation.AWAY_TEAM
+        attacking_directions = self._get_skillcorner_attacking_directions(
+            frames, periods
         )
+        if attacking_directions[1] == AttackingDirection.LTR:
+            orientation = Orientation.HOME_AWAY
+        elif attacking_directions[1] == AttackingDirection.RTL:
+            orientation = Orientation.AWAY_HOME
+        else:
+            warnings.warn(
+                "Could not determine orientation of dataset, defaulting to NOT_SET"
+            )
+            orientation = Orientation.NOT_SET
 
         metadata = Metadata(
             teams=teams,
@@ -394,7 +396,7 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
                 home=metadata["home_team_score"],
                 away=metadata["away_team_score"],
             ),
-            frame_rate=frame_rate,
+            frame_rate=10,
             orientation=orientation,
             provider=Provider.SKILLCORNER,
             flags=~(DatasetFlag.BALL_STATE | DatasetFlag.BALL_OWNING_TEAM),

--- a/kloppy/infra/serializers/tracking/sportec/deserializer.py
+++ b/kloppy/infra/serializers/tracking/sportec/deserializer.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from collections import defaultdict
 from typing import NamedTuple, Optional, Union, IO
 
@@ -195,24 +196,26 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
             frames = []
             for n, frame in enumerate(_iter()):
                 frame = transformer.transform_frame(frame)
-
                 frames.append(frame)
-
-                if not frame.period.attacking_direction_set:
-                    frame.period.set_attacking_direction(
-                        attacking_direction=attacking_direction_from_frame(
-                            frame
-                        )
-                    )
 
                 if self.limit and n >= self.limit:
                     break
 
-        orientation = (
-            Orientation.FIXED_HOME_AWAY
-            if periods[0].attacking_direction == AttackingDirection.HOME_AWAY
-            else Orientation.FIXED_AWAY_HOME
-        )
+        try:
+            first_frame = next(
+                frame for frame in frames if frame.period.id == 1
+            )
+            orientation = (
+                Orientation.HOME_AWAY
+                if attacking_direction_from_frame(first_frame)
+                == AttackingDirection.LTR
+                else Orientation.AWAY_HOME
+            )
+        except StopIteration:
+            warnings.warn(
+                "Could not determine orientation of dataset, defaulting to NOT_SET"
+            )
+            orientation = Orientation.NOT_SET
 
         metadata = Metadata(
             teams=teams,

--- a/kloppy/infra/serializers/tracking/tracab.py
+++ b/kloppy/infra/serializers/tracking/tracab.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import Tuple, Dict, NamedTuple, IO, Optional, Union
 
 from lxml import objectify
@@ -184,24 +185,26 @@ class TRACABDeserializer(TrackingDataDeserializer[TRACABInputs]):
                 frame = self._frame_from_line(teams, period, line, frame_rate)
 
                 frame = transformer.transform_frame(frame)
-
                 frames.append(frame)
-
-                if not period.attacking_direction_set:
-                    period.set_attacking_direction(
-                        attacking_direction=attacking_direction_from_frame(
-                            frame
-                        )
-                    )
 
                 if self.limit and n >= self.limit:
                     break
 
-        orientation = (
-            Orientation.FIXED_HOME_AWAY
-            if periods[0].attacking_direction == AttackingDirection.HOME_AWAY
-            else Orientation.FIXED_AWAY_HOME
-        )
+        try:
+            first_frame = next(
+                frame for frame in frames if frame.period.id == 1
+            )
+            orientation = (
+                Orientation.HOME_AWAY
+                if attacking_direction_from_frame(first_frame)
+                == AttackingDirection.LTR
+                else Orientation.AWAY_HOME
+            )
+        except StopIteration:
+            warnings.warn(
+                "Could not determine orientation of dataset, defaulting to NOT_SET"
+            )
+            orientation = Orientation.NOT_SET
 
         metadata = Metadata(
             teams=teams,

--- a/kloppy/tests/issues/issue_113/test_issue_113.py
+++ b/kloppy/tests/issues/issue_113/test_issue_113.py
@@ -21,7 +21,7 @@ def kloppy_load_data(f7, f24):
     dataset = opta.load(f7_data=f7, f24_data=f24)
 
     events = dataset.transform(
-        to_orientation=Orientation.FIXED_HOME_AWAY
+        to_orientation=Orientation.STATIC_HOME_AWAY
     ).to_pandas(
         additional_columns={
             "event_name": lambda event: str(getattr(event, "event_name", "")),

--- a/kloppy/tests/test_datafactory.py
+++ b/kloppy/tests/test_datafactory.py
@@ -30,7 +30,7 @@ class TestDatafactory:
         assert len(dataset.metadata.periods) == 2
         assert dataset.events[10].ball_owning_team == dataset.metadata.teams[1]
         assert dataset.events[23].ball_owning_team == dataset.metadata.teams[0]
-        assert dataset.metadata.orientation == Orientation.HOME_TEAM
+        assert dataset.metadata.orientation == Orientation.HOME_AWAY
         assert dataset.metadata.teams[0].name == "Team A"
         assert dataset.metadata.teams[0].ground == Ground.HOME
         assert dataset.metadata.teams[1].name == "Team B"
@@ -47,13 +47,11 @@ class TestDatafactory:
             id=1,
             start_timestamp=0,
             end_timestamp=2912,
-            attacking_direction=AttackingDirection.HOME_AWAY,
         )
         assert dataset.metadata.periods[1] == Period(
             id=2,
             start_timestamp=2700,
             end_timestamp=5710,
-            attacking_direction=AttackingDirection.AWAY_HOME,
         )
 
         assert dataset.events[0].coordinates == Point(0.01, 0.01)

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -179,12 +179,12 @@ class TestHelpers:
             transform1.frames[1].attacking_direction == AttackingDirection.LTR
         )
 
-        # Transform to FIXED_AWAY_HOME orientation
+        # Transform to STATIC_AWAY_HOME orientation
         transform2 = transform1.transform(
-            to_orientation=Orientation.FIXED_AWAY_HOME,
+            to_orientation=Orientation.STATIC_AWAY_HOME,
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
-        assert transform2.metadata.orientation == Orientation.FIXED_AWAY_HOME
+        assert transform2.metadata.orientation == Orientation.STATIC_AWAY_HOME
         # all coordintes in the second half should be flipped
         assert transform2.frames[0].ball_coordinates == Point3D(x=0, y=1, z=0)
         assert transform2.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
@@ -296,7 +296,7 @@ class TestHelpers:
         assert receipt_event.ball_owning_team == home_team
 
         transformed_dataset = dataset.transform(
-            to_orientation="fixed_home_away"
+            to_orientation="static_home_away"
         )
         transformed_pressure_event = transformed_dataset.get_event_by_id(
             pressure_event.event_id
@@ -336,7 +336,7 @@ class TestHelpers:
             "65f16e50-7c5d-4293-b2fc-d20887a772f9"
         )
         transformed_dataset = dataset.transform(
-            to_orientation="fixed_away_home"
+            to_orientation="static_away_home"
         )
         shot_event_transformed = transformed_dataset.get_event_by_id(
             shot_event.event_id

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -58,7 +58,7 @@ class TestHelpers:
             pitch_dimensions=PitchDimensions(
                 x_dim=Dimension(0, 100), y_dim=Dimension(-50, 50)
             ),
-            orientation=Orientation.HOME_TEAM,
+            orientation=Orientation.HOME_AWAY,
             frame_rate=25,
             periods=periods,
             teams=teams,
@@ -108,7 +108,7 @@ class TestHelpers:
 
         # orientation change AND dimension scale
         transformed_dataset = tracking_data.transform(
-            to_orientation="AWAY_TEAM",
+            to_orientation="AWAY_HOME",
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
 
@@ -119,7 +119,7 @@ class TestHelpers:
             x=1, y=0, z=1
         )
         assert (
-            transformed_dataset.metadata.orientation == Orientation.AWAY_TEAM
+            transformed_dataset.metadata.orientation == Orientation.AWAY_HOME
         )
         assert transformed_dataset.metadata.coordinate_system is None
         assert (
@@ -153,11 +153,11 @@ class TestHelpers:
 
     def test_transform_to_orientation(self):
         # Create a dataset with the KLOPPY pitch dimensions
-        # and HOME_TEAM orientation
+        # and HOME_AWAY orientation
         original = self._get_tracking_dataset().transform(
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
-        assert original.metadata.orientation == Orientation.HOME_TEAM
+        assert original.metadata.orientation == Orientation.HOME_AWAY
         assert original.frames[0].ball_coordinates == Point3D(x=1, y=0, z=0)
         assert original.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
         # the frames should have the correct attacking direction
@@ -179,12 +179,12 @@ class TestHelpers:
             == AttackingDirection.AWAY_HOME
         )
 
-        # Transform to AWAY_TEAM orientation
+        # Transform to AWAY_HOME orientation
         transform1 = original.transform(
-            to_orientation=Orientation.AWAY_TEAM,
+            to_orientation=Orientation.AWAY_HOME,
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
-        assert transform1.metadata.orientation == Orientation.AWAY_TEAM
+        assert transform1.metadata.orientation == Orientation.AWAY_HOME
         # all coordinates should be flipped
         assert transform1.frames[0].ball_coordinates == Point3D(x=0, y=1, z=0)
         assert transform1.frames[1].ball_coordinates == Point3D(x=1, y=0, z=1)
@@ -265,9 +265,9 @@ class TestHelpers:
         for period in transform4.metadata.periods:
             assert period.attacking_direction == AttackingDirection.NOT_SET
 
-        # Transform back to the original HOME_TEAM orientation
+        # Transform back to the original HOME_AWAY orientation
         transform5 = transform4.transform(
-            to_orientation=Orientation.HOME_TEAM,
+            to_orientation=Orientation.HOME_AWAY,
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
         # we should be back at the original

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -152,22 +152,24 @@ class TestHelpers:
         )
 
     def test_transform_to_orientation(self):
-        tracking_data = self._get_tracking_dataset()
-
-        original = tracking_data.transform(
+        # Create a dataset with the KLOPPY pitch dimensions
+        # and HOME_TEAM orientation
+        original = self._get_tracking_dataset().transform(
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
+        assert original.metadata.orientation == Orientation.HOME_TEAM
         assert original.frames[0].ball_coordinates == Point3D(x=1, y=0, z=0)
+        assert original.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
+        # the frames should have the correct attacking direction
         assert (
             original.frames[0].period.attacking_direction
             == AttackingDirection.HOME_AWAY
         )
-        assert original.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
         assert (
             original.frames[1].period.attacking_direction
             == AttackingDirection.AWAY_HOME
         )
-        assert original.metadata.orientation == Orientation.HOME_TEAM
+        # the metadata should have the correct attacking direction
         assert (
             original.metadata.periods[0].attacking_direction
             == AttackingDirection.HOME_AWAY
@@ -177,23 +179,25 @@ class TestHelpers:
             == AttackingDirection.AWAY_HOME
         )
 
-        print("T1")
+        # Transform to AWAY_TEAM orientation
         transform1 = original.transform(
             to_orientation=Orientation.AWAY_TEAM,
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
+        assert transform1.metadata.orientation == Orientation.AWAY_TEAM
         # all coordinates should be flipped
         assert transform1.frames[0].ball_coordinates == Point3D(x=0, y=1, z=0)
+        assert transform1.frames[1].ball_coordinates == Point3D(x=1, y=0, z=1)
+        # the frames should have the correct attacking direction
         assert (
             transform1.frames[0].period.attacking_direction
             == AttackingDirection.AWAY_HOME
         )
-        assert transform1.frames[1].ball_coordinates == Point3D(x=1, y=0, z=1)
         assert (
             transform1.frames[1].period.attacking_direction
             == AttackingDirection.HOME_AWAY
         )
-        assert transform1.metadata.orientation == Orientation.AWAY_TEAM
+        # the metadata should have the correct attacking direction
         assert (
             transform1.metadata.periods[0].attacking_direction
             == AttackingDirection.AWAY_HOME
@@ -203,112 +207,80 @@ class TestHelpers:
             == AttackingDirection.HOME_AWAY
         )
 
-        print("T2")
+        # Transform to FIXED_AWAY_HOME orientation
         transform2 = transform1.transform(
             to_orientation=Orientation.FIXED_AWAY_HOME,
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
+        assert transform2.metadata.orientation == Orientation.FIXED_AWAY_HOME
         # all coordintes in the second half should be flipped
         assert transform2.frames[0].ball_coordinates == Point3D(x=0, y=1, z=0)
-        assert (
-            transform2.frames[0].period.attacking_direction
-            == AttackingDirection.AWAY_HOME
-        )
         assert transform2.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
-        assert (
-            transform2.frames[1].period.attacking_direction
-            == AttackingDirection.AWAY_HOME
-        )
-        assert transform2.metadata.orientation == Orientation.FIXED_AWAY_HOME
-        assert (
-            transform2.metadata.periods[0].attacking_direction
-            == AttackingDirection.AWAY_HOME
-        )
-        assert (
-            transform2.metadata.periods[1].attacking_direction
-            == AttackingDirection.AWAY_HOME
-        )
+        # the frames should have the correct attacking direction
+        for frame in transform2.frames:
+            assert (
+                frame.period.attacking_direction
+                == AttackingDirection.AWAY_HOME
+            )
+        # the metadata should have the correct attacking direction
+        for period in transform2.metadata.periods:
+            assert period.attacking_direction == AttackingDirection.AWAY_HOME
 
-        print("T3")
+        # Transform to BALL_OWNING_TEAM orientation
         transform3 = transform2.transform(
             to_orientation=Orientation.BALL_OWNING_TEAM,
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
+        assert transform3.metadata.orientation == Orientation.BALL_OWNING_TEAM
         # the coordinates of frame 1 should be flipped
         assert transform3.frames[0].ball_coordinates == Point3D(x=1, y=0, z=0)
-        assert (
-            transform3.frames[0].period.attacking_direction
-            == AttackingDirection.NOT_SET
-        )
         assert transform3.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
-        assert (
-            transform3.frames[1].period.attacking_direction
-            == AttackingDirection.NOT_SET
-        )
-        assert transform3.metadata.orientation == Orientation.BALL_OWNING_TEAM
-        assert (
-            transform3.metadata.periods[0].attacking_direction
-            == AttackingDirection.NOT_SET
-        )
-        assert (
-            transform3.metadata.periods[1].attacking_direction
-            == AttackingDirection.NOT_SET
-        )
+        # the frames should have the correct attacking direction
+        for frame in transform3.frames:
+            assert (
+                frame.period.attacking_direction == AttackingDirection.NOT_SET
+            )
+        # the metadata should have the correct attacking direction
+        for period in transform3.metadata.periods:
+            assert period.attacking_direction == AttackingDirection.NOT_SET
 
-        print("T4")
-        transform4 = transform2.transform(
+        # Transform to ACTION_EXECUTING_TEAM orientation
+        transform4 = transform3.transform(
             to_orientation=Orientation.ACTION_EXECUTING_TEAM,
             to_pitch_dimensions=[[0, 1], [0, 1]],
-        )
-        # should be identical to transform3 as the action_executing team is not defined
-        assert transform4.frames[0].ball_coordinates == Point3D(x=1, y=0, z=0)
-        assert (
-            transform4.frames[0].period.attacking_direction
-            == AttackingDirection.NOT_SET
-        )
-        assert transform4.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
-        assert (
-            transform4.frames[1].period.attacking_direction
-            == AttackingDirection.NOT_SET
         )
         assert (
             transform4.metadata.orientation
             == Orientation.ACTION_EXECUTING_TEAM
         )
-        assert (
-            transform4.metadata.periods[0].attacking_direction
-            == AttackingDirection.NOT_SET
-        )
-        assert (
-            transform4.metadata.periods[1].attacking_direction
-            == AttackingDirection.NOT_SET
-        )
+        # should be identical to transform3 as the action_executing team is not defined
+        assert transform4.frames[0].ball_coordinates == Point3D(x=1, y=0, z=0)
+        # the frames should have the correct attacking direction
+        assert transform4.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
+        for frame in transform4.frames:
+            assert (
+                frame.period.attacking_direction == AttackingDirection.NOT_SET
+            )
+        # the metadata should have the correct attacking direction
+        for period in transform4.metadata.periods:
+            assert period.attacking_direction == AttackingDirection.NOT_SET
 
-        print("T5")
+        # Transform back to the original HOME_TEAM orientation
         transform5 = transform4.transform(
             to_orientation=Orientation.HOME_TEAM,
             to_pitch_dimensions=[[0, 1], [0, 1]],
         )
         # we should be back at the original
-        assert transform5.frames[0].ball_coordinates == Point3D(x=1, y=0, z=0)
-        assert (
-            transform5.frames[0].period.attacking_direction
-            == AttackingDirection.HOME_AWAY
-        )
-        assert transform5.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
-        assert (
-            transform5.frames[1].period.attacking_direction
-            == AttackingDirection.AWAY_HOME
-        )
-        assert transform5.metadata.orientation == Orientation.HOME_TEAM
-        assert (
-            transform5.metadata.periods[0].attacking_direction
-            == AttackingDirection.HOME_AWAY
-        )
-        assert (
-            transform5.metadata.periods[1].attacking_direction
-            == AttackingDirection.AWAY_HOME
-        )
+        for frame1, frame2 in zip(original.frames, transform5.frames):
+            assert frame1.ball_coordinates == frame2.ball_coordinates
+            assert (
+                frame1.period.attacking_direction
+                == frame2.period.attacking_direction
+            )
+        for period1, period2 in zip(
+            original.metadata.periods, transform5.metadata.periods
+        ):
+            assert period1.attacking_direction == period2.attacking_direction
 
     def test_transform_to_coordinate_system(self):
         base_dir = os.path.dirname(__file__)

--- a/kloppy/tests/test_metrica_csv.py
+++ b/kloppy/tests/test_metrica_csv.py
@@ -31,18 +31,16 @@ class TestMetricaCsvTracking:
         assert dataset.dataset_type == DatasetType.TRACKING
         assert len(dataset.records) == 6
         assert len(dataset.metadata.periods) == 2
-        assert dataset.metadata.orientation == Orientation.FIXED_HOME_AWAY
+        assert dataset.metadata.orientation == Orientation.HOME_AWAY
         assert dataset.metadata.periods[0] == Period(
             id=1,
             start_timestamp=0.04,
             end_timestamp=0.12,
-            attacking_direction=AttackingDirection.HOME_AWAY,
         )
         assert dataset.metadata.periods[1] == Period(
             id=2,
             start_timestamp=5800.16,
             end_timestamp=5800.24,
-            attacking_direction=AttackingDirection.AWAY_HOME,
         )
 
         # make sure data is loaded correctly (including flip y-axis)

--- a/kloppy/tests/test_metrica_epts.py
+++ b/kloppy/tests/test_metrica_epts.py
@@ -115,7 +115,7 @@ class TestMetricaEPTSTracking:
 
         assert len(dataset.records) == 100
         assert len(dataset.metadata.periods) == 2
-        assert dataset.metadata.orientation is Orientation.HOME_TEAM
+        assert dataset.metadata.orientation is Orientation.HOME_AWAY
 
         assert dataset.records[0].players_data[
             first_player

--- a/kloppy/tests/test_metrica_events.py
+++ b/kloppy/tests/test_metrica_events.py
@@ -36,7 +36,7 @@ class TestMetricaEvents:
         """It should parse the metadata correctly."""
         assert dataset.metadata.provider == Provider.METRICA
         assert len(dataset.metadata.periods) == 2
-        assert dataset.metadata.orientation is Orientation.HOME_TEAM
+        assert dataset.metadata.orientation is Orientation.HOME_AWAY
         assert dataset.metadata.teams[0].name == "Team A"
         assert dataset.metadata.teams[1].name == "Team B"
         player = dataset.metadata.teams[0].players[10]
@@ -49,13 +49,11 @@ class TestMetricaEvents:
             id=1,
             start_timestamp=14.44,
             end_timestamp=2783.76,
-            attacking_direction=AttackingDirection.NOT_SET,
         )
         assert dataset.metadata.periods[1] == Period(
             id=2,
             start_timestamp=2803.6,
             end_timestamp=5742.12,
-            attacking_direction=AttackingDirection.NOT_SET,
         )
 
     def test_coordinates(self, dataset: EventDataset):

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -89,19 +89,16 @@ class TestOpta:
             id=1,
             start_timestamp=1537714933.608,
             end_timestamp=1537717701.222,
-            attacking_direction=AttackingDirection.NOT_SET,
         )
         assert dataset.metadata.periods[1] == Period(
             id=2,
             start_timestamp=1537718728.873,
             end_timestamp=1537721737.788,
-            attacking_direction=AttackingDirection.NOT_SET,
         )
         assert dataset.metadata.periods[4] == Period(
             id=5,
             start_timestamp=1537729501.81,
             end_timestamp=1537730701.81,
-            attacking_direction=AttackingDirection.NOT_SET,
         )
 
         assert dataset.events[0].coordinates == Point(50.1, 49.4)

--- a/kloppy/tests/test_secondspectrum.py
+++ b/kloppy/tests/test_secondspectrum.py
@@ -44,24 +44,16 @@ class TestSecondSpectrumTracking:
         assert dataset.dataset_type == DatasetType.TRACKING
         assert len(dataset.records) == 376
         assert len(dataset.metadata.periods) == 2
-        assert dataset.metadata.orientation == Orientation.FIXED_AWAY_HOME
+        assert dataset.metadata.orientation == Orientation.AWAY_HOME
 
         # Check the Periods
         assert dataset.metadata.periods[0].id == 1
         assert dataset.metadata.periods[0].start_timestamp == 0
         assert dataset.metadata.periods[0].end_timestamp == 2982240
-        assert (
-            dataset.metadata.periods[0].attacking_direction
-            == AttackingDirection.AWAY_HOME
-        )
 
         assert dataset.metadata.periods[1].id == 2
         assert dataset.metadata.periods[1].start_timestamp == 3907360
         assert dataset.metadata.periods[1].end_timestamp == 6927840
-        assert (
-            dataset.metadata.periods[1].attacking_direction
-            == AttackingDirection.HOME_AWAY
-        )
 
         # Check some timestamps
         assert dataset.records[0].timestamp == 0  # First frame

--- a/kloppy/tests/test_skillcorner.py
+++ b/kloppy/tests/test_skillcorner.py
@@ -33,18 +33,16 @@ class TestSkillCornerTracking:
         assert dataset.dataset_type == DatasetType.TRACKING
         assert len(dataset.records) == 34783
         assert len(dataset.metadata.periods) == 2
-        assert dataset.metadata.orientation == Orientation.AWAY_TEAM
+        assert dataset.metadata.orientation == Orientation.AWAY_HOME
         assert dataset.metadata.periods[0] == Period(
             id=1,
             start_timestamp=0.0,
             end_timestamp=2753.3,
-            attacking_direction=AttackingDirection.AWAY_HOME,
         )
         assert dataset.metadata.periods[1] == Period(
             id=2,
             start_timestamp=2700.0,
             end_timestamp=5509.7,
-            attacking_direction=AttackingDirection.HOME_AWAY,
         )
 
         # are frames with wrong camera views and pregame skipped?

--- a/kloppy/tests/test_sportec.py
+++ b/kloppy/tests/test_sportec.py
@@ -49,18 +49,16 @@ class TestSportecEventData:
         assert len(dataset.events) == 29
         assert dataset.events[28].result == ShotResult.OWN_GOAL
 
-        assert dataset.metadata.orientation == Orientation.FIXED_HOME_AWAY
+        assert dataset.metadata.orientation == Orientation.HOME_AWAY
         assert dataset.metadata.periods[0] == Period(
             id=1,
             start_timestamp=1591381800.21,
             end_timestamp=1591384584.0,
-            attacking_direction=AttackingDirection.HOME_AWAY,
         )
         assert dataset.metadata.periods[1] == Period(
             id=2,
             start_timestamp=1591385607.01,
             end_timestamp=1591388598.0,
-            attacking_direction=AttackingDirection.AWAY_HOME,
         )
 
         player = dataset.metadata.teams[0].players[0]

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -155,10 +155,6 @@ class TestStatsBombMetadata:
         assert dataset.metadata.periods[0].end_timestamp == parse_str_ts(
             "00:47:38.122"
         )
-        assert (
-            dataset.metadata.periods[0].attacking_direction
-            == AttackingDirection.NOT_SET
-        )
         assert dataset.metadata.periods[1].id == 2
         assert dataset.metadata.periods[1].start_timestamp == parse_str_ts(
             "00:47:38.122"
@@ -166,10 +162,6 @@ class TestStatsBombMetadata:
         assert dataset.metadata.periods[1].end_timestamp == parse_str_ts(
             "00:47:38.122"
         ) + parse_str_ts("00:50:29.638")
-        assert (
-            dataset.metadata.periods[1].attacking_direction
-            == AttackingDirection.NOT_SET
-        )
 
     def test_pitch_dimensions(self, dataset):
         """It should set the correct pitch dimensions"""

--- a/kloppy/tests/test_statsperform.py
+++ b/kloppy/tests/test_statsperform.py
@@ -49,24 +49,16 @@ class TestStatsPerformTracking:
         assert dataset.dataset_type == DatasetType.TRACKING
         assert len(dataset.records) == 92
         assert len(dataset.metadata.periods) == 2
-        assert dataset.metadata.orientation == Orientation.FIXED_AWAY_HOME
+        assert dataset.metadata.orientation == Orientation.AWAY_HOME
 
         # Check the periods
         assert dataset.metadata.periods[1].id == 1
         assert dataset.metadata.periods[1].start_timestamp == 0
         assert dataset.metadata.periods[1].end_timestamp == 2500
-        assert (
-            dataset.metadata.periods[1].attacking_direction
-            == AttackingDirection.AWAY_HOME
-        )
 
         assert dataset.metadata.periods[2].id == 2
         assert dataset.metadata.periods[2].start_timestamp == 0
         assert dataset.metadata.periods[2].end_timestamp == 6500
-        assert (
-            dataset.metadata.periods[2].attacking_direction
-            == AttackingDirection.HOME_AWAY
-        )
 
         # Check some timestamps
         assert dataset.records[0].timestamp == 0  # First frame

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -39,19 +39,17 @@ class TestTracabTracking:
         assert dataset.dataset_type == DatasetType.TRACKING
         assert len(dataset.records) == 6
         assert len(dataset.metadata.periods) == 2
-        assert dataset.metadata.orientation == Orientation.FIXED_HOME_AWAY
+        assert dataset.metadata.orientation == Orientation.HOME_AWAY
         assert dataset.metadata.periods[0] == Period(
             id=1,
             start_timestamp=4.0,
             end_timestamp=4.08,
-            attacking_direction=AttackingDirection.HOME_AWAY,
         )
 
         assert dataset.metadata.periods[1] == Period(
             id=2,
             start_timestamp=8.0,
             end_timestamp=8.08,
-            attacking_direction=AttackingDirection.AWAY_HOME,
         )
 
         player_home_19 = dataset.metadata.teams[0].get_player_by_jersey_number(


### PR DESCRIPTION
This PR makes the following changes:

### Breaking changes

- The previous behaviour of `Orientation.FIXED_HOME_AWAY`, `Orientation.FIXED_AWAY_HOME`,  `Orientation.HOME_TEAM`, and `Orientation.AWAY_TEAM` was counter-intuitive. For example, when the orientation is `FIXED_HOME_AWAY` the user expects that the home team will play from left-to-right the entire dataset, while it changes during halftime. Therefore,  the definition of these orientations was changed as follows:

| Orientation     | Definition                                                                                                               | Corresponding old orientation |
|-----------------|--------------------------------------------------------------------------------------------------------------------------|-------------------------------|
| HOME_AWAY       | The home team plays from left to right in the first period. The away team plays from left to right in the second period. | FIXED_HOME_AWAY               |
| AWAY_HOME       | The away team plays from left to right in the first period. The home team plays from left to right in the second period. | FIXED_AWAY_HOME               |
| STATIC_HOME_AWAY | The home team plays from left to right in both periods.                                                                  | HOME_TEAM                     |
| STATIC_AWAY_HOME | The away team plays from left to right in both periods.                                                                  | AWAY_TEAM                     |

- `AttackingDirection.HOME_AWAY` was renamed to `AttackingDirection.LTR` (indicating that the home team attacks left-to-right) and `AttackingDirection.AWAY_HOME` was renamed to `AttackingDirection.RTL`  (indicating that the home team attacks right-to-left) to avoid confusion with the identically named orientations.
- The `attacking_direction` attribute was removed from `Period`. Instead, the attacking direction is now defined for each `DataRecord` as a property derived from the dataset's orientation.

### Fixes

- Fix the orientation transform logic (Fixes #175).
- Add support for orientation transforms on games with extra time.
- Guarantee that the dataset's pitch dimensions and coordinate system metadata attributes are consistent.
- Adapt orientation attribute of Datafactory deserializer from `Orientation.HOME_TEAM` to `Orientation.HOME_AWAY`. The home team always starts left-to-right and changes at half-time. 
- Adapt orientation attribute of Skillcorner deserializer from `Orientation.HOME_TEAM`/`Orientation.AWAY_TEAM` to `Orientation.HOME_AWAY`/`Orientation.AWAY_HOME`. The teams change halves at half-time. 

### Features

-  Raise a warning when the orientation of a dataset cannot be determined (e.g., when the first period is  not recorded for a tracking dataset)
