### PR TITLE
Add current formation and opponent formation info to event, start with parser for Opta

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -506,6 +506,8 @@ class Event(DataRecord, ABC):
     raw_event: Dict
     state: Dict[str, Any]
     related_event_ids: List[str]
+    formation: Optional[FormationType]
+    opponent_formation: Optional[FormationType]
 
     qualifiers: List[Qualifier]
 

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -447,6 +447,10 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
                         + (raw_event["minute"] * 60)
                         - (60 * 45)
                     ),
+                    "formation": raw_event["team"]["formation"],
+                    "opponent_formation": raw_event["OpponentTeam"][
+                        "formation"
+                    ],
                 }
 
                 primary_event_type = raw_event["type"]["primary"]

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -24,7 +24,7 @@ from kloppy.domain import (
     Point3D,
 )
 
-from kloppy.domain.models.event import EventType
+from kloppy.domain.models.event import EventType, FormationType
 
 from kloppy import opta
 
@@ -161,6 +161,18 @@ class TestOpta:
         assert (
             dataset.events[8].get_qualifier_values(DuelQualifier)[1].value
             == DuelType.GROUND
+        )
+
+        # Check event formations
+        assert (
+            dataset.events[5].formation == FormationType.FOUR_FOUR_TWO
+            and dataset.events[5].opponent_formation
+            == FormationType.FOUR_THREE_THREE
+        )
+        assert (
+            dataset.events[6].formation == FormationType.FOUR_THREE_THREE
+            and dataset.events[6].opponent_formation
+            == FormationType.FOUR_FOUR_TWO
         )
 
     def test_shot(self, f7_data: str, f24_data: str):


### PR DESCRIPTION
I want to add current formation and current opponent formation information to events. This would allow us to more easily filter out events of a team or player when they were playing in a certain formation or against a certain formation. E.g. only analyse events where Lionel Messi was playing as a LW in a 4-4-2 against a 4-3-3.

