### PR TITLE
Refactor pathlib tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3

--- a/kloppy/tests/conftest.py
+++ b/kloppy/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Module to store common fixtures. """
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def base_dir():
+    return Path(__file__).parent

--- a/kloppy/tests/issues/issue_113/test_issue_113.py
+++ b/kloppy/tests/issues/issue_113/test_issue_113.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from kloppy.domain import Orientation
 from kloppy import opta
@@ -38,8 +38,8 @@ def kloppy_load_data(f7, f24):
 
 class TestIssue113:
     def test_parse_opta(self):
-        dir_path = os.path.dirname(__file__)
+        dir_path = Path(__file__).parent
         kloppy_load_data(
-            f7=f"{dir_path}/opta_f7.xml",
-            f24=f"{dir_path}/opta_f24.xml",
+            f7=dir_path / "opta_f7.xml",
+            f24=dir_path / "opta_f24.xml",
         )

--- a/kloppy/tests/issues/test_issue_171.py
+++ b/kloppy/tests/issues/test_issue_171.py
@@ -1,15 +1,11 @@
-import os
-
 from kloppy import statsbomb
 
 
 class TestIssue171:
-    def test_determine_statsbomb_home_away_teams(self):
-        base_dir = os.path.dirname(__file__)
-
+    def test_determine_statsbomb_home_away_teams(self, base_dir):
         dataset = statsbomb.load(
-            event_data=f"{base_dir}/../files/statsbomb_3788741_event.json",
-            lineup_data=f"{base_dir}/../files/statsbomb_3788741_lineup.json",
+            event_data=base_dir / "files/statsbomb_3788741_event.json",
+            lineup_data=base_dir / "files/statsbomb_3788741_lineup.json",
             coordinates="statsbomb",
         )
 

--- a/kloppy/tests/test_adapter.py
+++ b/kloppy/tests/test_adapter.py
@@ -1,4 +1,3 @@
-import os
 from typing import BinaryIO
 
 import pytest
@@ -11,14 +10,12 @@ from kloppy.infra.io.adapters import Adapter, adapters
 
 class TestAdapter:
     @pytest.fixture
-    def f24_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/opta_f24.xml"
+    def f24_data(self, base_dir) -> str:
+        return base_dir / "files/opta_f24.xml"
 
     @pytest.fixture
-    def f7_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/opta_f7.xml"
+    def f7_data(self, base_dir) -> str:
+        return base_dir / "files/opta_f7.xml"
 
     def test_custom_adapter(self, f24_data: str, f7_data: str):
         """

--- a/kloppy/tests/test_config.py
+++ b/kloppy/tests/test_config.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from kloppy import opta
 from kloppy.config import set_config, get_config, config_context, reset_config
@@ -16,14 +14,12 @@ class TestConfig:
             reset_config()
 
     @pytest.fixture
-    def f24_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/opta_f24.xml"
+    def f24_data(self, base_dir) -> str:
+        return base_dir / "files/opta_f24.xml"
 
     @pytest.fixture
-    def f7_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/opta_f7.xml"
+    def f7_data(self, base_dir) -> str:
+        return base_dir / "files/opta_f7.xml"
 
     def test_set_config(self, f24_data: str, f7_data: str):
         """

--- a/kloppy/tests/test_datafactory.py
+++ b/kloppy/tests/test_datafactory.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from kloppy.domain import (
@@ -18,9 +16,8 @@ from kloppy import datafactory
 
 class TestDatafactory:
     @pytest.fixture
-    def event_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/datafactory_events.json"
+    def event_data(self, base_dir) -> str:
+        return base_dir / "files/datafactory_events.json"
 
     def test_correct_deserialization(self, event_data: str):
         dataset = datafactory.load(

--- a/kloppy/tests/test_event.py
+++ b/kloppy/tests/test_event.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 
@@ -11,14 +9,12 @@ class TestEvent:
     """"""
 
     @pytest.fixture
-    def event_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/statsbomb_event.json"
+    def event_data(self, base_dir) -> str:
+        return base_dir / "files/statsbomb_event.json"
 
     @pytest.fixture
-    def lineup_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/statsbomb_lineup.json"
+    def lineup_data(self, base_dir) -> str:
+        return base_dir / "files/statsbomb_lineup.json"
 
     @pytest.fixture()
     def dataset(self, lineup_data: str, event_data: str) -> EventDataset:

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -164,12 +164,10 @@ class TestHelpers:
             )
         )
 
-    def test_transform_to_coordinate_system(self):
-        base_dir = os.path.dirname(__file__)
-
+    def test_transform_to_coordinate_system(self, base_dir):
         dataset = tracab.load(
-            meta_data=f"{base_dir}/files/tracab_meta.xml",
-            raw_data=f"{base_dir}/files/tracab_raw.dat",
+            meta_data=base_dir / "files/tracab_meta.xml",
+            raw_data=base_dir / "files/tracab_raw.dat",
             only_alive=False,
             coordinates="tracab",
         )
@@ -206,14 +204,12 @@ class TestHelpers:
             == transformerd_coordinate_system.pitch_dimensions
         )
 
-    def test_transform_event_data(self):
+    def test_transform_event_data(self, base_dir):
         """Make sure event data that's in ACTION_EXECUTING orientation is
         transformed correctly"""
-        base_dir = os.path.dirname(__file__)
-
         dataset = statsbomb.load(
-            lineup_data=f"{base_dir}/files/statsbomb_lineup.json",
-            event_data=f"{base_dir}/files/statsbomb_event.json",
+            lineup_data=base_dir / "files/statsbomb_lineup.json",
+            event_data=base_dir / "files/statsbomb_event.json",
         )
 
         home_team, away_team = dataset.metadata.teams
@@ -257,13 +253,11 @@ class TestHelpers:
             == transformed_receipt_event.coordinates.y
         )
 
-    def test_transform_event_data_freeze_frame(self):
+    def test_transform_event_data_freeze_frame(self, base_dir):
         """Make sure the freeze frame within event data is transformed too"""
-        base_dir = os.path.dirname(__file__)
-
         dataset = statsbomb.load(
-            lineup_data=f"{base_dir}/files/statsbomb_lineup.json",
-            event_data=f"{base_dir}/files/statsbomb_event.json",
+            lineup_data=base_dir / "files/statsbomb_lineup.json",
+            event_data=base_dir / "files/statsbomb_event.json",
         )
 
         _, away_team = dataset.metadata.teams
@@ -312,23 +306,20 @@ class TestHelpers:
         )
         assert_frame_equal(data_frame, expected_data_frame, check_like=True)
 
-    def test_to_pandas_generic_events(self):
-        base_dir = os.path.dirname(__file__)
+    def test_to_pandas_generic_events(self, base_dir):
         dataset = opta.load(
-            f7_data=f"{base_dir}/files/opta_f7.xml",
-            f24_data=f"{base_dir}/files/opta_f24.xml",
+            f7_data=base_dir / "files/opta_f7.xml",
+            f24_data=base_dir / "files/opta_f24.xml",
         )
 
         dataframe = dataset.to_pandas()
         dataframe = dataframe[dataframe.event_type == "BALL_OUT"]
         assert dataframe.shape[0] == 2
 
-    def test_to_pandas_incomplete_pass(self):
-        base_dir = os.path.dirname(__file__)
-
+    def test_to_pandas_incomplete_pass(self, base_dir):
         dataset = statsbomb.load(
-            lineup_data=f"{base_dir}/files/statsbomb_lineup.json",
-            event_data=f"{base_dir}/files/statsbomb_event.json",
+            lineup_data=base_dir / "files/statsbomb_lineup.json",
+            event_data=base_dir / "files/statsbomb_event.json",
         )
         df = dataset.to_pandas()
         incomplete_passes = df[
@@ -370,15 +361,13 @@ class TestHelpers:
 
         assert_frame_equal(data_frame, expected_data_frame, check_like=True)
 
-    def test_event_dataset_to_polars(self):
+    def test_event_dataset_to_polars(self, base_dir):
         """
         Make sure an event dataset can be exported as a Polars DataFrame
         """
-        base_dir = os.path.dirname(__file__)
-
         dataset = statsbomb.load(
-            lineup_data=f"{base_dir}/files/statsbomb_lineup.json",
-            event_data=f"{base_dir}/files/statsbomb_event.json",
+            lineup_data=base_dir / "files/statsbomb_lineup.json",
+            event_data=base_dir / "files/statsbomb_event.json",
         )
         df = dataset.to_df(engine="polars")
 

--- a/kloppy/tests/test_metrica_csv.py
+++ b/kloppy/tests/test_metrica_csv.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from kloppy.domain import (
@@ -18,14 +16,12 @@ class TestMetricaCsvTracking:
     """"""
 
     @pytest.fixture
-    def home_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/metrica_home.csv"
+    def home_data(self, base_dir) -> str:
+        return base_dir / "files/metrica_home.csv"
 
     @pytest.fixture
-    def away_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/metrica_away.csv"
+    def away_data(self, base_dir) -> str:
+        return base_dir / "files/metrica_away.csv"
 
     def test_correct_deserialization(self, home_data: str, away_data: str):
         dataset = metrica.load_tracking_csv(

--- a/kloppy/tests/test_metrica_epts.py
+++ b/kloppy/tests/test_metrica_epts.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 import pytest
@@ -28,10 +27,9 @@ from kloppy import metrica
 
 
 class TestMetricaEPTSTracking:
-    def test_regex(self):
-        base_dir = os.path.dirname(__file__)
+    def test_regex(self, base_dir):
         with open(
-            f"{base_dir}/files/epts_metrica_metadata.xml", "rb"
+            base_dir / "files/epts_metrica_metadata.xml", "rb"
         ) as metadata_fp:
             metadata = load_metadata(metadata_fp)
 
@@ -49,10 +47,9 @@ class TestMetricaEPTSTracking:
 
         assert result is not None
 
-    def test_provider_name_recognition(self):
-        base_dir = os.path.dirname(__file__)
+    def test_provider_name_recognition(self, base_dir):
         with open(
-            f"{base_dir}/files/epts_metrica_metadata.xml", "rb"
+            base_dir / "files/epts_metrica_metadata.xml", "rb"
         ) as metadata_fp:
             root = objectify.fromstring(metadata_fp.read())
             metadata = root.find("Metadata")
@@ -60,30 +57,26 @@ class TestMetricaEPTSTracking:
 
         assert provider_from_file == Provider.METRICA
 
-    def test_read(self):
-        base_dir = os.path.dirname(__file__)
+    def test_read(self, base_dir):
         with open(
-            f"{base_dir}/files/epts_metrica_metadata.xml", "rb"
+            base_dir / "files/epts_metrica_metadata.xml", "rb"
         ) as metadata_fp:
             metadata = load_metadata(metadata_fp)
 
         with open(
-            f"{base_dir}/files/epts_metrica_tracking.txt", "rb"
+            base_dir / "files/epts_metrica_tracking.txt", "rb"
         ) as raw_data:
             iterator = read_raw_data(raw_data, metadata)
 
             with performance_logging("load"):
                 assert list(iterator)
 
-    def test_read_to_pandas(self):
-        base_dir = os.path.dirname(__file__)
-
+    def test_read_to_pandas(self, base_dir):
         with open(
-            f"{base_dir}/files/epts_metrica_metadata.xml", "rb"
+            base_dir / "files/epts_metrica_metadata.xml", "rb"
         ) as metadata_fp, open(
-            f"{base_dir}/files/epts_metrica_tracking.txt", "rb"
+            base_dir / "files/epts_metrica_tracking.txt", "rb"
         ) as raw_data:
-
             metadata = load_metadata(metadata_fp)
             records = read_raw_data(
                 raw_data, metadata, sensor_ids=["position"]
@@ -92,13 +85,11 @@ class TestMetricaEPTSTracking:
 
         assert "player_Track_1_x" in data_frame.columns
 
-    def test_skip_sensors(self):
-        base_dir = os.path.dirname(__file__)
-
+    def test_skip_sensors(self, base_dir):
         with open(
-            f"{base_dir}/files/epts_metrica_metadata.xml", "rb"
+            base_dir / "files/epts_metrica_metadata.xml", "rb"
         ) as metadata_fp, open(
-            f"{base_dir}/files/epts_metrica_tracking.txt", "rb"
+            base_dir / "files/epts_metrica_tracking.txt", "rb"
         ) as raw_data:
             metadata = load_metadata(metadata_fp)
             records = read_raw_data(raw_data, metadata, sensor_ids=["speed"])
@@ -108,14 +99,12 @@ class TestMetricaEPTSTracking:
         assert "player_Track_1_x" not in data_frame.columns
 
     @pytest.fixture
-    def meta_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/epts_metrica_metadata.xml"
+    def meta_data(self, base_dir) -> str:
+        return base_dir / "files/epts_metrica_metadata.xml"
 
     @pytest.fixture
-    def raw_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/epts_metrica_tracking.txt"
+    def raw_data(self, base_dir) -> str:
+        return base_dir / "files/epts_metrica_tracking.txt"
 
     def test_correct_deserialization(self, meta_data: str, raw_data: str):
         dataset = metrica.load_tracking_epts(
@@ -149,14 +138,12 @@ class TestMetricaEPTSTracking:
         )
 
     def test_read_with_sensor_unused_in_players_and_frame_count_name_modified(
-        self,
+        self, base_dir
     ):
-        base_dir = os.path.dirname(__file__)
-
         with open(
-            f"{base_dir}/files/epts_metrica_metadata_unused_sensor.xml", "rb"
+            base_dir / "files/epts_metrica_metadata_unused_sensor.xml", "rb"
         ) as metadata_fp, open(
-            f"{base_dir}/files/epts_metrica_tracking.txt", "rb"
+            base_dir / "files/epts_metrica_tracking.txt", "rb"
         ) as raw_data:
             dataset = metrica.load_tracking_epts(
                 meta_data=metadata_fp, raw_data=raw_data
@@ -171,15 +158,11 @@ class TestMetricaEPTSTracking:
         # But all defined sensors in the metadata are 4
         assert len(dataset.metadata.sensors) == 4
 
-    def test_read_empty_player_values(
-        self,
-    ):
-        base_dir = os.path.dirname(__file__)
-
+    def test_read_empty_player_values(self, base_dir):
         with open(
-            f"{base_dir}/files/epts_metrica_metadata.xml", "rb"
+            base_dir / "files/epts_metrica_metadata.xml", "rb"
         ) as metadata_fp, open(
-            f"{base_dir}/files/epts_metrica_tracking_with_empty_values.txt",
+            base_dir / "files/epts_metrica_tracking_with_empty_values.txt",
             "rb",
         ) as raw_data:
             dataset = metrica.load_tracking_epts(

--- a/kloppy/tests/test_metrica_events.py
+++ b/kloppy/tests/test_metrica_events.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from kloppy import metrica
@@ -16,14 +14,12 @@ from kloppy.domain.models.common import DatasetType
 
 class TestMetricaEvents:
     @pytest.fixture
-    def meta_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/epts_metrica_metadata.xml"
+    def meta_data(self, base_dir) -> str:
+        return base_dir / "files/epts_metrica_metadata.xml"
 
     @pytest.fixture
-    def event_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/metrica_events.json"
+    def event_data(self, base_dir) -> str:
+        return base_dir / "files/metrica_events.json"
 
     def test_correct_deserialization(self, event_data: str, meta_data: str):
         dataset = metrica.load_event(

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from kloppy.domain import (
@@ -24,14 +22,12 @@ class TestOpta:
     """"""
 
     @pytest.fixture
-    def f24_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/opta_f24.xml"
+    def f24_data(self, base_dir) -> str:
+        return base_dir / "files/opta_f24.xml"
 
     @pytest.fixture
-    def f7_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/opta_f7.xml"
+    def f7_data(self, base_dir) -> str:
+        return base_dir / "files/opta_f7.xml"
 
     def test_correct_deserialization(self, f7_data: str, f24_data: str):
         dataset = opta.load(

--- a/kloppy/tests/test_secondspectrum.py
+++ b/kloppy/tests/test_secondspectrum.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 
 import pytest
 
@@ -17,22 +17,19 @@ from kloppy import secondspectrum
 
 class TestSecondSpectrumTracking:
     @pytest.fixture
-    def meta_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/second_spectrum_fake_metadata.xml"
+    def meta_data(self, base_dir) -> str:
+        return base_dir / "files/second_spectrum_fake_metadata.xml"
 
     @pytest.fixture
-    def raw_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/second_spectrum_fake_data.jsonl"
+    def raw_data(self, base_dir) -> str:
+        return base_dir / "files/second_spectrum_fake_data.jsonl"
 
     @pytest.fixture
-    def additional_meta_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/second_spectrum_fake_metadata.json"
+    def additional_meta_data(self, base_dir) -> str:
+        return base_dir / "files/second_spectrum_fake_metadata.json"
 
     def test_correct_deserialization(
-        self, meta_data: str, raw_data: str, additional_meta_data: str
+        self, meta_data: Path, raw_data: Path, additional_meta_data: Path
     ):
         dataset = secondspectrum.load(
             meta_data=meta_data,
@@ -96,7 +93,7 @@ class TestSecondSpectrumTracking:
         assert pitch_dimensions.y_dim.max == 33.985
 
     def test_correct_normalized_deserialization(
-        self, meta_data: str, raw_data: str, additional_meta_data: str
+        self, meta_data: Path, raw_data: Path, additional_meta_data: Path
     ):
         dataset = secondspectrum.load(
             meta_data=meta_data,

--- a/kloppy/tests/test_skillcorner.py
+++ b/kloppy/tests/test_skillcorner.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -17,16 +17,14 @@ from kloppy import skillcorner
 
 class TestSkillCornerTracking:
     @pytest.fixture
-    def meta_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/skillcorner_match_data.json"
+    def meta_data(self, base_dir) -> str:
+        return base_dir / "files/skillcorner_match_data.json"
 
     @pytest.fixture
-    def raw_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/skillcorner_structured_data.json"
+    def raw_data(self, base_dir) -> str:
+        return base_dir / "files/skillcorner_structured_data.json"
 
-    def test_correct_deserialization(self, raw_data: str, meta_data: str):
+    def test_correct_deserialization(self, raw_data: Path, meta_data: Path):
         dataset = skillcorner.load(
             meta_data=meta_data, raw_data=raw_data, coordinates="skillcorner"
         )
@@ -109,7 +107,6 @@ class TestSkillCornerTracking:
     def test_correct_normalized_deserialization(
         self, meta_data: str, raw_data: str
     ):
-        base_dir = os.path.dirname(__file__)
         dataset = skillcorner.load(meta_data=meta_data, raw_data=raw_data)
 
         home_player = dataset.metadata.teams[0].players[2]

--- a/kloppy/tests/test_sportec.py
+++ b/kloppy/tests/test_sportec.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -20,16 +20,14 @@ class TestSportecEvent:
     """"""
 
     @pytest.fixture
-    def event_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/sportec_events.xml"
+    def event_data(self, base_dir) -> str:
+        return base_dir / "files/sportec_events.xml"
 
     @pytest.fixture
-    def meta_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/sportec_meta.xml"
+    def meta_data(self, base_dir) -> str:
+        return base_dir / "files/sportec_meta.xml"
 
-    def test_correct_deserialization(self, event_data: str, meta_data: str):
+    def test_correct_deserialization(self, event_data: Path, meta_data: Path):
         dataset = sportec.load(
             event_data=event_data, meta_data=meta_data, coordinates="sportec"
         )
@@ -72,7 +70,7 @@ class TestSportecEvent:
         assert dataset.events[0].coordinates == Point(56.41, 68.0)
 
     def test_correct_normalized_deserialization(
-        self, event_data: str, meta_data: str
+        self, event_data: Path, meta_data: Path
     ):
         dataset = sportec.load(event_data=event_data, meta_data=meta_data)
 

--- a/kloppy/tests/test_state_builder.py
+++ b/kloppy/tests/test_state_builder.py
@@ -1,4 +1,3 @@
-import os
 from itertools import groupby
 
 from kloppy.domain import EventType, Event, EventDataset, FormationType
@@ -10,16 +9,14 @@ from kloppy import statsbomb
 class TestStateBuilder:
     """"""
 
-    def _load_dataset(self, base_filename="statsbomb"):
-        base_dir = os.path.dirname(__file__)
-
+    def _load_dataset(self, base_dir, base_filename="statsbomb"):
         return statsbomb.load(
-            event_data=f"{base_dir}/files/{base_filename}_event.json",
-            lineup_data=f"{base_dir}/files/{base_filename}_lineup.json",
+            event_data=base_dir / f"files/{base_filename}_event.json",
+            lineup_data=base_dir / f"files/{base_filename}_lineup.json",
         )
 
-    def test_score_state_builder(self):
-        dataset = self._load_dataset()
+    def test_score_state_builder(self, base_dir):
+        dataset = self._load_dataset(base_dir)
 
         with performance_logging("add_state"):
             dataset_with_state = dataset.add_state("score")
@@ -38,8 +35,8 @@ class TestStateBuilder:
             "3-0": 3,
         }
 
-    def test_sequence_state_builder(self):
-        dataset = self._load_dataset()
+    def test_sequence_state_builder(self, base_dir):
+        dataset = self._load_dataset(base_dir)
 
         with performance_logging("add_state"):
             dataset_with_state = dataset.add_state("sequence")
@@ -55,8 +52,8 @@ class TestStateBuilder:
         assert events_per_sequence[0] == 4
         assert events_per_sequence[51] == 14
 
-    def test_lineup_state_builder(self):
-        dataset = self._load_dataset("statsbomb_15986")
+    def test_lineup_state_builder(self, base_dir):
+        dataset = self._load_dataset(base_dir, base_filename="statsbomb_15986")
 
         with performance_logging("add_state"):
             dataset_with_state = dataset.add_state("lineup")
@@ -80,8 +77,8 @@ class TestStateBuilder:
             (EventType.GENERIC, 21),
         ]
 
-    def test_formation_state_builder(self):
-        dataset = self._load_dataset("statsbomb")
+    def test_formation_state_builder(self, base_dir):
+        dataset = self._load_dataset(base_dir, base_filename="statsbomb")
 
         with performance_logging("add_state"):
             dataset_with_state = dataset.add_state("formation")
@@ -105,7 +102,7 @@ class TestStateBuilder:
             "formation"
         ].home == FormationType("4-4-2")
 
-    def test_register_custom_builder(self):
+    def test_register_custom_builder(self, base_dir):
         class CustomStateBuilder(StateBuilder):
             def initial_state(self, dataset: EventDataset) -> int:
                 return 0
@@ -116,7 +113,7 @@ class TestStateBuilder:
             def reduce_after(self, state: int, event: Event) -> int:
                 return state + 1
 
-        dataset = self._load_dataset("statsbomb_15986")
+        dataset = self._load_dataset(base_dir, base_filename="statsbomb_15986")
 
         with performance_logging("add_state"):
             dataset_with_state = dataset.add_state("custom")

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -1,5 +1,5 @@
-import os
 from collections import defaultdict
+from pathlib import Path
 
 import pytest
 
@@ -29,16 +29,16 @@ class TestStatsBomb:
     """"""
 
     @pytest.fixture
-    def event_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/statsbomb_event.json"
+    def event_data(self, base_dir) -> str:
+        return base_dir / "files/statsbomb_event.json"
 
     @pytest.fixture
-    def lineup_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/statsbomb_lineup.json"
+    def lineup_data(self, base_dir) -> str:
+        return base_dir / "files/statsbomb_lineup.json"
 
-    def test_correct_deserialization(self, lineup_data: str, event_data: str):
+    def test_correct_deserialization(
+        self, lineup_data: Path, event_data: Path
+    ):
         """
         This test uses data from the StatsBomb open data project.
         """
@@ -149,7 +149,7 @@ class TestStatsBomb:
         assert dataset.events[3392].get_qualifier_value(PassQualifier) is None
 
     def test_correct_normalized_deserialization(
-        self, lineup_data: str, event_data: str
+        self, lineup_data: Path, event_data: Path
     ):
         """
         This test uses data from the StatsBomb open data project.
@@ -160,7 +160,7 @@ class TestStatsBomb:
 
         assert dataset.events[10].coordinates == Point(0.2875, 0.25625)
 
-    def test_substitution(self, lineup_data: str, event_data: str):
+    def test_substitution(self, lineup_data: Path, event_data: Path):
         """
         Test substitution events
         """
@@ -188,7 +188,7 @@ class TestStatsBomb:
                 replacement_player_id
             )
 
-    def test_card(self, lineup_data: str, event_data: str):
+    def test_card(self, lineup_data: Path, event_data: Path):
         """
         Test card events
         """
@@ -203,7 +203,7 @@ class TestStatsBomb:
         for card in dataset.events:
             assert card.card_type == CardType.FIRST_YELLOW
 
-    def test_foul_committed(self, lineup_data: str, event_data: str):
+    def test_foul_committed(self, lineup_data: Path, event_data: Path):
         """
         Test foul committed events
         """
@@ -215,7 +215,7 @@ class TestStatsBomb:
 
         assert len(dataset.events) == 23
 
-    def test_related_events(self, lineup_data: str, event_data: str):
+    def test_related_events(self, lineup_data: Path, event_data: Path):
         dataset = statsbomb.load(
             lineup_data=lineup_data, event_data=event_data
         )
@@ -232,7 +232,7 @@ class TestStatsBomb:
         assert carry_event.get_related_events() == [receipt_event, pass_event]
         assert carry_event.related_pass() == pass_event
 
-    def test_player_position(self, lineup_data: str, event_data: str):
+    def test_player_position(self, lineup_data: Path, event_data: Path):
         """
         Validate position information is loaded correctly from the STARTING_XI events.
 
@@ -245,7 +245,7 @@ class TestStatsBomb:
         player_5246 = dataset.metadata.teams[0].get_player_by_id(20055)
         assert player_5246.position.position_id == "1"
 
-    def test_freeze_frame(self, lineup_data: str, event_data: str):
+    def test_freeze_frame(self, lineup_data: Path, event_data: Path):
         """
         Test freeze-frame is properly loaded and attached to shot events. The
         freeze-frames contain location information on player level.
@@ -271,13 +271,11 @@ class TestStatsBomb:
 
         assert shot_event.freeze_frame.frame_id == 3727
 
-    def test_freeze_frame_360(self):
-        base_dir = os.path.dirname(__file__)
-
+    def test_freeze_frame_360(self, base_dir):
         dataset = statsbomb.load(
-            event_data=f"{base_dir}/files/statsbomb_3788741_event.json",
-            lineup_data=f"{base_dir}/files/statsbomb_3788741_lineup.json",
-            three_sixty_data=f"{base_dir}/files/statsbomb_3788741_360.json",
+            event_data=base_dir / "files/statsbomb_3788741_event.json",
+            lineup_data=base_dir / "files/statsbomb_3788741_lineup.json",
+            three_sixty_data=base_dir / "files/statsbomb_3788741_360.json",
             coordinates="statsbomb",
         )
 

--- a/kloppy/tests/test_to_records.py
+++ b/kloppy/tests/test_to_records.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 from kloppy import statsbomb
@@ -12,17 +12,15 @@ from kloppy.domain.services.transformers.attribute import (
 
 class TestToRecords:
     @pytest.fixture
-    def event_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/statsbomb_event.json"
+    def event_data(self, base_dir) -> str:
+        return base_dir / "files/statsbomb_event.json"
 
     @pytest.fixture
-    def lineup_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/statsbomb_lineup.json"
+    def lineup_data(self, base_dir) -> str:
+        return base_dir / "files/statsbomb_lineup.json"
 
     @pytest.fixture
-    def dataset(self, event_data: str, lineup_data: str) -> EventDataset:
+    def dataset(self, event_data: Path, lineup_data: Path) -> EventDataset:
         return statsbomb.load(
             lineup_data=lineup_data,
             event_data=event_data,

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -20,18 +20,14 @@ from kloppy import tracab
 
 class TestTracabTracking:
     @pytest.fixture
-    def meta_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
-
-        return f"{base_dir}/files/tracab_meta.xml"
+    def meta_data(self, base_dir) -> str:
+        return base_dir / "files/tracab_meta.xml"
 
     @pytest.fixture
-    def raw_data(self) -> str:
-        base_dir = os.path.dirname(__file__)
+    def raw_data(self, base_dir) -> str:
+        return base_dir / "files/tracab_raw.dat"
 
-        return f"{base_dir}/files/tracab_raw.dat"
-
-    def test_correct_deserialization(self, meta_data: str, raw_data: str):
+    def test_correct_deserialization(self, meta_data: Path, raw_data: Path):
         dataset = tracab.load(
             meta_data=meta_data,
             raw_data=raw_data,
@@ -94,7 +90,7 @@ class TestTracabTracking:
         ]
 
     def test_correct_normalized_deserialization(
-        self, meta_data: str, raw_data: str
+        self, meta_data: Path, raw_data: Path
     ):
         dataset = tracab.load(
             meta_data=meta_data, raw_data=raw_data, only_alive=False

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 from kloppy.domain import Point, SetPieceType, SetPieceQualifier
@@ -10,16 +10,14 @@ class TestWyscout:
     """"""
 
     @pytest.fixture
-    def event_v3_data(self):
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/wyscout_events_v3.json"
+    def event_v3_data(self, base_dir):
+        return base_dir / "files/wyscout_events_v3.json"
 
     @pytest.fixture
-    def event_v2_data(self):
-        base_dir = os.path.dirname(__file__)
-        return f"{base_dir}/files/wyscout_events_v2.json"
+    def event_v2_data(self, base_dir):
+        return base_dir / "files/wyscout_events_v2.json"
 
-    def test_correct_v3_deserialization(self, event_v3_data: str):
+    def test_correct_v3_deserialization(self, event_v3_data: Path):
         dataset = wyscout.load(
             event_data=event_v3_data,
             coordinates="wyscout",
@@ -27,11 +25,11 @@ class TestWyscout:
         )
         assert dataset.records[2].coordinates == Point(36.0, 78.0)
 
-    def test_correct_normalized_v3_deserialization(self, event_v3_data: str):
+    def test_correct_normalized_v3_deserialization(self, event_v3_data: Path):
         dataset = wyscout.load(event_data=event_v3_data, data_version="V3")
         assert dataset.records[2].coordinates == Point(0.36, 0.78)
 
-    def test_correct_v2_deserialization(self, event_v2_data: str):
+    def test_correct_v2_deserialization(self, event_v2_data: Path):
         dataset = wyscout.load(
             event_data=event_v2_data,
             coordinates="wyscout",
@@ -39,11 +37,11 @@ class TestWyscout:
         )
         assert dataset.records[2].coordinates == Point(29.0, 6.0)
 
-    def test_correct_auto_recognize_deserialization(self, event_v2_data: str):
+    def test_correct_auto_recognize_deserialization(self, event_v2_data: Path):
         dataset = wyscout.load(event_data=event_v2_data, coordinates="wyscout")
         assert dataset.records[2].coordinates == Point(29.0, 6.0)
 
-    def test_correct_handling_of_corner_shot(self, event_v3_data: str):
+    def test_correct_handling_of_corner_shot(self, event_v3_data: Path):
         dataset = wyscout.load(
             event_data=event_v3_data, data_version="V3", event_types=["shot"]
         )

--- a/kloppy/tests/test_xml.py
+++ b/kloppy/tests/test_xml.py
@@ -9,9 +9,8 @@ from kloppy.infra.serializers.code.sportscode import SportsCodeSerializer
 
 
 class TestXMLCodeTracking:
-    def test_correct_deserialization(self):
-        base_dir = os.path.dirname(__file__)
-        dataset = sportscode.load(f"{base_dir}/files/code_xml.xml")
+    def test_correct_deserialization(self, base_dir):
+        dataset = sportscode.load(base_dir / "files/code_xml.xml")
 
         assert len(dataset.metadata.periods) == 1
 
@@ -50,9 +49,8 @@ class TestXMLCodeTracking:
 
         assert_frame_equal(dataframe, expected_data_frame)
 
-    def test_correct_serialization(self):
-        base_dir = os.path.dirname(__file__)
-        dataset = sportscode.load(f"{base_dir}/files/code_xml.xml")
+    def test_correct_serialization(self, base_dir):
+        dataset = sportscode.load(base_dir / "files/code_xml.xml")
 
         del dataset.codes[2:]
 


### PR DESCRIPTION
This pull request tries to solve the issue [#173 ](https://github.com/PySport/kloppy/issues/173).
It includes changes in multiple files, but they are all related to the issue :).
Also, given `base_dir` is a fixture reused across a lot of tests, a `conftest.py` file was added (just for this variable, I don't know if it would be interesting to add other fixtures reused in here).
It also includes a change (an update of the black version) to `.pre-commit-config.yaml` that I noticed when running the pre-commit hook.
If there are other changes expected to close the issue, please let me know, I'd be happy to help.