### PR TITLE
Fixed foot left/right typo in shot parsing for WyScout v3

### DIFF
--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -103,7 +103,7 @@ def _parse_shot(raw_event: Dict) -> Dict:
         qualifiers.append(BodyPartQualifier(value=BodyPart.HEAD))
     elif raw_event["shot"]["bodyPart"] == "left_foot":
         qualifiers.append(BodyPartQualifier(value=BodyPart.LEFT_FOOT))
-    elif raw_event["shot"]["bodyPart"] == "left_foot":
+    elif raw_event["shot"]["bodyPart"] == "right_foot":
         qualifiers.append(BodyPartQualifier(value=BodyPart.RIGHT_FOOT))
 
     return {


### PR DESCRIPTION
As per the title, a very minor fix to correctly assign the body part of the shot.

Unfortunately, `wyscout_events_v3.json` does not have any shot events with a defined body part preventing me from adding an appropriate test. If someone could please let me know where to find other events of the match in that json file, I can easily add the test.