### PR TITLE
Add shot body part qualifiers for Wyscout v2

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -368,13 +368,15 @@ class BodyPart(Enum):
         RIGHT_FOOT (BodyPart): Pass or Shot with right foot, save with right foot (for goalkeepers).
         LEFT_FOOT (BodyPart): Pass or Shot with left foot, save with left foot (for goalkeepers).
         HEAD (BodyPart): Pass or Shot with head, save with head (for goalkeepers).
+        OTHER (BodyPart): Other body part (chest, back, etc.), for Pass and Shot.
+        HEAD_OTHER (BodyPart): Pass or Shot with head or other body part. Only used when the
+                               data provider does not distinguish between HEAD and OTHER.
         BOTH_HANDS (BodyPart): Goalkeeper only. Save with both hands.
         CHEST (BodyPart): Goalkeeper only. Save with chest.
         LEFT_HAND (BodyPart): Goalkeeper only. Save with left hand.
         RIGHT_HAND (BodyPart): Goalkeeper only. Save with right hand.
         DROP_KICK (BodyPart): Pass is a keeper drop kick.
         KEEPER_ARM (BodyPart): Pass thrown from keepers hands.
-        OTHER (BodyPart): Other body part (chest, back, etc.), for Pass and Shot.
         NO_TOUCH (BodyPart): Pass only. A player deliberately let the pass go past him
                              instead of receiving it to deliver to a teammate behind him.
                              (Also known as a "dummy").
@@ -383,6 +385,8 @@ class BodyPart(Enum):
     RIGHT_FOOT = "RIGHT_FOOT"
     LEFT_FOOT = "LEFT_FOOT"
     HEAD = "HEAD"
+    OTHER = "OTHER"
+    HEAD_OTHER = "HEAD_OTHER"
 
     BOTH_HANDS = "BOTH_HANDS"
     CHEST = "CHEST"
@@ -390,7 +394,7 @@ class BodyPart(Enum):
     RIGHT_HAND = "RIGHT_HAND"
     DROP_KICK = "DROP_KICK"
     KEEPER_ARM = "KEEPER_ARM"
-    OTHER = "OTHER"
+
     NO_TOUCH = "NO_TOUCH"
 
 

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
@@ -80,9 +80,22 @@ def _generic_qualifiers(raw_event: Dict) -> List[Qualifier]:
     return qualifiers
 
 
+def _bodypart_qualifiers(raw_event: Dict) -> List[Qualifier]:
+    qualifiers = []
+    if _has_tag(raw_event, wyscout_tags.LEFT_FOOT):
+        qualifiers.append(BodyPartQualifier(BodyPart.LEFT_FOOT))
+    elif _has_tag(raw_event, wyscout_tags.RIGHT_FOOT):
+        qualifiers.append(BodyPartQualifier(BodyPart.RIGHT_FOOT))
+    elif _has_tag(raw_event, wyscout_tags.HEAD_BODY):
+        qualifiers.append(BodyPartQualifier(BodyPart.HEAD_OTHER))
+    return qualifiers
+
+
 def _parse_shot(raw_event: Dict, next_event: Dict) -> Dict:
-    result = None
     qualifiers = _generic_qualifiers(raw_event)
+    qualifiers.extend(_bodypart_qualifiers(raw_event))
+
+    result = None
     if _has_tag(raw_event, 101):
         result = ShotResult.GOAL
     elif _has_tag(raw_event, 2101):
@@ -123,6 +136,7 @@ def _pass_qualifiers(raw_event) -> List[Qualifier]:
         qualifiers.append(PassQualifier(PassType.CROSS))
     elif raw_event["subEventId"] == wyscout_events.PASS.HAND:
         qualifiers.append(PassQualifier(PassType.HAND_PASS))
+        qualifiers.append(BodyPartQualifier(BodyPart.KEEPER_ARM))
     elif raw_event["subEventId"] == wyscout_events.PASS.HEAD:
         qualifiers.append(PassQualifier(PassType.HEAD_PASS))
         qualifiers.append(BodyPartQualifier(BodyPart.HEAD))
@@ -135,10 +149,9 @@ def _pass_qualifiers(raw_event) -> List[Qualifier]:
     elif raw_event["subEventId"] == wyscout_events.PASS.SMART:
         qualifiers.append(PassQualifier(PassType.SMART_PASS))
 
-    if _has_tag(raw_event, wyscout_tags.LEFT_FOOT):
-        qualifiers.append(BodyPartQualifier(BodyPart.LEFT_FOOT))
-    elif _has_tag(raw_event, wyscout_tags.RIGHT_FOOT):
-        qualifiers.append(BodyPartQualifier(BodyPart.RIGHT_FOOT))
+    # If the subevent type did not define the bodypart, we infer it from the tags
+    if not any(isinstance(q, BodyPartQualifier) for q in qualifiers):
+        qualifiers.extend(_bodypart_qualifiers(raw_event))
 
     if _has_tag(raw_event, wyscout_tags.HIGH):
         qualifiers.append(PassQualifier(PassType.HIGH_PASS))

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import pytest
 from kloppy.domain import (
+    BodyPart,
+    BodyPartQualifier,
     Point,
     SetPieceType,
     SetPieceQualifier,
@@ -80,6 +82,10 @@ class TestWyscout:
         assert (
             dataset.events[43].get_qualifier_values(DuelQualifier)[1].value
             == DuelType.AERIAL
+        )
+        assert (
+            dataset.events[118].get_qualifier_value(BodyPartQualifier)
+            == BodyPart.RIGHT_FOOT
         )
         assert (
             dataset.events[268].get_qualifier_values(DuelQualifier)[2].value


### PR DESCRIPTION
- Adds the body part qualifier for shots
- Adds a HEAD_OTHER body part since Wyscout does not distinguish between both
- Sets the body part of hand passes to KEEPER_ARM