### PR TITLE
Fix Wyscout orientation

### DIFF
--- a/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
@@ -712,7 +712,7 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
             pitch_dimensions=transformer.get_to_coordinate_system().pitch_dimensions,
             score=None,
             frame_rate=None,
-            orientation=Orientation.BALL_OWNING_TEAM,
+            orientation=Orientation.ACTION_EXECUTING_TEAM,
             flags=None,
             provider=Provider.WYSCOUT,
             coordinate_system=transformer.get_to_coordinate_system(),

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -684,7 +684,7 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
             pitch_dimensions=transformer.get_to_coordinate_system().pitch_dimensions,
             score=None,
             frame_rate=None,
-            orientation=Orientation.BALL_OWNING_TEAM,
+            orientation=Orientation.ACTION_EXECUTING_TEAM,
             flags=None,
             provider=Provider.WYSCOUT,
             coordinate_system=transformer.get_to_coordinate_system(),

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -16,6 +16,7 @@ from kloppy.domain import (
     GoalkeeperActionType,
     CardQualifier,
     CardType,
+    Orientation,
 )
 
 from kloppy import wyscout
@@ -52,6 +53,9 @@ class TestWyscoutV2:
             data_version="V2",
         )
         assert dataset.dataset_type == DatasetType.EVENT
+        assert (
+            dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
+        )
         return dataset
 
     def test_shot_event(self, dataset: EventDataset):
@@ -130,6 +134,9 @@ class TestWyscoutV3:
             data_version="V3",
         )
         assert dataset.dataset_type == DatasetType.EVENT
+        assert (
+            dataset.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
+        )
         return dataset
 
     def test_coordinates(self, dataset: EventDataset):


### PR DESCRIPTION
Wyscout v2 and v3 have` ACTION_EXECUTING_TEAM` as orientation. See issue https://github.com/PySport/kloppy/issues/236 for context.
