### PR TITLE
Add CardQualifiers for StatsBomb FoulCommited event

### DIFF
--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -35,6 +35,7 @@ from kloppy.domain import (
     Point3D,
 )
 from kloppy.domain.models.event import (
+    CardQualifier,
     PassQualifier,
     PassType,
     EventType,
@@ -592,7 +593,13 @@ def _parse_bad_behaviour(bad_behaviour_dict: Dict) -> Dict:
 def _parse_foul_committed(foul_committed_dict: Dict) -> Dict:
     foul_committed = {}
     if "card" in foul_committed_dict:
-        foul_committed["card"] = _parse_card(foul_committed_dict["card"])
+        card_kwargs = _parse_card(foul_committed_dict["card"])
+        foul_committed["qualifiers"] = [
+            CardQualifier(value=card_kwargs["card_type"])
+        ]
+        foul_committed["card"] = card_kwargs
+    else:
+        foul_committed["qualifiers"] = None
 
     return foul_committed
 
@@ -953,7 +960,7 @@ class StatsBombDeserializer(EventDataDeserializer[StatsBombInputs]):
                     foul_committed_event = (
                         self.event_factory.build_foul_committed(
                             result=None,
-                            qualifiers=None,
+                            **foul_committed_kwargs,
                             **generic_event_kwargs,
                         )
                     )

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -244,6 +244,14 @@ class TestStatsBomb:
             event_types=["foul_committed"],
         )
 
+        for foul in dataset.events:
+            if foul.event_id == "382879fa-47ac-487f-801c-587f75f6a9a4":
+                assert CardType.FIRST_YELLOW in [
+                    q.value for q in foul.qualifiers
+                ]
+            else:
+                assert foul.qualifiers is None
+
         assert len(dataset.events) == 23
 
     def test_related_events(self, lineup_data: Path, event_data: Path):


### PR DESCRIPTION
This PR adds the QardQualifier attribute to FouldCommited events in the StatsBomb deserializer.