### PR TITLE
Remove duplicate Metrica set-piece events

### DIFF
--- a/kloppy/tests/conftest.py
+++ b/kloppy/tests/conftest.py
@@ -5,6 +5,6 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def base_dir() -> Path:
     return Path(__file__).parent

--- a/kloppy/tests/test_metrica_events.py
+++ b/kloppy/tests/test_metrica_events.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 
 from kloppy import metrica
@@ -8,32 +9,36 @@ from kloppy.domain import (
     AttackingDirection,
     SetPieceType,
     BodyPart,
+    EventDataset,
+    Point,
+    SetPieceQualifier,
+    BodyPartQualifier,
 )
 from kloppy.domain.models.common import DatasetType
 
 
 class TestMetricaEvents:
-    @pytest.fixture
-    def meta_data(self, base_dir) -> str:
-        return base_dir / "files/epts_metrica_metadata.xml"
+    """Tests related to deserialization of Metrica JSON events."""
 
-    @pytest.fixture
-    def event_data(self, base_dir) -> str:
-        return base_dir / "files/metrica_events.json"
-
-    def test_correct_deserialization(self, event_data: str, meta_data: str):
+    @pytest.fixture(scope="class")
+    def dataset(self, base_dir: Path) -> EventDataset:
+        """Load a Metrica event dataset."""
         dataset = metrica.load_event(
-            event_data=event_data, meta_data=meta_data
+            # FIXME: these files represent different matches
+            event_data=base_dir / "files" / "metrica_events.json",
+            meta_data=base_dir / "files" / "epts_metrica_metadata.xml",
         )
-
-        assert dataset.metadata.provider == Provider.METRICA
         assert dataset.dataset_type == DatasetType.EVENT
-        assert len(dataset.events) == 3684
+        assert len(dataset.events) == 3594
+        return dataset
+
+    def test_metadata(self, dataset: EventDataset):
+        """It should parse the metadata correctly."""
+        assert dataset.metadata.provider == Provider.METRICA
         assert len(dataset.metadata.periods) == 2
         assert dataset.metadata.orientation is Orientation.HOME_TEAM
         assert dataset.metadata.teams[0].name == "Team A"
         assert dataset.metadata.teams[1].name == "Team B"
-
         player = dataset.metadata.teams[0].players[10]
         assert player.player_id == "Track_11"
         assert player.jersey_no == 11
@@ -53,8 +58,34 @@ class TestMetricaEvents:
             attacking_direction=AttackingDirection.NOT_SET,
         )
 
-        assert dataset.events[1].coordinates.x == 0.50125
+    def test_coordinates(self, dataset: EventDataset):
+        """It should parse the coordinates of events correctly."""
+        assert dataset.events[0].coordinates == Point(x=0.50125, y=0.48725)
 
-        # Check the qualifiers
-        assert dataset.records[1].qualifiers[0].value == SetPieceType.KICK_OFF
-        assert dataset.records[100].qualifiers[0].value == BodyPart.HEAD
+    def test_body_part_qualifiers(self, dataset: EventDataset):
+        """It should add body part qualifiers to the event."""
+        # The body part qualifier should be set for headers
+        header = dataset.get_event_by_id("99")
+        assert header.get_qualifier_value(BodyPartQualifier) == BodyPart.HEAD
+        # It should be None (i.e., unknown) for events that are not headers
+        foot = dataset.get_event_by_id("2")
+        assert foot.get_qualifier_value(BodyPartQualifier) is None
+
+    def test_set_piece(self, dataset: EventDataset):
+        """It should integrate set piece events in the next event."""
+        # The next event can be a pass
+        kick_off_event = dataset.get_event_by_id("1")
+        assert kick_off_event is None
+        pass_after_kick_off = dataset.get_event_by_id("2")
+        assert (
+            pass_after_kick_off.get_qualifier_value(SetPieceQualifier)
+            == SetPieceType.KICK_OFF
+        )
+        # or a shot
+        free_kick_event = dataset.get_event_by_id("130")
+        assert free_kick_event is None
+        shot_after_free_kick = dataset.get_event_by_id("131")
+        assert (
+            shot_after_free_kick.get_qualifier_value(SetPieceQualifier)
+            == SetPieceType.FREE_KICK
+        )


### PR DESCRIPTION
Metrica encodes set-pieces as two events. The first event defines the set-piece type (e.g., kick-off) and the second event defines the action type (e.g., pass). In Kloppy, these two events should be integrated in a single event.

Furthermore, I few small fixes and some refactoring:
- Fixes a few type annotations
- Removes unused imports
- Refactor unit tests
- Metrica does not define an event id. The `index` is now used as the event id.
- The `previous_event`  variable wrapped around to the last event of the dataset, which could cause unexpected behavior.