### PR TITLE
Add InterceptionEvent

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -156,6 +156,28 @@ class DuelResult(ResultType):
         return self == self.WON
 
 
+class InterceptionResult(ResultType):
+    """
+    InterceptionResult
+
+    Attributes:
+        SUCCESS (InterceptionResult): An interception that gains possession of the ball (without going out of bounds)
+        LOST (InterceptionResult): An interception by the defending team that knocked the ball to an attacker
+        OUT (InterceptionResult): An interception that knocked the ball out of bounds
+    """
+
+    SUCCESS = "SUCCESS"
+    LOST = "LOST"
+    OUT = "OUT"
+
+    @property
+    def is_success(self):
+        """
+        Returns if the interception was successful
+        """
+        return self == self.SUCCESS
+
+
 class CardType(Enum):
     """
     CardType
@@ -180,6 +202,7 @@ class EventType(Enum):
         TAKE_ON (EventType):
         CARRY (EventType):
         CLEARANCE (EventType):
+        INTERCEPTION (EventType):
         DUEL (EventType):
         SUBSTITUTION (EventType):
         CARD (EventType):
@@ -200,6 +223,7 @@ class EventType(Enum):
     TAKE_ON = "TAKE_ON"
     CARRY = "CARRY"
     CLEARANCE = "CLEARANCE"
+    INTERCEPTION = "INTERCEPTION"
     DUEL = "DUEL"
     SUBSTITUTION = "SUBSTITUTION"
     CARD = "CARD"
@@ -770,6 +794,21 @@ class CarryEvent(Event):
 
 @dataclass(repr=False)
 @docstring_inherit_attributes(Event)
+class InterceptionEvent(Event):
+    """
+    InterceptionEvent
+
+    Attributes:
+        event_type (EventType): `EventType.INTERCEPTION` (See [`EventType`][kloppy.domain.models.event.EventType])
+        event_name (str): `"interception"`
+    """
+
+    event_type: EventType = EventType.INTERCEPTION
+    event_name: str = "interception"
+
+
+@dataclass(repr=False)
+@docstring_inherit_attributes(Event)
 class ClearanceEvent(Event):
     """
     ClearanceEvent
@@ -1044,6 +1083,8 @@ __all__ = [
     "TakeOnEvent",
     "CarryEvent",
     "ClearanceEvent",
+    "InterceptionEvent",
+    "InterceptionResult",
     "SubstitutionEvent",
     "PlayerOnEvent",
     "PlayerOffEvent",

--- a/kloppy/domain/services/event_factory.py
+++ b/kloppy/domain/services/event_factory.py
@@ -12,6 +12,7 @@ from kloppy.domain import (
     MiscontrolEvent,
     CarryEvent,
     DuelEvent,
+    InterceptionEvent,
     ClearanceEvent,
     FormationChangeEvent,
     BallOutEvent,
@@ -88,6 +89,9 @@ class EventFactory:
 
     def build_carry(self, **kwargs) -> CarryEvent:
         return create_event(CarryEvent, **kwargs)
+
+    def build_interception(self, **kwargs) -> InterceptionEvent:
+        return create_event(InterceptionEvent, **kwargs)
 
     def build_clearance(self, **kwargs) -> ClearanceEvent:
         return create_event(ClearanceEvent, **kwargs)

--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 import pytz
 from lxml import objectify
+from lxml.objectify import ObjectifiedElement
 
 from kloppy.domain import (
     EventDataset,
@@ -28,6 +29,7 @@ from kloppy.domain import (
     Metadata,
     Player,
     Position,
+    InterceptionResult,
     RecoveryEvent,
     BallOutEvent,
     FoulCommittedEvent,
@@ -63,6 +65,7 @@ EVENT_TYPE_TAKE_ON = 3
 EVENT_TYPE_TACKLE = 7
 EVENT_TYPE_AERIAL = 44
 EVENT_TYPE_50_50 = 67
+EVENT_TYPE_INTERCEPTION = 8
 EVENT_TYPE_CLEARANCE = 12
 EVENT_TYPE_SHOT_MISS = 13
 EVENT_TYPE_SHOT_POST = 14
@@ -382,6 +385,27 @@ def _parse_duel(raw_qualifiers: List, type_id: int, outcome: int) -> Dict:
     )
 
 
+def _parse_interception(
+    raw_qualifiers: List, team: Team, next_event: ObjectifiedElement
+) -> Dict:
+    qualifiers = _get_event_qualifiers(raw_qualifiers)
+    result = InterceptionResult.SUCCESS
+
+    if next_event:
+        next_event_type_id = int(next_event.attrib["type_id"])
+        if next_event_type_id in BALL_OUT_EVENTS:
+            result = InterceptionResult.OUT
+        elif (next_event_type_id in BALL_OWNING_EVENTS) and (
+            next_event.attrib["team_id"] != team.team_id
+        ):
+            result = InterceptionResult.LOST
+
+    return dict(
+        result=result,
+        qualifiers=qualifiers,
+    )
+
+
 def _parse_team_players(
     f7_root, team_ref: str
 ) -> Tuple[str, Dict[str, Dict[str, str]]]:
@@ -618,7 +642,13 @@ class OptaDeserializer(EventDataDeserializer[OptaInputs]):
             ]
             possession_team = None
             events = []
-            for event_elm in game_elm.iterchildren("Event"):
+            events_list = list(game_elm.iterchildren("Event"))
+            for idx, event_elm in enumerate(events_list):
+                next_event_elm = (
+                    events_list[idx + 1]
+                    if (idx + 1) < len(events_list)
+                    else None
+                )
                 event_id = event_elm.attrib["id"]
                 type_id = int(event_elm.attrib["type_id"])
                 timestamp = _parse_f24_datetime(event_elm.attrib["timestamp"])
@@ -712,6 +742,7 @@ class OptaDeserializer(EventDataDeserializer[OptaInputs]):
                         event = self.event_factory.build_take_on(
                             **take_on_event_kwargs,
                             **generic_event_kwargs,
+                            qualifiers=None,
                         )
                     elif type_id in (
                         EVENT_TYPE_SHOT_MISS,
@@ -759,6 +790,14 @@ class OptaDeserializer(EventDataDeserializer[OptaInputs]):
                         )
                         event = self.event_factory.build_duel(
                             **duel_event_kwargs,
+                            **generic_event_kwargs,
+                        )
+                    elif type_id == EVENT_TYPE_INTERCEPTION:
+                        interception_event_kwargs = _parse_interception(
+                            raw_qualifiers, team, next_event_elm
+                        )
+                        event = self.event_factory.build_interception(
+                            **interception_event_kwargs,
                             **generic_event_kwargs,
                         )
                     elif type_id in KEEPER_EVENTS:

--- a/kloppy/infra/serializers/event/sportec/deserializer.py
+++ b/kloppy/infra/serializers/event/sportec/deserializer.py
@@ -112,7 +112,10 @@ def sportec_metadata_from_xml_elm(match_root) -> SportecMetadata:
     if not away_team:
         raise DeserializationError("Away team is missing from metadata")
 
-    (home_score, away_score,) = match_root.MatchInformation.General.attrib[
+    (
+        home_score,
+        away_score,
+    ) = match_root.MatchInformation.General.attrib[
         "Result"
     ].split(":")
     score = Score(home=int(home_score), away=int(away_score))

--- a/kloppy/infra/serializers/event/sportec/deserializer.py
+++ b/kloppy/infra/serializers/event/sportec/deserializer.py
@@ -112,10 +112,7 @@ def sportec_metadata_from_xml_elm(match_root) -> SportecMetadata:
     if not away_team:
         raise DeserializationError("Away team is missing from metadata")
 
-    (
-        home_score,
-        away_score,
-    ) = match_root.MatchInformation.General.attrib[
+    (home_score, away_score,) = match_root.MatchInformation.General.attrib[
         "Result"
     ].split(":")
     score = Score(home=int(home_score), away=int(away_score))

--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -16,6 +16,7 @@ from kloppy.domain import (
     TakeOnResult,
     CarryResult,
     DuelResult,
+    InterceptionResult,
     DuelQualifier,
     DuelType,
     Metadata,
@@ -50,6 +51,7 @@ logger = logging.getLogger(__name__)
 SB_EVENT_TYPE_RECOVERY = 2
 SB_EVENT_TYPE_DUEL = 4
 SB_EVENT_TYPE_CLEARANCE = 9
+SB_EVENT_TYPE_INTERCEPTION = 10
 SB_EVENT_TYPE_DRIBBLE = 14
 SB_EVENT_TYPE_SHOT = 16
 SB_EVENT_TYPE_GOALKEEPER_EVENT = 23
@@ -76,6 +78,8 @@ SB_PASS_OUTCOME_OUT = 75
 SB_PASS_OUTCOME_OFFSIDE = 76
 SB_PASS_OUTCOME_UNKNOWN = 77
 
+SB_PASS_TYPE_ONE_TOUCH_INTERCEPTION = 64
+
 SB_PASS_HEIGHT_GROUND = 1
 SB_PASS_HEIGHT_LOW = 2
 SB_PASS_HEIGHT_HIGH = 3
@@ -89,8 +93,17 @@ SB_SHOT_OUTCOME_OFF_WAYWARD = 101
 SB_SHOT_OUTCOME_SAVED_OFF_TARGET = 115
 SB_SHOT_OUTCOME_SAVED_TO_POST = 116
 
-SB_EVENT_TYPE_AERIAL_LOST = 10
-SB_EVENT_TYPE_TACKLE = 11
+SB_DUEL_TYPE_AERIAL_LOST = 10
+SB_DUEL_TYPE_TACKLE = 11
+
+SB_INTERCEPTION_OUTCOME_LOST = 1
+SB_INTERCEPTION_OUTCOME_WON = 4
+SB_INTERCEPTION_OUTCOME_LOST_IN_PLAY = 13
+SB_INTERCEPTION_OUTCOME_LOST_OUT = 14
+SB_INTERCEPTION_OUTCOME_SUCCESS = 15
+SB_INTERCEPTION_OUTCOME_SUCCESS_IN_PLAY = 16
+SB_INTERCEPTION_OUTCOME_SUCCESS_OUT = 17
+
 
 DUEL_WON_NAMES = [
     "Won",
@@ -466,6 +479,42 @@ def _parse_carry(carry_dict: Dict, fidelity_version: int) -> Dict:
     }
 
 
+def _parse_interception(raw_event: Dict) -> Dict:
+    event_type = raw_event["type"]["id"]
+    # Note: passes with interception qualifier, are always successful. Otherwise, interception that is LOST or OUT
+    result = InterceptionResult.SUCCESS
+
+    if event_type == SB_EVENT_TYPE_INTERCEPTION:
+        outcome = raw_event.get("interception", {}).get("outcome", {})
+        outcome_id = outcome.get("id")
+        if outcome_id in [
+            SB_INTERCEPTION_OUTCOME_LOST_OUT,
+            SB_INTERCEPTION_OUTCOME_SUCCESS_OUT,
+        ]:
+            result = InterceptionResult.OUT
+        elif outcome_id in [
+            SB_INTERCEPTION_OUTCOME_WON,
+            SB_INTERCEPTION_OUTCOME_SUCCESS,
+            SB_INTERCEPTION_OUTCOME_SUCCESS_IN_PLAY,
+        ]:
+            result = InterceptionResult.SUCCESS
+        elif outcome_id in [
+            SB_INTERCEPTION_OUTCOME_LOST,
+            SB_INTERCEPTION_OUTCOME_LOST_IN_PLAY,
+        ]:
+            result = InterceptionResult.LOST
+        else:
+            raise DeserializationError(
+                f"Unknown interception outcome: {raw_event['outcome']['name']}({outcome_id})"
+            )
+
+    qualifiers = []
+    body_part_qualifiers = _get_body_part_qualifiers(raw_event)
+    qualifiers.extend(body_part_qualifiers)
+
+    return {"result": result, "qualifiers": qualifiers}
+
+
 def _parse_clearance(raw_event: Dict, events: List) -> Dict:
     qualifiers = []
     if "related_events" in raw_event:
@@ -525,12 +574,12 @@ def _parse_duel(
     if event_type == SB_EVENT_TYPE_DUEL:
         duel_dict = raw_event.get("duel", {})
         type_id = duel_dict.get("type", {}).get("id")
-        if type_id == SB_EVENT_TYPE_AERIAL_LOST:
+        if type_id == SB_DUEL_TYPE_AERIAL_LOST:
             duel_qualifiers = [
                 DuelQualifier(value=DuelType.LOOSE_BALL),
                 DuelQualifier(value=DuelType.AERIAL),
             ]
-        elif type_id == SB_EVENT_TYPE_TACKLE:
+        elif type_id == SB_DUEL_TYPE_TACKLE:
             duel_qualifiers = [DuelQualifier(value=DuelType.GROUND)]
     elif event_type == SB_EVENT_TYPE_50_50:
         duel_dict = raw_event.get("50_50", {})
@@ -837,6 +886,20 @@ class StatsBombDeserializer(EventDataDeserializer[StatsBombInputs]):
                         **pass_event_kwargs,
                         **generic_event_kwargs,
                     )
+                    # if pass is an interception, insert interception prior to pass event
+                    if "type" in raw_event["pass"]:
+                        type_id = raw_event["pass"]["type"]["id"]
+                        if type_id == SB_PASS_TYPE_ONE_TOUCH_INTERCEPTION:
+                            interception_event_kwargs = _parse_interception(
+                                raw_event=raw_event
+                            )
+                            interception_event = (
+                                self.event_factory.build_interception(
+                                    **interception_event_kwargs,
+                                    **generic_event_kwargs,
+                                )
+                            )
+                            new_events.append(interception_event)
                     new_events.append(pass_event)
                 elif event_type == SB_EVENT_TYPE_SHOT:
                     shot_event_kwargs = _parse_shot(
@@ -847,6 +910,15 @@ class StatsBombDeserializer(EventDataDeserializer[StatsBombInputs]):
                         **generic_event_kwargs,
                     )
                     new_events.append(shot_event)
+                elif event_type == SB_EVENT_TYPE_INTERCEPTION:
+                    interception_event_kwargs = _parse_interception(
+                        raw_event=raw_event
+                    )
+                    interception_event = self.event_factory.build_interception(
+                        **interception_event_kwargs,
+                        **generic_event_kwargs,
+                    )
+                    new_events.append(interception_event)
                 elif event_type == SB_EVENT_TYPE_CLEARANCE:
                     clearance_event_kwargs = _parse_clearance(
                         raw_event=raw_event, events=events

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
@@ -15,6 +15,7 @@ from kloppy.domain import (
     GoalkeeperQualifier,
     GoalkeeperActionType,
     Ground,
+    InterceptionResult,
     Metadata,
     Orientation,
     PassQualifier,
@@ -262,6 +263,38 @@ def _parse_set_piece(raw_event: Dict, next_event: Dict) -> Dict:
     return result
 
 
+def _parse_interception(raw_event: Dict, next_event: Dict) -> Dict:
+    qualifiers = _generic_qualifiers(raw_event)
+    result = InterceptionResult.SUCCESS
+    ball_owning_events = (
+        wyscout_events.PASS.EVENT,
+        wyscout_events.SHOT.EVENT,
+    )
+
+    if next_event is not None:
+        if next_event["eventId"] == wyscout_events.INTERRUPTION.EVENT:
+            if (
+                next_event["subEventId"]
+                == wyscout_events.INTERRUPTION.BALL_OUT
+            ):
+                result = InterceptionResult.OUT
+        elif raw_event["eventId"] == wyscout_events.PASS.EVENT:
+            result = (
+                InterceptionResult.LOST
+                if _has_tag(raw_event, wyscout_tags.NOT_ACCURATE) is True
+                else InterceptionResult.SUCCESS
+            )
+        # check whether team keeps ball possession
+        elif next_event["eventId"] in ball_owning_events:
+            if raw_event["teamId"] != next_event["teamId"]:
+                result = InterceptionResult.LOST
+
+    return {
+        "result": result,
+        "qualifiers": qualifiers,
+    }
+
+
 def _parse_duel(raw_event: Dict) -> Dict:
     qualifiers = _generic_qualifiers(raw_event)
     duel_qualifiers = []
@@ -476,6 +509,24 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
                         qualifiers=qualifiers,
                         **generic_event_args,
                     )
+
+                # If also an interception event, add this before other event (It is a tag on multiple wyscout_events)
+                if _has_tag(raw_event, wyscout_tags.INTERCEPTION):
+                    interception_event_args = _parse_interception(
+                        raw_event, next_event
+                    )
+                    interception_event = self.event_factory.build_interception(
+                        **interception_event_args,
+                        **generic_event_args,
+                    )
+
+                    if event.event_type.name != "RECOVERY":
+                        events.append(
+                            transformer.transform_event(interception_event)
+                        )
+                    else:
+                        # overwrite recovery event
+                        event = interception_event
 
                 if event and self.should_include_event(event):
                     events.append(transformer.transform_event(event))

--- a/kloppy/tests/files/opta_f24.xml
+++ b/kloppy/tests/files/opta_f24.xml
@@ -287,6 +287,10 @@
       <Q id="3666298279" qualifier_id="232" />
       <Q id="3667330981" qualifier_id="389" />
     </Event>
+    <Event id="2609934569" event_id="500" type_id="8" period_id="1" min="0" sec="16" player_id="116187" team_id="2592" outcome="1" x="60.7" y="84.9" timestamp="2018-09-23T16:05:30.430" last_modified="2018-09-23T16:05:38" version="1537715138594">
+      <Q id="4615915061" qualifier_id="385" />
+      <Q id="4614449843" qualifier_id="56" value="Left" />
+    </Event>
     <Event id="2509132175" event_id="50" type_id="61" period_id="1" min="22" sec="6" player_id="460842" team_id="2592" outcome="0" x="1.3" y="81.1" timestamp="2018-09-23T17:21:01.810" last_modified="2018-09-23T17:08:02"  version="1537718881823">
       <Q id="4042410691" qualifier_id="178" />
       <Q id="4039492675" qualifier_id="56" value="Back" />

--- a/kloppy/tests/files/wyscout_events_v3.json
+++ b/kloppy/tests/files/wyscout_events_v3.json
@@ -871,6 +871,130 @@
       "infraction": null,
       "carry": null,
       "possession": null
+    },
+    {
+      "id": 1397082780,
+      "matchId": 5352624,
+      "matchPeriod": "2H",
+      "minute": 9,
+      "second": 10,
+      "matchTimestamp": "00:09:10.480",
+      "videoTimestamp": "551.480239",
+      "relatedEventId": 1397083059,
+      "type": {
+        "primary": "interception",
+        "secondary": [
+          "loss",
+          "pass",
+          "progressive_pass",
+          "short_or_medium_pass"
+        ]
+      },
+      "location": {
+        "x": 44,
+        "y": 12
+      },
+      "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+      "opponentTeam": {
+        "formation": "3-4-3",
+        "id": 3185,
+        "name": "Torino"
+      },
+      "player": {
+        "id": 99430,
+        "name": "Ł. Skorupski",
+        "position": "GK"
+      },
+      "possession": null,
+      "pass": {
+        "accurate": false,
+        "angle": 99,
+        "height": null,
+        "length": 12,
+        "recipient": {
+          "id": 644493,
+          "name": "Ł. Skorupski",
+          "position": "RCMF"
+        },
+        "endLocation": {
+          "x": 42,
+          "y": 29
+        }
+      }
+    },
+    {
+      "id": 139700000,
+      "matchId": 5352524,
+      "matchPeriod": "2H",
+      "minute": 50,
+      "second": 27,
+      "matchTimestamp": "00:50:27.129",
+      "videoTimestamp": "3070.129596",
+      "relatedEventId": 1397089017,
+      "type": {
+        "primary": "interception",
+        "secondary": [
+          "recovery"
+        ]
+      },
+      "location": {
+        "x": 9,
+        "y": 90
+      },
+      "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+      "opponentTeam": {
+        "formation": "3-4-3",
+        "id": 3185,
+        "name": "Torino"
+      },
+      "player": {
+        "id": 99430,
+        "name": "Ł. Skorupski",
+        "position": "GK"
+      },
+      "pass": null,
+      "shot": null,
+      "groundDuel": null,
+      "aerialDuel": null,
+      "infraction": null,
+      "carry": null,
+      "possession": {
+        "id": 13970000,
+        "duration": "21.63938",
+        "types": [
+          "attack"
+        ],
+        "eventsNumber": 12,
+        "eventIndex": 11,
+        "startLocation": {
+          "x": 34,
+          "y": 67
+        },
+        "endLocation": {
+          "x": 91,
+          "y": 10
+        },
+        "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+        "attack": {
+          "withShot": false,
+          "withShotOnGoal": false,
+          "withGoal": false,
+          "flank": "left",
+          "xg": 0
+        }
+      }
     }
   ],
   "formations": {

--- a/kloppy/tests/test_adapter.py
+++ b/kloppy/tests/test_adapter.py
@@ -57,4 +57,4 @@ class TestAdapter:
             # Asserts borrowed from `test_opta.py`
             assert dataset.metadata.provider == Provider.OPTA
             assert dataset.dataset_type == DatasetType.EVENT
-            assert len(dataset.events) == 29
+            assert len(dataset.events) == 30

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -376,7 +376,7 @@ class TestHelpers:
         import polars as pl
 
         c = df.select(pl.col("event_id").count())[0, 0]
-        assert c == 4041
+        assert c == 4047
 
     def test_tracking_dataset_to_polars(self):
         """

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -42,7 +42,7 @@ class TestOpta:
         )
         assert dataset.metadata.provider == Provider.OPTA
         assert dataset.dataset_type == DatasetType.EVENT
-        assert len(dataset.events) == 29
+        assert len(dataset.events) == 30
         assert len(dataset.metadata.periods) == 2
         assert (
             dataset.events[10].ball_owning_team == dataset.metadata.teams[1]
@@ -138,7 +138,10 @@ class TestOpta:
             == GoalkeeperActionType.SMOTHER
         )
         assert (
-            dataset.events[28].event_type == EventType.MISCONTROL
+            dataset.events[28].event_type == EventType.INTERCEPTION
+        )  # 2609934569
+        assert (
+            dataset.events[29].event_type == EventType.MISCONTROL
         )  # 250913217
 
         # Check counterattack

--- a/kloppy/tests/test_state_builder.py
+++ b/kloppy/tests/test_state_builder.py
@@ -29,8 +29,8 @@ class TestStateBuilder:
             events_per_score[str(score)] = len(events)
 
         assert events_per_score == {
-            "0-0": 2909,
-            "1-0": 717,
+            "0-0": 2914,
+            "1-0": 718,
             "2-0": 405,
             "3-0": 10,
         }
@@ -92,8 +92,8 @@ class TestStateBuilder:
             events_per_formation_change[str(formation)] = len(events)
 
         # inspect FormationChangeEvent usage and formation state_builder
-        assert events_per_formation_change["4-1-4-1"] == 3085
-        assert events_per_formation_change["4-4-2"] == 956
+        assert events_per_formation_change["4-1-4-1"] == 3090
+        assert events_per_formation_change["4-4-2"] == 957
 
         assert dataset.metadata.teams[0].starting_formation == FormationType(
             "4-4-2"

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -55,7 +55,7 @@ class TestStatsBomb:
 
         assert dataset.metadata.provider == Provider.STATSBOMB
         assert dataset.dataset_type == DatasetType.EVENT
-        assert len(dataset.events) == 4041
+        assert len(dataset.events) == 4047
         assert len(dataset.metadata.periods) == 2
         assert (
             dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
@@ -98,12 +98,12 @@ class TestStatsBomb:
         assert dataset.events[10].coordinates == Point(34.5, 20.5)
 
         assert (
-            dataset.events[794].get_qualifier_value(BodyPartQualifier)
+            dataset.events[796].get_qualifier_value(BodyPartQualifier)
             == BodyPart.HEAD
         )
 
         assert (
-            dataset.events[2232].get_qualifier_value(BodyPartQualifier)
+            dataset.events[2236].get_qualifier_value(BodyPartQualifier)
             == BodyPart.RIGHT_FOOT
         )
 
@@ -112,17 +112,17 @@ class TestStatsBomb:
         )
 
         assert (
-            dataset.events[1438].get_qualifier_value(PassQualifier)
+            dataset.events[1441].get_qualifier_value(PassQualifier)
             == PassType.CROSS
         )
 
         assert (
-            dataset.events[1557].get_qualifier_value(PassQualifier)
+            dataset.events[1560].get_qualifier_value(PassQualifier)
             == PassType.THROUGH_BALL
         )
 
         assert (
-            dataset.events[444].get_qualifier_value(PassQualifier)
+            dataset.events[445].get_qualifier_value(PassQualifier)
             == PassType.SWITCH_OF_PLAY
         )
 
@@ -137,45 +137,46 @@ class TestStatsBomb:
         )
 
         assert (
-            dataset.events[654].get_qualifier_value(PassQualifier)
+            dataset.events[656].get_qualifier_value(PassQualifier)
             == PassType.HEAD_PASS
         )
 
         assert (
-            dataset.events[3145].get_qualifier_value(PassQualifier)
+            dataset.events[3150].get_qualifier_value(PassQualifier)
             == PassType.HAND_PASS
         )
 
         assert (
-            dataset.events[3622].get_qualifier_value(PassQualifier)
+            dataset.events[3628].get_qualifier_value(PassQualifier)
             == PassType.ASSIST
         )
 
-        assert dataset.events[3400].get_qualifier_value(PassQualifier) is None
+        assert dataset.events[4].get_qualifier_value(PassQualifier) is None
 
         assert (
             dataset.events[194].get_qualifier_values(DuelQualifier)[1].value
             == DuelType.AERIAL
         )
         assert (
-            dataset.events[4032].get_qualifier_values(DuelQualifier)[1].value
+            dataset.events[307].get_qualifier_values(DuelQualifier)[0].value
             == DuelType.GROUND
         )
         assert dataset.events[272].event_type == EventType.CLEARANCE
         assert dataset.events[68].event_type == EventType.MISCONTROL
+        assert dataset.events[343].event_type == EventType.INTERCEPTION
 
         assert (
-            dataset.events[761].get_qualifier_value(GoalkeeperQualifier)
+            dataset.events[763].get_qualifier_value(GoalkeeperQualifier)
             == GoalkeeperActionType.SAVE
         )
 
         assert (
-            dataset.events[4039].get_qualifier_value(GoalkeeperQualifier)
+            dataset.events[4045].get_qualifier_value(GoalkeeperQualifier)
             == GoalkeeperActionType.SMOTHER
         )
 
         assert (
-            dataset.events[4040].get_qualifier_value(GoalkeeperQualifier)
+            dataset.events[4046].get_qualifier_value(GoalkeeperQualifier)
             == GoalkeeperActionType.PUNCH
         )
 

--- a/kloppy/tests/test_to_records.py
+++ b/kloppy/tests/test_to_records.py
@@ -29,7 +29,7 @@ class TestToRecords:
 
     def test_default_columns(self, dataset: EventDataset):
         records = dataset.to_records()
-        assert len(records) == 4041
+        assert len(records) == 4047
         assert list(records[0].keys()) == [
             "event_id",
             "event_type",

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -70,7 +70,7 @@ class TestWyscout:
         assert dataset.records[2].coordinates == Point(29.0, 6.0)
         assert dataset.events[11].event_type == EventType.MISCONTROL
         assert dataset.events[34].event_type == EventType.INTERCEPTION
-        assert dataset.events[144].event_type == EventType.CLEARANCE
+        assert dataset.events[143].event_type == EventType.CLEARANCE
 
         assert (
             dataset.events[39].get_qualifier_value(DuelQualifier)
@@ -81,11 +81,11 @@ class TestWyscout:
             == DuelType.AERIAL
         )
         assert (
-            dataset.events[269].get_qualifier_values(DuelQualifier)[2].value
+            dataset.events[268].get_qualifier_values(DuelQualifier)[2].value
             == DuelType.SLIDING_TACKLE
         )
         assert (
-            dataset.events[302].get_qualifier_value(GoalkeeperQualifier)
+            dataset.events[301].get_qualifier_value(GoalkeeperQualifier)
             == GoalkeeperActionType.SAVE
         )
 

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -55,6 +55,7 @@ class TestWyscout:
             == DuelType.SLIDING_TACKLE
         )
         assert dataset.events[9].event_type == EventType.CLEARANCE
+        assert dataset.events[12].event_type == EventType.INTERCEPTION
 
     def test_correct_normalized_v3_deserialization(self, event_v3_data: Path):
         dataset = wyscout.load(event_data=event_v3_data, data_version="V3")
@@ -68,7 +69,8 @@ class TestWyscout:
         )
         assert dataset.records[2].coordinates == Point(29.0, 6.0)
         assert dataset.events[11].event_type == EventType.MISCONTROL
-        assert dataset.events[137].event_type == EventType.CLEARANCE
+        assert dataset.events[34].event_type == EventType.INTERCEPTION
+        assert dataset.events[144].event_type == EventType.CLEARANCE
 
         assert (
             dataset.events[39].get_qualifier_value(DuelQualifier)
@@ -79,11 +81,11 @@ class TestWyscout:
             == DuelType.AERIAL
         )
         assert (
-            dataset.events[259].get_qualifier_values(DuelQualifier)[2].value
+            dataset.events[269].get_qualifier_values(DuelQualifier)[2].value
             == DuelType.SLIDING_TACKLE
         )
         assert (
-            dataset.events[291].get_qualifier_value(GoalkeeperQualifier)
+            dataset.events[302].get_qualifier_value(GoalkeeperQualifier)
             == GoalkeeperActionType.SAVE
         )
 


### PR DESCRIPTION
fixes #222 

Notes:
- Whenever needed (wyscout & opta), I inferred the InterceptionResult from the next event. Though, this approach might still be suboptimal.
- In WyScout v2: The orginal RecoveryEvent gets overwritten by the InterceptionEvent, whenever possible

What do you think? @probberechts  @JanVanHaaren 