### PR TITLE
Add dribbled past duel type

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -473,6 +473,7 @@ class DuelType(Enum):
     LOOSE_BALL = "LOOSE_BALL"
     SLIDING_TACKLE = "SLIDING_TACKLE"
     TACKLE = "TACKLE"
+    DRIBBLED_PAST = "DRIBBLED_PAST"
 
 
 @dataclass

--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -57,7 +57,9 @@ EVENT_TYPE_OFFSIDE_PASS = 2
 EVENT_TYPE_TAKE_ON = 3
 EVENT_TYPE_TACKLE = 7
 EVENT_TYPE_AERIAL = 44
+EVENT_TYPE_CHALLENGE = 45
 EVENT_TYPE_50_50 = 67
+EVENT_TYPE_ATTEMPTED_TACKLE = 83
 EVENT_TYPE_INTERCEPTION = 8
 EVENT_TYPE_CLEARANCE = 12
 EVENT_TYPE_SHOT_MISS = 13
@@ -91,6 +93,8 @@ DUEL_EVENTS = [
     EVENT_TYPE_TACKLE,
     EVENT_TYPE_AERIAL,
     EVENT_TYPE_50_50,
+    EVENT_TYPE_CHALLENGE,
+    EVENT_TYPE_ATTEMPTED_TACKLE,
 ]
 
 BALL_OWNING_EVENTS = (
@@ -403,8 +407,13 @@ def _parse_duel(
     raw_qualifiers: Dict[int, str], type_id: int, outcome: int
 ) -> Dict:
     qualifiers = _get_event_qualifiers(raw_qualifiers)
-    if type_id == EVENT_TYPE_TACKLE:
-        qualifiers.extend([DuelQualifier(value=DuelType.GROUND)])
+    if type_id in [EVENT_TYPE_TACKLE, EVENT_TYPE_ATTEMPTED_TACKLE]:
+        qualifiers.extend(
+            [
+                DuelQualifier(value=DuelType.GROUND),
+                DuelQualifier(value=DuelType.TACKLE),
+            ]
+        )
     elif type_id == EVENT_TYPE_AERIAL:
         qualifiers.extend(
             [
@@ -417,6 +426,14 @@ def _parse_duel(
             [
                 DuelQualifier(value=DuelType.LOOSE_BALL),
                 DuelQualifier(value=DuelType.GROUND),
+            ]
+        )
+
+    elif type_id == EVENT_TYPE_CHALLENGE:
+        qualifiers.extend(
+            [
+                DuelQualifier(value=DuelType.GROUND),
+                DuelQualifier(value=DuelType.DRIBBLED_PAST),
             ]
         )
 

--- a/kloppy/infra/serializers/event/statsbomb/specification.py
+++ b/kloppy/infra/serializers/event/statsbomb/specification.py
@@ -697,6 +697,26 @@ class DRIBBLE(EVENT):
         return [take_on_event]
 
 
+class DRIBBLED_PAST(EVENT):
+    """StatsBomb 39/Dribbled Past event."""
+
+    def _create_events(
+        self, event_factory: EventFactory, **generic_event_kwargs
+    ) -> List[Event]:
+        duel_result = DuelResult.LOST
+        duel_qualifiers = [
+            DuelQualifier(value=DuelType.GROUND),
+            DuelQualifier(value=DuelType.DRIBBLED_PAST),
+        ]
+        dribbled_past_event = event_factory.build_duel(
+            result=duel_result,
+            qualifiers=duel_qualifiers,
+            **generic_event_kwargs,
+        )
+
+        return [dribbled_past_event]
+
+
 class CARRY(EVENT):
     """StatsBomb 43/Carry event."""
 
@@ -748,7 +768,10 @@ class DUEL(EVENT):
                 DuelQualifier(value=DuelType.AERIAL),
             ]
         elif type_id == DUEL.TYPE.TACKLE:
-            duel_qualifiers = [DuelQualifier(value=DuelType.GROUND)]
+            duel_qualifiers = [
+                DuelQualifier(value=DuelType.GROUND),
+                DuelQualifier(value=DuelType.TACKLE),
+            ]
 
         # Get duel result
         duel_won_outcomes = [
@@ -1272,6 +1295,7 @@ def event_decoder(raw_event: Dict) -> Union[EVENT, Dict]:
         EVENT_TYPE.CARRY: CARRY,
         EVENT_TYPE.DUEL: DUEL,
         EVENT_TYPE.FIFTY_FIFTY: FIFTY_FIFTY,
+        EVENT_TYPE.DRIBBLED_PAST: DRIBBLED_PAST,
         EVENT_TYPE.GOALKEEPER: GOALKEEPER,
         EVENT_TYPE.SUBSTITUTION: SUBSTITUTION,
         EVENT_TYPE.BAD_BEHAVIOUR: BAD_BEHAVIOUR,

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -829,8 +829,8 @@ class TestStatsBombDuelEvent:
         """It should deserialize all duel and 50/50 events"""
         events = dataset.find_all("duel")
         assert (
-            len(events) == 59 + 4 + 26
-        )  # duels + 50/50 + aerial won attribute
+            len(events) == 59 + 4 + 26 + 22
+        )  # duels + 50/50 + aerial won attribute + dribbled past
 
     def test_attributes(self, dataset: EventDataset):
         """Verify specific attributes of duels"""
@@ -838,7 +838,10 @@ class TestStatsBombDuelEvent:
         # A duel should have a result
         assert duel.result == DuelResult.WON
         # A duel should have a duel type
-        assert duel.get_qualifier_values(DuelQualifier) == [DuelType.GROUND]
+        assert duel.get_qualifier_values(DuelQualifier) == [
+            DuelType.GROUND,
+            DuelType.TACKLE,
+        ]
         # A duel does not have a body part
         assert duel.get_qualifier_value(BodyPartQualifier) is None
 
@@ -853,7 +856,10 @@ class TestStatsBombDuelEvent:
     def test_tackle_qualfiers(self, dataset: EventDataset):
         """It should add ground duel qualifiers"""
         duel = dataset.get_event_by_id("15c4bfaa-36fd-4b3e-bec1-bc8bcc1febb9")
-        assert duel.get_qualifier_values(DuelQualifier) == [DuelType.GROUND]
+        assert duel.get_qualifier_values(DuelQualifier) == [
+            DuelType.GROUND,
+            DuelType.TACKLE,
+        ]
 
     def test_loose_ground_duel_qualfiers(self, dataset: EventDataset):
         """It should add ground duel + loose ball qualifiers"""
@@ -861,6 +867,14 @@ class TestStatsBombDuelEvent:
         assert duel.get_qualifier_values(DuelQualifier) == [
             DuelType.LOOSE_BALL,
             DuelType.GROUND,
+        ]
+
+    def test_dribbled_past_qualifiers(self, dataset: EventDataset):
+        """It should add ground  + dribbled past qualifiers"""
+        duel = dataset.get_event_by_id("ebf42396-6fc0-4700-9618-32b24df33bf3")
+        assert duel.get_qualifier_values(DuelQualifier) == [
+            DuelType.GROUND,
+            DuelType.DRIBBLED_PAST,
         ]
 
 


### PR DESCRIPTION
PR related to https://github.com/PySport/kloppy/issues/257.

We introduced A `DRIBBLED_PAST` `DuelType` and added the `TACKLE` qualifier to duels for Opta & StatsBomb.

