### PR TITLE
Missing 'qualifiers' key in event_factory kwargs

### DIFF
--- a/kloppy/domain/services/event_factory.py
+++ b/kloppy/domain/services/event_factory.py
@@ -44,6 +44,9 @@ def create_event(event_cls: Type[T], **kwargs) -> T:
     if "freeze_frame" not in kwargs:
         kwargs["freeze_frame"] = None
 
+    if 'qualifiers' not in kwargs:
+        kwargs['qualifiers'] = None
+
     all_kwargs = dict(**kwargs, **extra_kwargs)
 
     relevant_kwargs = {
@@ -55,7 +58,7 @@ def create_event(event_cls: Type[T], **kwargs) -> T:
             and field.name not in all_kwargs
         )
     }
-
+    
     if len(relevant_kwargs) < len(all_kwargs):
         skipped_kwargs = set(all_kwargs.keys()) - set(relevant_kwargs.keys())
         warnings.warn(

--- a/kloppy/domain/services/event_factory.py
+++ b/kloppy/domain/services/event_factory.py
@@ -44,8 +44,8 @@ def create_event(event_cls: Type[T], **kwargs) -> T:
     if "freeze_frame" not in kwargs:
         kwargs["freeze_frame"] = None
 
-    if 'qualifiers' not in kwargs:
-        kwargs['qualifiers'] = None
+    if "qualifiers" not in kwargs:
+        kwargs["qualifiers"] = None
 
     all_kwargs = dict(**kwargs, **extra_kwargs)
 
@@ -58,7 +58,7 @@ def create_event(event_cls: Type[T], **kwargs) -> T:
             and field.name not in all_kwargs
         )
     }
-    
+
     if len(relevant_kwargs) < len(all_kwargs):
         skipped_kwargs = set(all_kwargs.keys()) - set(relevant_kwargs.keys())
         warnings.warn(


### PR DESCRIPTION
Hi,

I was trying to load some Opta data and got the following error:

```TypeError: TakeOnEvent.__init__() missing 1 required positional argument: 'qualifiers'```

I checked and it seemed to only occur at TakeOnEvents (for this particular game of data I was testing). 

I simply added these two lines to add a qualifiers key to kwargs if it doesn't exist.

```
 if 'qualifiers' not in kwargs:
        kwargs['qualifiers'] = None
```

 It seems consistent with the lines above in the `create_event` function where we add "freeze_frame" and/or "related_event_ids" if they don't exist. Like so:

``` 
def create_event(event_cls: Type[T], **kwargs) -> T:
    """
    Do the actual construction of an event.

    This method does a couple of things:
    1. Fill in some arguments when not passed
    2. Pass only arguments that are accepted by the `event_cls`.
       This is required in cases an EventFactory initialized less rich
       Events than data is passed for. E.g. `expected_goal` is passed
       to a regular `ShotEvent`.
       Normally this would break because of an 'Unexpected argument' exception,
       but we filter those arguments out.
    """
    extra_kwargs = {"state": {}}
    if "related_event_ids" not in kwargs:
        extra_kwargs["related_event_ids"] = []

    if "freeze_frame" not in kwargs:
        kwargs["freeze_frame"] = None

   etc. etc.

```