### PR TITLE
Fix FoulComitted + Card for Wyscout v2

### DIFF
--- a/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
@@ -556,8 +556,8 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
                     )
                     new_events.append(generic_event)
 
-                # Wyscout v2 does not have a seperate event type for
-                # interceptions. Interceptions are recored by adding a tag to
+                # Wyscout v2 does not have a separate event type for
+                # interceptions. Interceptions are recorded by adding a tag to
                 # the next pass, touch or duel. Therefore, we convert events
                 # with this tag to an interception.
                 if _has_tag(raw_event, wyscout_tags.INTERCEPTION):

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Tuple, NamedTuple, IO
 from kloppy.domain import (
     BodyPart,
     BodyPartQualifier,
+    CardQualifier,
     CardType,
     CounterAttackQualifier,
     Dimension,
@@ -12,6 +13,7 @@ from kloppy.domain import (
     DuelQualifier,
     DuelType,
     EventDataset,
+    EventType,
     GoalkeeperQualifier,
     GoalkeeperActionType,
     Ground,
@@ -208,6 +210,14 @@ def _parse_goalkeeper_save(raw_event) -> List[Qualifier]:
 
 def _parse_foul(raw_event: Dict) -> Dict:
     qualifiers = _generic_qualifiers(raw_event)
+
+    if _has_tag(raw_event, wyscout_tags.RED_CARD):
+        qualifiers.append(CardQualifier(value=CardType.RED))
+    elif _has_tag(raw_event, wyscout_tags.YELLOW_CARD):
+        qualifiers.append(CardQualifier(value=CardType.FIRST_YELLOW))
+    elif _has_tag(raw_event, wyscout_tags.SECOND_YELLOW_CARD):
+        qualifiers.append(CardQualifier(value=CardType.SECOND_YELLOW))
+
     return {
         "result": None,
         "qualifiers": qualifiers,
@@ -428,39 +438,47 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
                     "timestamp": raw_event["eventSec"],
                 }
 
-                event = None
+                new_events = []
                 if raw_event["eventId"] == wyscout_events.SHOT.EVENT:
                     shot_event_args = _parse_shot(raw_event, next_event)
-                    event = self.event_factory.build_shot(
+                    shot_event = self.event_factory.build_shot(
                         **shot_event_args, **generic_event_args
                     )
+                    new_events.append(shot_event)
                 elif raw_event["eventId"] == wyscout_events.PASS.EVENT:
                     pass_event_args = _parse_pass(raw_event, next_event)
-                    event = self.event_factory.build_pass(
+                    pass_event = self.event_factory.build_pass(
                         **pass_event_args, **generic_event_args
                     )
+                    new_events.append(pass_event)
                 elif raw_event["eventId"] == wyscout_events.FOUL.EVENT:
                     foul_event_args = _parse_foul(raw_event)
-                    event = self.event_factory.build_foul_committed(
+                    foul_event = self.event_factory.build_foul_committed(
                         **foul_event_args, **generic_event_args
                     )
+                    new_events.append(foul_event)
                     if any(
                         (_has_tag(raw_event, tag) for tag in wyscout_tags.CARD)
                     ):
                         card_event_args = _parse_card(raw_event)
-                        event = self.event_factory.build_card(
+                        card_event = self.event_factory.build_card(
                             **card_event_args, **generic_event_args
                         )
+                        new_events.append(card_event)
                 elif raw_event["eventId"] == wyscout_events.INTERRUPTION.EVENT:
                     ball_out_event_args = _parse_ball_out(raw_event)
-                    event = self.event_factory.build_ball_out(
+                    ball_out_event = self.event_factory.build_ball_out(
                         **ball_out_event_args, **generic_event_args
                     )
+                    new_events.append(ball_out_event)
                 elif raw_event["eventId"] == wyscout_events.SAVE.EVENT:
                     goalkeeper_save_args = _parse_goalkeeper_save(raw_event)
-                    event = self.event_factory.build_goalkeeper_event(
-                        **goalkeeper_save_args, **generic_event_args
+                    goalkeeper_save_event = (
+                        self.event_factory.build_goalkeeper_event(
+                            **goalkeeper_save_args, **generic_event_args
+                        )
                     )
+                    new_events.append(goalkeeper_save_event)
                 elif raw_event["eventId"] == wyscout_events.FREE_KICK.EVENT:
                     set_piece_event_args = _parse_set_piece(
                         raw_event, next_event
@@ -469,16 +487,18 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
                         raw_event["subEventId"]
                         in wyscout_events.FREE_KICK.PASS_TYPES
                     ):
-                        event = self.event_factory.build_pass(
+                        fk_pass_event = self.event_factory.build_pass(
                             **set_piece_event_args, **generic_event_args
                         )
+                        new_events.append(fk_pass_event)
                     elif (
                         raw_event["subEventId"]
                         in wyscout_events.FREE_KICK.SHOT_TYPES
                     ):
-                        event = self.event_factory.build_shot(
+                        fk_shot_event = self.event_factory.build_shot(
                             **set_piece_event_args, **generic_event_args
                         )
+                        new_events.append(fk_shot_event)
 
                 elif (
                     raw_event["eventId"] == wyscout_events.OTHERS_ON_BALL.EVENT
@@ -488,10 +508,11 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
                         == wyscout_events.OTHERS_ON_BALL.CLEARANCE
                     ):
                         clearance_event_args = _parse_clearance(raw_event)
-                        event = self.event_factory.build_clearance(
+                        clearance_event = self.event_factory.build_clearance(
                             **clearance_event_args,
                             **generic_event_args,
                         )
+                        new_events.append(clearance_event)
                     elif (
                         raw_event["subEventId"]
                         == wyscout_events.OTHERS_ON_BALL.TOUCH
@@ -500,34 +521,40 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
                             "result": None,
                             "qualifiers": _generic_qualifiers(raw_event),
                         }
-                        event = self.event_factory.build_miscontrol(
+                        miscontrol_event = self.event_factory.build_miscontrol(
                             **miscontrol_event_args,
                             **generic_event_args,
                         )
+                        new_events.append(miscontrol_event)
                     else:
                         recovery_event_args = _parse_recovery(raw_event)
-                        event = self.event_factory.build_recovery(
+                        recovery_event = self.event_factory.build_recovery(
                             **recovery_event_args, **generic_event_args
                         )
+                        new_events.append(recovery_event)
                 elif raw_event["eventId"] == wyscout_events.DUEL.EVENT:
                     duel_event_args = _parse_duel(raw_event)
-                    event = self.event_factory.build_duel(
+                    duel_event = self.event_factory.build_duel(
                         **duel_event_args, **generic_event_args
                     )
+                    new_events.append(duel_event)
                 elif raw_event["eventId"] not in [
                     wyscout_events.SAVE.EVENT,
                     wyscout_events.OFFSIDE.EVENT,
                 ]:
                     # The events SAVE and OFFSIDE are already merged with PASS and SHOT events
                     qualifiers = _generic_qualifiers(raw_event)
-                    event = self.event_factory.build_generic(
+                    generic_event = self.event_factory.build_generic(
                         result=None,
                         qualifiers=qualifiers,
                         **generic_event_args,
                     )
+                    new_events.append(generic_event)
 
-                # Since Interception is not an event in wyscout v2 but a tag for pass, touch and duel. Therefore,
-                # we convert those duels and touch events to an interception. And insert interception before passes.
+                # Wyscout v2 does not have a seperate event type for
+                # interceptions. Interceptions are recored by adding a tag to
+                # the next pass, touch or duel. Therefore, we convert events
+                # with this tag to an interception.
                 if _has_tag(raw_event, wyscout_tags.INTERCEPTION):
                     interception_event_args = _parse_interception(
                         raw_event, next_event
@@ -537,19 +564,29 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
                         **generic_event_args,
                     )
 
-                    if event.event_type.name == "DUEL":
-                        # when DuelEvent is interception, we need to overwrite this and the previous DuelEvent
-                        events = events[:-1]
-                        event = interception_event
-                    elif event.event_name in ["recovery", "miscontrol"]:
-                        event = interception_event
-                    elif event.event_name in ["pass", "clearance"]:
-                        events.append(
-                            transformer.transform_event(interception_event)
-                        )
+                    for i, new_event in enumerate(list(new_events)):
+                        if new_event.event_type == EventType.DUEL:
+                            # when DuelEvent is interception, we need to
+                            # overwrite this and the previous DuelEvent
+                            events = events[:-1]
+                            new_events[i] = interception_event
+                        elif new_event.event_type in [
+                            EventType.RECOVERY,
+                            EventType.MISCONTROL,
+                        ]:
+                            # replace touch events
+                            new_events[i] = interception_event
+                        elif new_event.event_type in [
+                            EventType.PASS,
+                            EventType.CLEARANCE,
+                        ]:
+                            # insert an interception event before interception passes
+                            new_events.insert(i, interception_event)
 
-                if event and self.should_include_event(event):
-                    events.append(transformer.transform_event(event))
+                for new_event in new_events:
+                    if self.should_include_event(new_event):
+                        events.append(transformer.transform_event(new_event))
+                new_events = []
 
         metadata = Metadata(
             teams=[home_team, away_team],

--- a/kloppy/tests/conftest.py
+++ b/kloppy/tests/conftest.py
@@ -5,6 +5,6 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def base_dir() -> Path:
     return Path(__file__).parent

--- a/kloppy/tests/files/wyscout_events_v3.json
+++ b/kloppy/tests/files/wyscout_events_v3.json
@@ -590,7 +590,7 @@
       "videoTimestamp": "8.148438"
     },
     {
-      "id": 663291840,
+      "id": 663291841,
       "type": {
         "primary": "duel",
         "secondary": [
@@ -662,7 +662,7 @@
       "videoTimestamp": "8.148438"
     },
     {
-      "id": 663291840,
+      "id": 663291842,
       "type": {
         "primary": "duel",
         "secondary": [
@@ -724,7 +724,7 @@
       "videoTimestamp": "8.148438"
     },
     {
-        "id": 663291842,
+        "id": 663291843,
         "minute": 0,
         "matchId": 2852835,
         "matchPeriod": "1H",

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -55,7 +55,6 @@ class TestWyscoutV2:
     def test_miscontrol_event(self, dataset: EventDataset):
         miscontrol_event = dataset.get_event_by_id("190078351")
         assert miscontrol_event.event_type == EventType.MISCONTROL
-        assert dataset.events[11].event_type == EventType.MISCONTROL
 
     def test_interception_event(self, dataset: EventDataset):
         # A touch or duel with "interception" tag should be converted to an interception event

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -86,7 +86,7 @@ class TestWyscout:
             == DuelType.SLIDING_TACKLE
         )
         assert (
-            dataset.events[301].get_qualifier_value(GoalkeeperQualifier)
+            dataset.events[302].get_qualifier_value(GoalkeeperQualifier)
             == GoalkeeperActionType.SAVE
         )
 

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -76,15 +76,13 @@ class TestWyscoutV2:
         aerial_duel_event = dataset.get_event_by_id("190078381")
         assert aerial_duel_event.event_type == EventType.DUEL
         assert (
-            aerial_duel_event.get_qualifier_values(DuelQualifier)[1].value
+            aerial_duel_event.get_qualifier_values(DuelQualifier)[1]
             == DuelType.AERIAL
         )
         sliding_tackle_duel_event = dataset.get_event_by_id("190079260")
         assert sliding_tackle_duel_event.event_type == EventType.DUEL
         assert (
-            sliding_tackle_duel_event.get_qualifier_values(DuelQualifier)[
-                2
-            ].value
+            sliding_tackle_duel_event.get_qualifier_values(DuelQualifier)[2]
             == DuelType.SLIDING_TACKLE
         )
 

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -3,93 +3,186 @@ from pathlib import Path
 import pytest
 from kloppy.domain import (
     Point,
+    EventDataset,
     SetPieceType,
     SetPieceQualifier,
+    DatasetType,
     DuelQualifier,
     DuelType,
     EventType,
     GoalkeeperQualifier,
     GoalkeeperActionType,
+    CardQualifier,
+    CardType,
 )
 
 from kloppy import wyscout
 
 
-class TestWyscout:
-    """"""
+@pytest.fixture(scope="session")
+def event_v2_data(base_dir: Path) -> Path:
+    return base_dir / "files" / "wyscout_events_v2.json"
 
-    @pytest.fixture
-    def event_v3_data(self, base_dir):
-        return base_dir / "files/wyscout_events_v3.json"
 
-    @pytest.fixture
-    def event_v2_data(self, base_dir):
-        return base_dir / "files/wyscout_events_v2.json"
+@pytest.fixture(scope="session")
+def event_v3_data(base_dir: Path) -> Path:
+    return base_dir / "files" / "wyscout_events_v3.json"
 
-    def test_correct_v3_deserialization(self, event_v3_data: Path):
-        dataset = wyscout.load(
-            event_data=event_v3_data,
-            coordinates="wyscout",
-            data_version="V3",
-        )
-        assert dataset.records[2].coordinates == Point(36.0, 78.0)
-        assert (
-            dataset.events[10].get_qualifier_value(GoalkeeperQualifier)
-            == GoalkeeperActionType.SAVE
-        )
-        assert (
-            dataset.events[4].get_qualifier_value(SetPieceQualifier)
-            == SetPieceType.CORNER_KICK
-        )
-        assert dataset.events[5].event_type == EventType.FOUL_COMMITTED
-        assert (
-            dataset.events[6].get_qualifier_value(DuelQualifier)
-            == DuelType.GROUND
-        )
-        assert (
-            dataset.events[7].get_qualifier_values(DuelQualifier)[1].value
-            == DuelType.AERIAL
-        )
-        assert (
-            dataset.events[8].get_qualifier_values(DuelQualifier)[2].value
-            == DuelType.SLIDING_TACKLE
-        )
-        assert dataset.events[9].event_type == EventType.CLEARANCE
-        assert dataset.events[12].event_type == EventType.INTERCEPTION
-        assert dataset.events[14].event_type == EventType.TAKE_ON
 
-    def test_correct_normalized_v3_deserialization(self, event_v3_data: Path):
-        dataset = wyscout.load(event_data=event_v3_data, data_version="V3")
-        assert dataset.records[2].coordinates == Point(0.36, 0.78)
+def test_correct_auto_recognize_deserialization(
+    event_v2_data: Path, event_v3_data: Path
+):
+    dataset = wyscout.load(event_data=event_v2_data, coordinates="wyscout")
+    assert dataset.records[2].coordinates == Point(29.0, 6.0)
+    dataset = wyscout.load(event_data=event_v3_data, coordinates="wyscout")
+    assert dataset.records[2].coordinates == Point(36.0, 78.0)
 
-    def test_correct_v2_deserialization(self, event_v2_data: Path):
+
+class TestWyscoutV2:
+    """Tests related to deserialization of Wyscout V2 data."""
+
+    @pytest.fixture(scope="class")
+    def dataset(self, event_v2_data) -> EventDataset:
+        """Load Wyscout V2 event dataset"""
         dataset = wyscout.load(
             event_data=event_v2_data,
             coordinates="wyscout",
             data_version="V2",
         )
-        assert dataset.records[2].coordinates == Point(29.0, 6.0)
-        assert dataset.events[11].event_type == EventType.MISCONTROL
-        assert dataset.events[34].event_type == EventType.INTERCEPTION
-        assert dataset.events[143].event_type == EventType.CLEARANCE
+        assert dataset.dataset_type == DatasetType.EVENT
+        return dataset
 
+    def test_miscontrol_event(self, dataset: EventDataset):
+        miscontrol_event = dataset.get_event_by_id("190078351")
+        assert miscontrol_event.event_type == EventType.MISCONTROL
+        assert dataset.events[11].event_type == EventType.MISCONTROL
+
+    def test_interception_event(self, dataset: EventDataset):
+        # A touch or duel with "interception" tag should be converted to an interception event
+        interception_event = dataset.get_event_by_id("190079090")
+        assert interception_event.event_type == EventType.INTERCEPTION
+        # Other events with "interception" tag should be split in two events
+        clearance_event = dataset.get_event_by_id("190079171")
+        assert clearance_event.event_type == EventType.CLEARANCE
+        interception_event = dataset.get_event_by_id("interception-190079171")
+        assert interception_event.event_type == EventType.INTERCEPTION
+
+    def test_duel_event(self, dataset: EventDataset):
+        ground_duel_event = dataset.get_event_by_id("190078379")
+        assert ground_duel_event.event_type == EventType.DUEL
         assert (
-            dataset.events[39].get_qualifier_value(DuelQualifier)
+            ground_duel_event.get_qualifier_value(DuelQualifier)
             == DuelType.GROUND
         )
+        aerial_duel_event = dataset.get_event_by_id("190078381")
+        assert aerial_duel_event.event_type == EventType.DUEL
         assert (
-            dataset.events[43].get_qualifier_values(DuelQualifier)[1].value
+            aerial_duel_event.get_qualifier_values(DuelQualifier)[1].value
             == DuelType.AERIAL
         )
+        sliding_tackle_duel_event = dataset.get_event_by_id("190079260")
+        assert sliding_tackle_duel_event.event_type == EventType.DUEL
         assert (
-            dataset.events[268].get_qualifier_values(DuelQualifier)[2].value
+            sliding_tackle_duel_event.get_qualifier_values(DuelQualifier)[
+                2
+            ].value
             == DuelType.SLIDING_TACKLE
         )
+
+    def test_goalkeeper_event(self, dataset: EventDataset):
+        goalkeeper_event = dataset.get_event_by_id("190079010")
+        assert goalkeeper_event.event_type == EventType.GOALKEEPER
         assert (
-            dataset.events[302].get_qualifier_value(GoalkeeperQualifier)
+            goalkeeper_event.get_qualifier_value(GoalkeeperQualifier)
             == GoalkeeperActionType.SAVE
         )
 
-    def test_correct_auto_recognize_deserialization(self, event_v2_data: Path):
-        dataset = wyscout.load(event_data=event_v2_data, coordinates="wyscout")
-        assert dataset.records[2].coordinates == Point(29.0, 6.0)
+    def test_foul_committed_event(self, dataset: EventDataset):
+        foul_committed_event = dataset.get_event_by_id("190079289")
+        assert foul_committed_event.event_type == EventType.FOUL_COMMITTED
+        assert (
+            foul_committed_event.get_qualifier_value(CardQualifier)
+            == CardType.FIRST_YELLOW
+        )
+        card_event = dataset.get_event_by_id("card-190079289")
+        assert card_event.event_type == EventType.CARD
+
+    def test_correct_normalized_deserialization(self, event_v2_data: Path):
+        dataset = wyscout.load(event_data=event_v2_data, data_version="V2")
+        assert dataset.records[2].coordinates == Point(0.29, 0.06)
+
+
+class TestWyscoutV3:
+    """Tests related to deserialization of Wyscout V3 data."""
+
+    @pytest.fixture(scope="class")
+    def dataset(self, event_v3_data: Path) -> EventDataset:
+        """Load Wyscout V3 event dataset"""
+        dataset = wyscout.load(
+            event_data=event_v3_data,
+            coordinates="wyscout",
+            data_version="V3",
+        )
+        assert dataset.dataset_type == DatasetType.EVENT
+        return dataset
+
+    def test_coordinates(self, dataset: EventDataset):
+        assert dataset.records[2].coordinates == Point(36.0, 78.0)
+
+    def test_normalized_deserialization(self, event_v3_data: Path):
+        dataset = wyscout.load(event_data=event_v3_data, data_version="V3")
+        assert dataset.records[2].coordinates == Point(0.36, 0.78)
+
+    def test_goalkeeper_event(self, dataset: EventDataset):
+        goalkeeper_event = dataset.get_event_by_id(1331979498)
+        assert goalkeeper_event.event_type == EventType.GOALKEEPER
+        assert (
+            goalkeeper_event.get_qualifier_value(GoalkeeperQualifier)
+            == GoalkeeperActionType.SAVE
+        )
+
+    def test_shot_event(self, dataset: EventDataset):
+        shot_event = dataset.get_event_by_id(663291840)
+        assert shot_event.event_type == EventType.SHOT
+        assert (
+            shot_event.get_qualifier_value(SetPieceQualifier)
+            == SetPieceType.CORNER_KICK
+        )
+
+    def test_foul_committed_event(self, dataset: EventDataset):
+        foul_committed_event = dataset.get_event_by_id(1343788476)
+        assert foul_committed_event.event_type == EventType.FOUL_COMMITTED
+
+    def test_duel_event(self, dataset: EventDataset):
+        ground_duel_event = dataset.get_event_by_id(663291421)
+        assert ground_duel_event.event_type == EventType.DUEL
+        assert (
+            ground_duel_event.get_qualifier_value(DuelQualifier)
+            == DuelType.GROUND
+        )
+        aerial_duel_event = dataset.get_event_by_id(663291841)
+        assert aerial_duel_event.event_type == EventType.DUEL
+        assert (
+            aerial_duel_event.get_qualifier_values(DuelQualifier)[1].value
+            == DuelType.AERIAL
+        )
+        sliding_tackle_duel_event = dataset.get_event_by_id(663291842)
+        assert sliding_tackle_duel_event.event_type == EventType.DUEL
+        assert (
+            sliding_tackle_duel_event.get_qualifier_values(DuelQualifier)[
+                2
+            ].value
+            == DuelType.SLIDING_TACKLE
+        )
+
+    def test_clearance_event(self, dataset: EventDataset):
+        clearance_event = dataset.get_event_by_id(663291843)
+        assert clearance_event.event_type == EventType.CLEARANCE
+
+    def test_interception_event(self, dataset: EventDataset):
+        interception_event = dataset.get_event_by_id(1397082780)
+        assert interception_event.event_type == EventType.INTERCEPTION
+
+    def test_take_on_event(self, dataset: EventDataset):
+        take_on_event = dataset.get_event_by_id(139800000)
+        assert take_on_event.event_type == EventType.TAKE_ON

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -168,9 +168,7 @@ class TestWyscoutV3:
         sliding_tackle_duel_event = dataset.get_event_by_id(663291842)
         assert sliding_tackle_duel_event.event_type == EventType.DUEL
         assert (
-            sliding_tackle_duel_event.get_qualifier_values(DuelQualifier)[
-                2
-            ]
+            sliding_tackle_duel_event.get_qualifier_values(DuelQualifier)[2]
             == DuelType.SLIDING_TACKLE
         )
 

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -54,6 +54,13 @@ class TestWyscoutV2:
         assert dataset.dataset_type == DatasetType.EVENT
         return dataset
 
+    def test_shot_event(self, dataset: EventDataset):
+        shot_event = dataset.get_event_by_id("190079151")
+        assert (
+            shot_event.get_qualifier_value(BodyPartQualifier)
+            == BodyPart.RIGHT_FOOT
+        )
+
     def test_miscontrol_event(self, dataset: EventDataset):
         miscontrol_event = dataset.get_event_by_id("190078351")
         assert miscontrol_event.event_type == EventType.MISCONTROL
@@ -169,11 +176,6 @@ class TestWyscoutV3:
         assert sliding_tackle_duel_event.event_type == EventType.DUEL
         assert (
             sliding_tackle_duel_event.get_qualifier_values(DuelQualifier)[2]
-            dataset.events[118].get_qualifier_value(BodyPartQualifier)
-            == BodyPart.RIGHT_FOOT
-        )
-        assert (
-            dataset.events[268].get_qualifier_values(DuelQualifier)[2]
             == DuelType.SLIDING_TACKLE
         )
 


### PR DESCRIPTION
- No FoulComitted event was recorded when a card was given. To be consistent with the other data providers both a FoulCommittedEvent and CardEvent are recorded now.
- Adds CardQualifiers to the FoulCommittedEvent.