### PR TITLE
Add DuelEvent 

### DIFF
--- a/kloppy/_providers/datafactory.py
+++ b/kloppy/_providers/datafactory.py
@@ -28,7 +28,6 @@ def load(
         event_factory=event_factory or get_config("event_factory"),
     )
     with open_as_file(event_data) as event_data_fp:
-
         return deserializer.deserialize(
             inputs=DatafactoryInputs(event_data=event_data_fp),
         )

--- a/kloppy/_providers/opta.py
+++ b/kloppy/_providers/opta.py
@@ -32,7 +32,6 @@ def load(
     with open_as_file(f7_data) as f7_data_fp, open_as_file(
         f24_data
     ) as f24_data_fp:
-
         return deserializer.deserialize(
             inputs=OptaInputs(f7_data=f7_data_fp, f24_data=f24_data_fp),
         )

--- a/kloppy/_providers/statsbomb.py
+++ b/kloppy/_providers/statsbomb.py
@@ -48,7 +48,6 @@ def load(
     ) as lineup_data_fp, open_as_file(
         Source.create(three_sixty_data, optional=True)
     ) as three_sixty_data_fp:
-
         return deserializer.deserialize(
             inputs=StatsBombInputs(
                 event_data=event_data_fp,

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -426,7 +426,6 @@ class KloppyCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-
         if self.length is not None and self.width is not None:
             return PitchDimensions(
                 x_dim=Dimension(0, 1),
@@ -656,7 +655,6 @@ class StatsPerformCoordinateSystem(CoordinateSystem):
 
 
 def build_coordinate_system(provider: Provider, **kwargs):
-
     if provider == Provider.TRACAB:
         return TracabCoordinateSystem(normalized=False, **kwargs)
 
@@ -966,7 +964,6 @@ class Dataset(ABC, Generic[T]):
         as_list: bool = True,
         **named_columns: "Column",
     ) -> Union[List[Dict[str, Any]], Iterable[Dict[str, Any]]]:
-
         from ..services.transformers.data_record import get_transformer_cls
 
         transformer = get_transformer_cls(self.dataset_type)(
@@ -984,7 +981,6 @@ class Dataset(ABC, Generic[T]):
         orient: Literal["list"] = "list",
         **named_columns: "Column",
     ) -> Dict[str, List[Any]]:
-
         if orient == "list":
             from ..services.transformers.data_record import get_transformer_cls
 

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -140,10 +140,12 @@ class DuelResult(ResultType):
     Attributes:
         WON (DuelResult): When winning the duel (player touching the ball first)
         LOST (DuelResult): When losing the duel (opponent touches the ball first)
+        NEUTRAL (DuelResult): When neither player wins duel [Mainly for WyScout v2]
     """
 
     WON = "WON"
     LOST = "LOST"
+    NEUTRAL = "NEUTRAL"
 
     @property
     def is_success(self):
@@ -385,14 +387,12 @@ class DuelType(Enum):
         GROUND (DuelType): A duel when the ball is on the ground.
         LOOSE_BALL (DuelType): When the ball is not under the control of any particular player or team.
         SLIDING_TACKLE (DuelType): A duel where the player slides on the ground to kick the ball away from an opponent.
-        STANDING_TACKLE (DuelType): A duel where the player makes a standing tackle.
     """
 
     AERIAL = "AERIAL"
     GROUND = "GROUND"
     LOOSE_BALL = "LOOSE_BALL"
     SLIDING_TACKLE = "SLIDING_TACKLE"
-    STANDING_TACKLE = "STANDING_TACKLE"
 
 
 @dataclass
@@ -468,7 +468,6 @@ class Event(DataRecord, ABC):
                 if isinstance(qualifier, qualifier_type):
                     return qualifier.value
         return None
-
 
     def get_qualifier_values(self, qualifier_type: Type[Qualifier]):
         """

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -488,10 +488,7 @@ class Event(DataRecord, ABC):
                 if isinstance(qualifier, qualifier_type):
                     qualifiers.append(qualifier)
 
-            if qualifiers:
-                return qualifiers
-
-        return None
+        return qualifiers
 
     def get_related_events(self) -> List["Event"]:
         if not self.dataset:

--- a/kloppy/domain/services/event_factory.py
+++ b/kloppy/domain/services/event_factory.py
@@ -10,6 +10,7 @@ from kloppy.domain import (
     TakeOnEvent,
     RecoveryEvent,
     CarryEvent,
+    DuelEvent,
     FormationChangeEvent,
     BallOutEvent,
     PlayerOnEvent,
@@ -81,6 +82,9 @@ class EventFactory:
 
     def build_carry(self, **kwargs) -> CarryEvent:
         return create_event(CarryEvent, **kwargs)
+
+    def build_duel(self, **kwargs) -> DuelEvent:
+        return create_event(DuelEvent, **kwargs)
 
     def build_formation_change(self, **kwargs) -> FormationChangeEvent:
         return create_event(FormationChangeEvent, **kwargs)

--- a/kloppy/domain/services/state_builder/__init__.py
+++ b/kloppy/domain/services/state_builder/__init__.py
@@ -36,7 +36,6 @@ def add_state(dataset: EventDataset, *builder_keys: List[str]) -> EventDataset:
 
     events = []
     for event in dataset.events:
-
         state = {
             builder_key: builder.reduce_before(state[builder_key], event)
             for builder_key, builder in builders.items()

--- a/kloppy/domain/services/state_builder/builders/sequence.py
+++ b/kloppy/domain/services/state_builder/builders/sequence.py
@@ -43,7 +43,6 @@ class SequenceStateBuilder(StateBuilder):
         return state
 
     def reduce_after(self, state: Sequence, event: Event) -> Sequence:
-
         if isinstance(event, CLOSE_SEQUENCE):
             state = replace(
                 state, sequence_id=state.sequence_id + 1, team=None

--- a/kloppy/domain/services/transformers/attribute.py
+++ b/kloppy/domain/services/transformers/attribute.py
@@ -276,7 +276,6 @@ class DefaultFrameTransformer:
             else None,
         )
         for player, player_data in frame.players_data.items():
-
             row.update(
                 {
                     f"{player.player_id}_x": player_data.coordinates.x

--- a/kloppy/domain/services/transformers/data_record.py
+++ b/kloppy/domain/services/transformers/data_record.py
@@ -25,7 +25,6 @@ class DataRecordToDictTransformer(ABC, Generic[T]):
         **named_columns: Union[str, Callable[[T], Any]],
     ):
         if not columns and not named_columns:
-
             converter = self.default_transformer()
         else:
             default = self.default_transformer()

--- a/kloppy/domain/services/transformers/dataset.py
+++ b/kloppy/domain/services/transformers/dataset.py
@@ -30,7 +30,6 @@ class DatasetTransformer:
         to_pitch_dimensions: Optional[PitchDimensions] = None,
         to_orientation: Optional[Orientation] = None,
     ):
-
         if (
             from_pitch_dimensions
             and from_coordinate_system
@@ -90,7 +89,6 @@ class DatasetTransformer:
     def change_point_dimensions(
         self, point: Union[Point, Point3D, None]
     ) -> Union[Point, Point3D, None]:
-
         if point is None:
             return None
 
@@ -108,7 +106,6 @@ class DatasetTransformer:
     def flip_point(
         self, point: Union[Point, Point3D, None]
     ) -> Union[Point, Point3D, None]:
-
         if not point:
             return None
 
@@ -160,7 +157,6 @@ class DatasetTransformer:
         return flip
 
     def transform_frame(self, frame: Frame) -> Frame:
-
         # Change coordinate system
         if self._needs_coordinate_system_change:
             frame = self.__change_frame_coordinate_system(frame)
@@ -178,7 +174,6 @@ class DatasetTransformer:
         return frame
 
     def __change_frame_coordinate_system(self, frame: Frame):
-
         return Frame(
             # doesn't change
             timestamp=frame.timestamp,
@@ -205,7 +200,6 @@ class DatasetTransformer:
         )
 
     def __change_frame_dimensions(self, frame: Frame):
-
         return Frame(
             # doesn't change
             timestamp=frame.timestamp,
@@ -234,7 +228,6 @@ class DatasetTransformer:
     def __change_point_coordinate_system(
         self, point: Union[Point, Point3D, None]
     ) -> Union[Point, Point3D, None]:
-
         if not point:
             return None
 
@@ -257,7 +250,6 @@ class DatasetTransformer:
             return Point(x=x, y=y)
 
     def __flip_frame(self, frame: Frame):
-
         players_data = {}
         for player, data in frame.players_data.items():
             players_data[player] = PlayerData(
@@ -281,7 +273,6 @@ class DatasetTransformer:
         )
 
     def transform_event(self, event: Event) -> Event:
-
         # Change coordinate system
         if self._needs_coordinate_system_change:
             event = self.__change_event_coordinate_system(event)
@@ -303,7 +294,6 @@ class DatasetTransformer:
         return event
 
     def __change_event_coordinate_system(self, event: Event):
-
         position_changes = {
             field.name: self.__change_point_coordinate_system(
                 getattr(event, field.name)
@@ -316,7 +306,6 @@ class DatasetTransformer:
         return replace(event, **position_changes)
 
     def __change_event_dimensions(self, event: Event):
-
         position_changes = {
             field.name: self.change_point_dimensions(
                 getattr(event, field.name)
@@ -329,7 +318,6 @@ class DatasetTransformer:
         return replace(event, **position_changes)
 
     def __flip_event(self, event: Event):
-
         position_changes = {
             field.name: self.flip_point(getattr(event, field.name))
             for field in fields(event)
@@ -350,7 +338,6 @@ class DatasetTransformer:
         to_orientation: Optional[Orientation] = None,
         to_coordinate_system: Optional[CoordinateSystem] = None,
     ) -> Dataset:
-
         if (
             to_pitch_dimensions is None
             and to_orientation is None

--- a/kloppy/infra/serializers/event/datafactory/deserializer.py
+++ b/kloppy/infra/serializers/event/datafactory/deserializer.py
@@ -353,7 +353,6 @@ class DatafactoryDeserializer(EventDataDeserializer[DatafactoryInputs]):
         return Provider.DATAFACTORY
 
     def deserialize(self, inputs: DatafactoryInputs) -> EventDataset:
-
         transformer = self.get_transformer(length=2, width=2)
 
         with performance_logging("load data", logger=logger):

--- a/kloppy/infra/serializers/event/metrica/json_deserializer.py
+++ b/kloppy/infra/serializers/event/metrica/json_deserializer.py
@@ -118,7 +118,6 @@ def _parse_subtypes(event: dict) -> List:
 def _parse_pass(
     event: Dict, previous_event: Dict, subtypes: List, team: Team
 ) -> Dict:
-
     event_type_id = event["type"]["id"]
 
     if event_type_id == MS_PASS_OUTCOME_COMPLETE:
@@ -157,7 +156,6 @@ def _parse_pass(
 def _get_event_qualifiers(
     event: Dict, previous_event: Dict, subtypes: List
 ) -> List[Qualifier]:
-
     qualifiers = []
 
     qualifiers.extend(_get_event_setpiece_qualifiers(previous_event, subtypes))
@@ -169,7 +167,6 @@ def _get_event_qualifiers(
 def _get_event_setpiece_qualifiers(
     previous_event: Dict, subtypes: List
 ) -> List[Qualifier]:
-
     qualifiers = []
     previous_event_type_id = previous_event["type"]["id"]
     if previous_event_type_id == MS_SET_PIECE:
@@ -193,7 +190,6 @@ def _get_event_setpiece_qualifiers(
 
 
 def _get_event_bodypart_qualifiers(subtypes: List) -> List[Qualifier]:
-
     qualifiers = []
     if subtypes and MS_BODY_PART_HEAD in subtypes:
         qualifiers.append(BodyPartQualifier(value=BodyPart.HEAD))
@@ -274,7 +270,6 @@ class MetricaJsonEventDataDeserializer(
         with performance_logging("parse data", logger=logger):
             events = []
             for i, raw_event in enumerate(raw_events["data"]):
-
                 if raw_event["team"]["id"] == metadata.teams[0].team_id:
                     team = metadata.teams[0]
                 elif raw_event["team"]["id"] == metadata.teams[1].team_id:

--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -336,10 +336,7 @@ def _parse_duel(raw_qualifiers: List, type_id: int, outcome: int) -> Dict:
             ]
         )
 
-    if outcome:
-        result = DuelResult.WON
-    else:
-        result = DuelResult.LOST
+    result = DuelResult.WON if outcome else DuelResult.LOST
 
     return dict(
         result=result,

--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -717,7 +717,7 @@ class OptaDeserializer(EventDataDeserializer[OptaInputs]):
                             **generic_event_kwargs,
                         )
                     elif (type_id == EVENT_TYPE_FOUL_COMMITTED) and (
-                            outcome == 0
+                        outcome == 0
                     ):
                         event = self.event_factory.build_foul_committed(
                             result=None,

--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -462,10 +462,9 @@ def _parse_duel(
         "type", {}
     ).get("name")
 
-    if outcome_name in DUEL_WON_NAMES:
-        result = DuelResult.WON
-    else:
-        result = DuelResult.LOST
+    result = (
+        DuelResult.WON if outcome_name in DUEL_WON_NAMES else DuelResult.LOST
+    )
 
     return {"result": result, "qualifiers": qualifiers}
 
@@ -909,7 +908,8 @@ class StatsBombDeserializer(EventDataDeserializer[StatsBombInputs]):
                             **duel_event_kwargs,
                             **generic_event_kwargs,
                         )
-                        new_events.append(duel_event)
+                        # add duel event as first event.
+                        new_events.insert(0, duel_event)
 
                 for event in new_events:
                     if self.should_include_event(event):

--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -15,6 +15,9 @@ from kloppy.domain import (
     ShotResult,
     TakeOnResult,
     CarryResult,
+    DuelResult,
+    DuelQualifier,
+    DuelType,
     Metadata,
     Ground,
     Player,
@@ -43,9 +46,11 @@ from ..deserializer import EventDataDeserializer
 logger = logging.getLogger(__name__)
 
 SB_EVENT_TYPE_RECOVERY = 2
+SB_EVENT_TYPE_DUEL = 4
 SB_EVENT_TYPE_DRIBBLE = 14
 SB_EVENT_TYPE_SHOT = 16
 SB_EVENT_TYPE_PASS = 30
+SB_EVENT_TYPE_50_50 = 33
 SB_EVENT_TYPE_CARRY = 43
 
 SB_EVENT_TYPE_HALF_START = 18
@@ -78,6 +83,28 @@ SB_SHOT_OUTCOME_SAVED = 100
 SB_SHOT_OUTCOME_OFF_WAYWARD = 101
 SB_SHOT_OUTCOME_SAVED_OFF_TARGET = 115
 SB_SHOT_OUTCOME_SAVED_TO_POST = 116
+
+SB_EVENT_TYPE_AERIAL_LOST = 10
+SB_EVENT_TYPE_TACKLE = 11
+
+# SB_50_50_OUTCOME_WON = 108
+# SB_50_50_OUTCOME_LOST = 109
+# SB_50_50_OUTCOME_SUCCESS_TO_OPPOSITION = 2  # TODO: Documentation says: 148 - Asking StatsBomb support
+# SB_50_50_OUTCOME_SUCCESS_TO_TEAM = 3  # TODO: Documentation says: 147 - Asking StatsBomb support
+#
+# SB_DUEL_OUTCOME_LOST = 1
+# SB_DUEL_OUTCOME_WON = 4
+# SB_DUEL_OUTCOME_LOST_IN_PLAY = 13
+# SB_DUEL_OUTCOME_LOST_OUT = 14
+# SB_DUEL_OUTCOME_SUCCESS = 15
+# SB_DUEL_OUTCOME_SUCCESS_IN_PLAY = 16
+# SB_DUEL_OUTCOME_SUCCESS_OUT = 17
+DUEL_WON_NAMES = ["Won", "Success To Team", "Success", "Success In Play", "Success Out"]
+DUEL_LOST_NAMES = ["Lost", "Aerial Lost", "Success To Opposition", "Lost In Play", "Lost Out"]
+# DUEL_WON_IDS = [SB_50_50_OUTCOME_WON, SB_50_50_OUTCOME_SUCCESS_TO_TEAM, SB_DUEL_OUTCOME_WON, SB_DUEL_OUTCOME_SUCCESS,
+#                 SB_DUEL_OUTCOME_SUCCESS_IN_PLAY, SB_DUEL_OUTCOME_SUCCESS_OUT]
+# DUEL_LOST_IDS = [SB_50_50_OUTCOME_LOST, SB_50_50_OUTCOME_SUCCESS_TO_OPPOSITION, SB_DUEL_OUTCOME_LOST,
+#                  SB_DUEL_OUTCOME_LOST_IN_PLAY, SB_DUEL_OUTCOME_LOST_OUT, SB_EVENT_TYPE_AERIAL_LOST]
 
 SB_EVENT_TYPE_FREE_KICK = 62
 SB_EVENT_TYPE_THROW_IN = 67
@@ -416,6 +443,58 @@ def _parse_take_on(take_on_dict: Dict) -> Dict:
     }
 
 
+def _parse_duel(raw_event: dict, event_type: int, ) -> Dict:
+    qualifiers = []
+
+    if event_type == SB_EVENT_TYPE_DUEL:
+        duel_dict = raw_event["duel"]
+        if "type" in duel_dict:
+            type_id = duel_dict["type"]["id"]
+            if type_id == SB_EVENT_TYPE_AERIAL_LOST:
+                duel_qualifiers = [DuelQualifier(value=DuelType.LOOSE_BALL), DuelQualifier(value=DuelType.AERIAL)]
+            elif type_id == SB_EVENT_TYPE_TACKLE:
+                duel_qualifiers = [DuelQualifier(value=DuelType.GROUND), DuelQualifier(value=DuelType.STANDING_TACKLE)]
+    elif event_type == SB_EVENT_TYPE_50_50:
+        duel_dict = raw_event["50_50"]
+        duel_qualifiers = [DuelQualifier(value=DuelType.LOOSE_BALL), DuelQualifier(value=DuelType.GROUND)]
+
+    qualifiers.extend(duel_qualifiers)
+    body_part_qualifiers = _get_body_part_qualifiers(duel_dict)
+    qualifiers.extend(body_part_qualifiers)
+
+    if "outcome" in duel_dict:
+        outcome_name = duel_dict["outcome"]["name"]
+    else:
+        outcome_name = duel_dict["type"]["name"]
+
+    result = None
+    if outcome_name in DUEL_WON_NAMES:
+        result = DuelResult.WON
+    elif outcome_name in DUEL_LOST_NAMES:
+        result = DuelResult.LOST
+
+    return {
+        "result": result,
+        "qualifiers": qualifiers
+    }
+
+
+def _parse_aerial_won_duel(raw_event: dict, type_name: str) -> Dict:
+    qualifiers = []
+    aerial_won_dict = raw_event[type_name]
+    duel_qualifiers = [DuelQualifier(value=DuelType.LOOSE_BALL), DuelQualifier(value=DuelType.AERIAL)]
+    result = DuelResult.WON
+
+    qualifiers.extend(duel_qualifiers)
+    body_part_qualifiers = _get_body_part_qualifiers(aerial_won_dict)
+    qualifiers.extend(body_part_qualifiers)
+
+    return {
+        "result": result,
+        "qualifiers": qualifiers
+    }
+
+
 def _parse_substitution(substitution_dict: Dict, team: Team) -> Dict:
     replacement_player = None
     for player in team.players:
@@ -724,6 +803,15 @@ class StatsBombDeserializer(EventDataDeserializer[StatsBombInputs]):
                         **generic_event_kwargs,
                     )
                     new_events.append(carry_event)
+                elif event_type in [SB_EVENT_TYPE_DUEL, SB_EVENT_TYPE_50_50]:
+                    duel_event_kwargs = _parse_duel(
+                        raw_event=raw_event, event_type=event_type
+                    )
+                    duel_event = self.event_factory.build_duel(
+                        **duel_event_kwargs,
+                        **generic_event_kwargs,
+                    )
+                    new_events.append(duel_event)
 
                 # lineup affecting events
                 elif event_type == SB_EVENT_TYPE_SUBSTITUTION:
@@ -819,6 +907,19 @@ class StatsBombDeserializer(EventDataDeserializer[StatsBombInputs]):
                         **generic_event_kwargs,
                     )
                     new_events.append(generic_event)
+
+                # Add possible aerial won - Last, since applicable to multiple event types
+                for type_name in ["shot", "clearance", "miscontrol", "pass"]:
+                    if type_name in raw_event and "aerial_won" in raw_event[type_name]:
+                        duel_event_kwargs = _parse_aerial_won_duel(
+                            raw_event=raw_event, type_name=type_name
+                        )
+                        duel_event = self.event_factory.build_duel(
+                            **duel_event_kwargs,
+                            **generic_event_kwargs,
+                        )
+                        new_events.append(duel_event)
+
 
                 for event in new_events:
                     if self.should_include_event(event):

--- a/kloppy/infra/serializers/event/wyscout/wyscout_events.py
+++ b/kloppy/infra/serializers/event/wyscout/wyscout_events.py
@@ -4,6 +4,7 @@ from typing import List
 class DUEL:
     EVENT = 1
 
+    AERIAL = 10
     GROUND_ATTACKING = 11
     GROUND_DEFENDING = 12
     GROUND_LOOSE_BALL = 13

--- a/kloppy/infra/serializers/tracking/metrica_csv.py
+++ b/kloppy/infra/serializers/tracking/metrica_csv.py
@@ -123,7 +123,6 @@ class MetricaCSVTrackingDataDeserializer(
     def __validate_partials(
         home_partial_frame: __PartialFrame, away_partial_frame: __PartialFrame
     ):
-
         if home_partial_frame.frame_id != away_partial_frame.frame_id:
             raise ValueError(
                 f"frame_id mismatch: home {home_partial_frame.frame_id}, "

--- a/kloppy/infra/serializers/tracking/metrica_epts/deserializer.py
+++ b/kloppy/infra/serializers/tracking/metrica_epts/deserializer.py
@@ -51,7 +51,6 @@ class MetricaEPTSTrackingDataDeserializer(
         players_data = {}
         for team in metadata.teams:
             for player in team.players:
-
                 other_data = {}
                 for sensor in other_sensors:
                     player_sensor_field_str = f"player_{player.player_id}_{sensor.channels[0].channel_id}"

--- a/kloppy/infra/serializers/tracking/secondspectrum.py
+++ b/kloppy/infra/serializers/tracking/secondspectrum.py
@@ -55,7 +55,6 @@ class SecondSpectrumDeserializer(
 
     @classmethod
     def _frame_from_framedata(cls, teams, period, frame_data):
-
         frame_id = frame_data["frameIdx"]
         frame_timestamp = frame_data["gameClock"]
 
@@ -75,7 +74,6 @@ class SecondSpectrumDeserializer(
         players_data = {}
         for team, team_str in zip(teams, ["homePlayers", "awayPlayers"]):
             for player_data in frame_data[team_str]:
-
                 jersey_no = player_data["number"]
                 x, y, _ = player_data["xyz"]
                 player = team.get_player_by_jersey_number(jersey_no)
@@ -111,7 +109,6 @@ class SecondSpectrumDeserializer(
             raise ValueError("Please specify a value for 'raw_data'")
 
     def deserialize(self, inputs: SecondSpectrumInputs) -> TrackingDataset:
-
         metadata = None
 
         # Handles the XML metadata that contains the pitch dimensions and frame info
@@ -201,7 +198,6 @@ class SecondSpectrumDeserializer(
                         teams, ["homePlayers", "awayPlayers"]
                     ):
                         for player_data in metadata[team_str]:
-
                             # We use the attributes field of Player to store the extra IDs provided by the
                             # metadata. We designate the player_id to be the 'optaId' field as this is what's
                             # used as 'player_id' in the raw frame data file

--- a/kloppy/infra/serializers/tracking/tracab.py
+++ b/kloppy/infra/serializers/tracking/tracab.py
@@ -156,7 +156,6 @@ class TRACABDeserializer(TrackingDataDeserializer[TRACABInputs]):
                     )
 
         with performance_logging("Loading data", logger=logger):
-
             transformer = self.get_transformer(
                 length=pitch_size_width, width=pitch_size_height
             )

--- a/kloppy/tests/files/opta_f24.xml
+++ b/kloppy/tests/files/opta_f24.xml
@@ -85,10 +85,8 @@
       <Q id="2022515959" qualifier_id="285" />
       <Q id="1344596334" qualifier_id="233" value="9" />
     </Event>
-    <Event id="2140914735" event_id="9" type_id="44" period_id="1" min="0" sec="21" player_id="84359" team_id="569" outcome="1" x="58.2" y="26.6" timestamp="2018-09-23T15:02:35.171" last_modified="2018-09-23T15:02:37" version="1537711356793">
-      <Q id="1681866436" qualifier_id="56" value="Center" />
-      <Q id="1234458284" qualifier_id="286" />
-      <Q id="1514024241" qualifier_id="233" value="4" />
+    <Event id="2140914735" event_id="9" type_id="67" period_id="1" min="0" sec="21" player_id="84359" team_id="569" outcome="1" x="58.2" y="26.6" timestamp="2018-09-23T15:02:35.171" last_modified="2018-09-23T15:02:37" version="1537711356793">
+      <Q id="4100379669" qualifier_id="233" value="892" />
     </Event>
     <Event id="1821879260" event_id="321" type_id="30" period_id="1" min="46" sec="7" team_id="2592" outcome="1" x="0.0" y="0.0" timestamp="2018-09-23T15:48:21.132" last_modified="2018-09-23T15:48:22" version="1537714101136">
       <Q id="1701622280" qualifier_id="57" value="0" />

--- a/kloppy/tests/files/statsbomb_event.json
+++ b/kloppy/tests/files/statsbomb_event.json
@@ -170129,6 +170129,126 @@
     }
   }
 }, {
+  "id" : "d9152217-8772-454c-b461-9d1d66070859",
+  "index" : 1501,
+  "period" : 2,
+  "timestamp" : "00:48:01.770",
+  "minute" : 93,
+  "second" : 1,
+  "type" : {
+    "id" : 33,
+    "name" : "50/50"
+  },
+  "possession" : 144,
+  "possession_team" : {
+    "id" : 217,
+    "name" : "Barcelona"
+  },
+  "play_pattern" : {
+    "id" : 1,
+    "name" : "Regular Play"
+  },
+  "team" : {
+    "id" : 217,
+    "name" : "Barcelona"
+  },
+  "player" : {
+    "id" : 5503,
+    "name" : "Lionel Andrés Messi Cuccittini"
+  },
+  "position" : {
+    "id" : 17,
+    "name" : "Right Wing"
+  },
+  "location" : [ 47.4, 22.4 ],
+  "duration" : 0.0,
+  "under_pressure" : true,
+  "related_events" : [ "10bf8575-16df-43b2-b4b7-9854bb708944" ],
+  "50_50" : {
+    "outcome" : {
+      "id" : 3,
+      "name" : "Success To Team"
+    }
+  }
+}, {
+  "id" : "d9152217-8772-454c-b461-9d1d66070129",
+  "index" : 1501,
+  "period" : 2,
+  "timestamp" : "00:48:01.770",
+  "minute" : 93,
+  "second" : 1,
+  "type" : {
+    "id" : 9,
+    "name" : "Clearance"
+  },
+  "possession" : 144,
+  "possession_team" : {
+    "id" : 217,
+    "name" : "Barcelona"
+  },
+  "play_pattern" : {
+    "id" : 1,
+    "name" : "Regular Play"
+  },
+  "team" : {
+    "id" : 217,
+    "name" : "Barcelona"
+  },
+  "player" : {
+    "id" : 5503,
+    "name" : "Lionel Andrés Messi Cuccittini"
+  },
+  "position" : {
+    "id" : 17,
+    "name" : "Right Wing"
+  },
+  "location" : [ 47.4, 22.4 ],
+  "duration" : 0.0,
+  "under_pressure" : true,
+  "related_events" : [ "54a0f549-fba3-4baa-8695-0bd92a2039bb", "8096dfc1-4842-41e1-8090-aa4c7117a499" ],
+  "clearance" : {
+    "aerial_won" : true
+  }
+}, {
+  "id" : "d9152217-8772-454c-b461-9d1d42070129",
+  "index" : 1809,
+  "period" : 2,
+  "timestamp" : "00:48:01.770",
+  "minute" : 93,
+  "second" : 1,
+  "type" : {
+    "id" : 38,
+    "name" : "Miscontrol"
+  },
+  "possession" : 144,
+  "possession_team" : {
+    "id" : 217,
+    "name" : "Barcelona"
+  },
+  "play_pattern" : {
+    "id" : 1,
+    "name" : "Regular Play"
+  },
+  "team" : {
+    "id" : 217,
+    "name" : "Barcelona"
+  },
+  "player" : {
+    "id" : 5503,
+    "name" : "Lionel Andrés Messi Cuccittini"
+  },
+  "position" : {
+    "id" : 17,
+    "name" : "Right Wing"
+  },
+  "location" : [ 47.4, 22.4 ],
+  "duration" : 0.0,
+  "under_pressure" : true,
+  "related_events" : [ "09feb961-9f36-4c0e-a11d-9ab8eee9bf87" ],
+  "miscontrol" : {
+    "aerial_won" : true
+  }
+}, {
   "id" : "e1cc4d5e-ba55-4b6b-88cc-dae13311c1d9",
   "index" : 4001,
   "period" : 2,
@@ -170180,4 +170300,5 @@
   },
   "duration" : 0.0,
   "related_events" : [ "e1cc4d5e-ba55-4b6b-88cc-dae13311c1d9" ]
-} ]
+}
+]

--- a/kloppy/tests/files/wyscout_events_v3.json
+++ b/kloppy/tests/files/wyscout_events_v3.json
@@ -441,7 +441,8 @@
         "primary": "duel",
         "secondary": [
           "ground_duel",
-          "offensive_duel"
+          "offensive_duel",
+          "loose_ball_duel"
         ]
       },
       "location": {

--- a/kloppy/tests/files/wyscout_events_v3.json
+++ b/kloppy/tests/files/wyscout_events_v3.json
@@ -434,6 +434,216 @@
         "name": "Bologna"
       },
       "videoTimestamp": "8.148438"
+    },
+    {
+      "id": 663291421,
+      "type": {
+        "primary": "duel",
+        "secondary": [
+          "ground_duel",
+          "offensive_duel"
+        ]
+      },
+      "location": {
+        "x": 95,
+        "y": 7
+      },
+      "matchId": 2852835,
+      "matchPeriod": "1H",
+      "matchTimestamp": "00:00:08.295",
+      "minute": 0,
+      "opponentTeam": {
+        "formation": "3-4-3",
+        "id": 3185,
+        "name": "Torino"
+      },
+      "shot": null,
+      "groundDuel": {
+        "opponent": {
+          "id": 636942,
+          "name": "N. Ngoy",
+          "position": "RCB3"
+        },
+        "duelType": "offensive_duel",
+        "keptPossession": true,
+        "progressedWithBall": true,
+        "stoppedProgress": null,
+        "recoveredPossession": null,
+        "takeOn": false,
+        "side": null,
+        "relatedDuelId": 1331978561
+      },
+      "aerialDuel": null,
+      "player": {
+        "id": 20583,
+        "name": "Danilo",
+        "position": "RCB"
+      },
+      "possession": {
+        "id": 663291837,
+        "duration": "1.261821",
+        "types": [
+          "corner",
+          "set_piece_attack"
+        ],
+        "eventsNumber": 1,
+        "eventIndex": 0,
+        "startLocation": {
+          "x": 100,
+          "y": 0
+        },
+        "endLocation": {
+          "x": 98,
+          "y": 55
+        },
+        "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+        "attack": null
+      },
+      "second": 8,
+      "team": {
+        "formation": "4-2-3-1",
+        "id": 3166,
+        "name": "Bologna"
+      },
+      "videoTimestamp": "8.148438"
+    },
+    {
+      "id": 663291840,
+      "type": {
+        "primary": "duel",
+        "secondary": [
+          "aerial_duel",
+          "loss"
+        ]
+      },
+      "location": {
+        "x": 96,
+        "y": 39
+      },
+      "matchId": 2852835,
+      "matchPeriod": "1H",
+      "matchTimestamp": "00:00:08.295",
+      "minute": 0,
+      "opponentTeam": {
+        "formation": "3-4-3",
+        "id": 3185,
+        "name": "Torino"
+      },
+      "shot": null,
+      "groundDuel": null,
+      "aerialDuel": {
+        "opponent": {
+          "id": 0,
+          "name": null,
+          "position": null,
+          "height": null
+        },
+        "firstTouch": true,
+        "height": 185,
+        "relatedDuelId": 1331979623
+      },
+      "player": {
+        "id": 20583,
+        "name": "Danilo",
+        "position": "RCB"
+      },
+      "possession": {
+        "id": 663291837,
+        "duration": "1.261821",
+        "types": [
+          "corner",
+          "set_piece_attack"
+        ],
+        "eventsNumber": 1,
+        "eventIndex": 0,
+        "startLocation": {
+          "x": 100,
+          "y": 0
+        },
+        "endLocation": {
+          "x": 98,
+          "y": 55
+        },
+        "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+        "attack": null
+      },
+      "second": 8,
+      "team": {
+        "formation": "4-2-3-1",
+        "id": 3166,
+        "name": "Bologna"
+      },
+      "videoTimestamp": "8.148438"
+    },
+    {
+      "id": 663291840,
+      "type": {
+        "primary": "duel",
+        "secondary": [
+          "loose_ball_duel",
+          "sliding_tackle"
+        ]
+      },
+      "location": {
+        "x": 26,
+        "y": 32
+      },
+      "matchId": 2852835,
+      "matchPeriod": "1H",
+      "matchTimestamp": "00:00:08.295",
+      "minute": 0,
+      "opponentTeam": {
+        "formation": "3-4-3",
+        "id": 3185,
+        "name": "Torino"
+      },
+      "shot": null,
+      "groundDuel": null,
+      "aerialDuel": null,
+      "player": {
+        "id": 20583,
+        "name": "Danilo",
+        "position": "RCB"
+      },
+      "possession": {
+        "id": 663291837,
+        "duration": "1.261821",
+        "types": [
+          "corner",
+          "set_piece_attack"
+        ],
+        "eventsNumber": 1,
+        "eventIndex": 0,
+        "startLocation": {
+          "x": 100,
+          "y": 0
+        },
+        "endLocation": {
+          "x": 98,
+          "y": 55
+        },
+        "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+        "attack": null
+      },
+      "second": 8,
+      "team": {
+        "formation": "4-2-3-1",
+        "id": 3166,
+        "name": "Bologna"
+      },
+      "videoTimestamp": "8.148438"
     }
   ],
   "formations": {

--- a/kloppy/tests/issues/issue_60/test_issue_60.py
+++ b/kloppy/tests/issues/issue_60/test_issue_60.py
@@ -18,5 +18,5 @@ class TestIssue60:
         # OPTA F24 file: Pass -> Deleted Event -> Tackle
         assert event_dataset.events[14].event_name == "pass"
         assert (
-            event_dataset.events[15].event_name == "tackle"
+            event_dataset.events[15].event_name == "duel"
         )  # Deleted Event is filter out

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -374,7 +374,7 @@ class TestHelpers:
         import polars as pl
 
         c = df.select(pl.col("event_id").count())[0, 0]
-        assert c == 4023
+        assert c == 4039
 
     def test_tracking_dataset_to_polars(self):
         """

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -13,6 +13,8 @@ from kloppy.domain import (
     DatasetType,
     CardType,
     FormationType,
+    DuelQualifier,
+    DuelType,
 )
 
 from kloppy import opta
@@ -106,6 +108,11 @@ class TestOpta:
         assert dataset.events[18].result.value == "OWN_GOAL"  # 2318697001
         # Check OFFSIDE pass has end_coordinates
         assert dataset.events[20].receiver_coordinates.x == 89.3  # 2360555167
+
+        # Check DuelQualifiers
+        assert dataset.events[7].get_qualifier_values(DuelQualifier)[1].value == DuelType.AERIAL
+        assert dataset.events[8].get_qualifier_values(DuelQualifier)[1].value == DuelType.GROUND
+        assert dataset.events[16].get_qualifier_values(DuelQualifier)[1].value == DuelType.STANDING_TACKLE
 
     def test_correct_normalized_deserialization(
         self, f7_data: str, f24_data: str

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -110,9 +110,14 @@ class TestOpta:
         assert dataset.events[20].receiver_coordinates.x == 89.3  # 2360555167
 
         # Check DuelQualifiers
-        assert dataset.events[7].get_qualifier_values(DuelQualifier)[1].value == DuelType.AERIAL
-        assert dataset.events[8].get_qualifier_values(DuelQualifier)[1].value == DuelType.GROUND
-        assert dataset.events[16].get_qualifier_values(DuelQualifier)[1].value == DuelType.STANDING_TACKLE
+        assert (
+            dataset.events[7].get_qualifier_values(DuelQualifier)[1].value
+            == DuelType.AERIAL
+        )
+        assert (
+            dataset.events[8].get_qualifier_values(DuelQualifier)[1].value
+            == DuelType.GROUND
+        )
 
     def test_correct_normalized_deserialization(
         self, f7_data: str, f24_data: str

--- a/kloppy/tests/test_state_builder.py
+++ b/kloppy/tests/test_state_builder.py
@@ -29,10 +29,10 @@ class TestStateBuilder:
             events_per_score[str(score)] = len(events)
 
         assert events_per_score == {
-            "0-0": 2898,
+            "0-0": 2909,
             "1-0": 717,
             "2-0": 405,
-            "3-0": 3,
+            "3-0": 8,
         }
 
     def test_sequence_state_builder(self, base_dir):
@@ -92,8 +92,8 @@ class TestStateBuilder:
             events_per_formation_change[str(formation)] = len(events)
 
         # inspect FormationChangeEvent usage and formation state_builder
-        assert events_per_formation_change["4-1-4-1"] == 3074
-        assert events_per_formation_change["4-4-2"] == 949
+        assert events_per_formation_change["4-1-4-1"] == 3085
+        assert events_per_formation_change["4-4-2"] == 954
 
         assert dataset.metadata.teams[0].starting_formation == FormationType(
             "4-4-2"

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -8,6 +8,8 @@ from kloppy.domain import (
     BodyPart,
     BodyPartQualifier,
     DatasetType,
+    DuelQualifier,
+    DuelType,
     Orientation,
     Period,
     Point,
@@ -50,7 +52,7 @@ class TestStatsBomb:
 
         assert dataset.metadata.provider == Provider.STATSBOMB
         assert dataset.dataset_type == DatasetType.EVENT
-        assert len(dataset.events) == 4023
+        assert len(dataset.events) == 4039
         assert len(dataset.metadata.periods) == 2
         assert (
             dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
@@ -93,7 +95,7 @@ class TestStatsBomb:
         assert dataset.events[10].coordinates == Point(34.5, 20.5)
 
         assert (
-            dataset.events[792].get_qualifier_value(BodyPartQualifier)
+            dataset.events[794].get_qualifier_value(BodyPartQualifier)
             == BodyPart.HEAD
         )
 
@@ -107,46 +109,50 @@ class TestStatsBomb:
         )
 
         assert (
-            dataset.events[1433].get_qualifier_value(PassQualifier)
+            dataset.events[1438].get_qualifier_value(PassQualifier)
             == PassType.CROSS
         )
 
         assert (
-            dataset.events[1552].get_qualifier_value(PassQualifier)
+            dataset.events[1557].get_qualifier_value(PassQualifier)
             == PassType.THROUGH_BALL
         )
 
         assert (
-            dataset.events[443].get_qualifier_value(PassQualifier)
+            dataset.events[444].get_qualifier_value(PassQualifier)
             == PassType.SWITCH_OF_PLAY
         )
 
         assert (
-            dataset.events[3438].get_qualifier_value(PassQualifier)
+            dataset.events[101].get_qualifier_value(PassQualifier)
             == PassType.LONG_BALL
         )
 
         assert (
-            dataset.events[2266].get_qualifier_value(PassQualifier)
+            dataset.events[17].get_qualifier_value(PassQualifier)
             == PassType.HIGH_PASS
         )
 
         assert (
-            dataset.events[653].get_qualifier_value(PassQualifier)
+            dataset.events[654].get_qualifier_value(PassQualifier)
             == PassType.HEAD_PASS
         )
 
         assert (
-            dataset.events[3134].get_qualifier_value(PassQualifier)
+            dataset.events[3145].get_qualifier_value(PassQualifier)
             == PassType.HAND_PASS
         )
 
         assert (
-            dataset.events[3611].get_qualifier_value(PassQualifier)
+            dataset.events[3622].get_qualifier_value(PassQualifier)
             == PassType.ASSIST
         )
 
-        assert dataset.events[3392].get_qualifier_value(PassQualifier) is None
+        assert dataset.events[3400].get_qualifier_value(PassQualifier) is None
+
+        assert dataset.events[194].get_qualifier_values(DuelQualifier)[1].value == DuelType.AERIAL
+        assert dataset.events[307].get_qualifier_values(DuelQualifier)[1].value == DuelType.STANDING_TACKLE
+        assert dataset.events[4032].get_qualifier_values(DuelQualifier)[1].value == DuelType.GROUND
 
     def test_correct_normalized_deserialization(
         self, lineup_data: Path, event_data: Path

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -159,8 +159,7 @@ class TestStatsBomb:
             dataset.events[4032].get_qualifier_values(DuelQualifier)[1].value
             == DuelType.GROUND
         )
-
-        assert dataset.events[271].event_type == EventType.CLEARANCE
+        assert dataset.events[272].event_type == EventType.CLEARANCE
 
     def test_correct_normalized_deserialization(
         self, lineup_data: Path, event_data: Path

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -150,9 +150,14 @@ class TestStatsBomb:
 
         assert dataset.events[3400].get_qualifier_value(PassQualifier) is None
 
-        assert dataset.events[194].get_qualifier_values(DuelQualifier)[1].value == DuelType.AERIAL
-        assert dataset.events[307].get_qualifier_values(DuelQualifier)[1].value == DuelType.STANDING_TACKLE
-        assert dataset.events[4032].get_qualifier_values(DuelQualifier)[1].value == DuelType.GROUND
+        assert (
+            dataset.events[194].get_qualifier_values(DuelQualifier)[1].value
+            == DuelType.AERIAL
+        )
+        assert (
+            dataset.events[4032].get_qualifier_values(DuelQualifier)[1].value
+            == DuelType.GROUND
+        )
 
     def test_correct_normalized_deserialization(
         self, lineup_data: Path, event_data: Path

--- a/kloppy/tests/test_to_records.py
+++ b/kloppy/tests/test_to_records.py
@@ -29,7 +29,7 @@ class TestToRecords:
 
     def test_default_columns(self, dataset: EventDataset):
         records = dataset.to_records()
-        assert len(records) == 4023
+        assert len(records) == 4039
         assert list(records[0].keys()) == [
             "event_id",
             "event_type",

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 
 import pytest
-from kloppy.domain import Point, SetPieceType, SetPieceQualifier
+from kloppy.domain import (
+    Point,
+    SetPieceType,
+    SetPieceQualifier,
+    DuelQualifier,
+    DuelType,
+)
 
 from kloppy import wyscout
 
@@ -25,6 +31,19 @@ class TestWyscout:
         )
         assert dataset.records[2].coordinates == Point(36.0, 78.0)
 
+        assert (
+            dataset.events[5].get_qualifier_value(DuelQualifier)
+            == DuelType.GROUND
+        )
+        assert (
+            dataset.events[6].get_qualifier_values(DuelQualifier)[1].value
+            == DuelType.AERIAL
+        )
+        assert (
+            dataset.events[7].get_qualifier_values(DuelQualifier)[2].value
+            == DuelType.SLIDING_TACKLE
+        )
+
     def test_correct_normalized_v3_deserialization(self, event_v3_data: Path):
         dataset = wyscout.load(event_data=event_v3_data, data_version="V3")
         assert dataset.records[2].coordinates == Point(0.36, 0.78)
@@ -36,6 +55,19 @@ class TestWyscout:
             data_version="V2",
         )
         assert dataset.records[2].coordinates == Point(29.0, 6.0)
+
+        assert (
+            dataset.events[39].get_qualifier_value(DuelQualifier)
+            == DuelType.GROUND
+        )
+        assert (
+            dataset.events[43].get_qualifier_values(DuelQualifier)[1].value
+            == DuelType.AERIAL
+        )
+        assert (
+            dataset.events[258].get_qualifier_values(DuelQualifier)[2].value
+            == DuelType.SLIDING_TACKLE
+        )
 
     def test_correct_auto_recognize_deserialization(self, event_v2_data: Path):
         dataset = wyscout.load(event_data=event_v2_data, coordinates="wyscout")

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -30,25 +30,26 @@ class TestWyscout:
             coordinates="wyscout",
             data_version="V3",
         )
+        df = dataset.to_df()
         assert dataset.records[2].coordinates == Point(36.0, 78.0)
         assert (
-                dataset.events[4].get_qualifier_value(SetPieceQualifier)
-                == SetPieceType.CORNER_KICK
+            dataset.events[4].get_qualifier_value(SetPieceQualifier)
+            == SetPieceType.CORNER_KICK
         )
         assert dataset.events[5].event_type == EventType.FOUL_COMMITTED
         assert (
-            dataset.events[5].get_qualifier_value(DuelQualifier)
+            dataset.events[6].get_qualifier_value(DuelQualifier)
             == DuelType.GROUND
         )
         assert (
-            dataset.events[6].get_qualifier_values(DuelQualifier)[1].value
+            dataset.events[7].get_qualifier_values(DuelQualifier)[1].value
             == DuelType.AERIAL
         )
         assert (
-            dataset.events[7].get_qualifier_values(DuelQualifier)[2].value
+            dataset.events[8].get_qualifier_values(DuelQualifier)[2].value
             == DuelType.SLIDING_TACKLE
         )
-        assert dataset.events[8].event_type == EventType.CLEARANCE
+        assert dataset.events[9].event_type == EventType.CLEARANCE
 
     def test_correct_normalized_v3_deserialization(self, event_v3_data: Path):
         dataset = wyscout.load(event_data=event_v3_data, data_version="V3")

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -31,7 +31,7 @@ class TestWyscout:
             data_version="V3",
         )
         assert dataset.records[2].coordinates == Point(36.0, 78.0)
-        assert dataset.events[5].event_type == EventType.CLEARANCE
+        assert dataset.events[8].event_type == EventType.CLEARANCE
 
         assert (
             dataset.events[5].get_qualifier_value(DuelQualifier)

--- a/kloppy/utils.py
+++ b/kloppy/utils.py
@@ -96,7 +96,6 @@ def deprecated(reason):
     """
 
     if isinstance(reason, string_types):
-
         # The @deprecated is used with a 'reason'.
         #
         # .. code-block:: python
@@ -106,7 +105,6 @@ def deprecated(reason):
         #      pass
 
         def decorator(func1):
-
             if inspect.isclass(func1):
                 fmt1 = "Call to deprecated class {name} ({reason})."
             else:
@@ -128,7 +126,6 @@ def deprecated(reason):
         return decorator
 
     elif inspect.isclass(reason) or inspect.isfunction(reason):
-
         # The @deprecated is used without any 'reason'.
         #
         # .. code-block:: python

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ pytest
 pandas>=1.0.0
 polars>=0.16.6
 pre-commit
+kloppy~=3.11.0
+pytz~=2023.3
+python-dateutil~=2.8.2
+setuptools~=67.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,3 @@ pytest
 pandas>=1.0.0
 polars>=0.16.6
 pre-commit
-kloppy~=3.11.0
-pytz~=2023.3
-python-dateutil~=2.8.2
-setuptools~=67.8.0


### PR DESCRIPTION
PR related to issue described in #135

Added DuelEvent for:
•	StatsBomb, Opta & WyScout (v2 & v3); including tests
•	Added DuelTypes: `AERIAL`, `GROUND`, `LOOSE_BALL` & `SLIDING_TACKLE`
•	Added .get_qualifier_values() to get a list of qualifiers instead of the first value. 

@probberechts  can you take a look, whether this suffices?