### PR TITLE
Add support for JSON Tracab data

### DIFF
--- a/kloppy/_providers/tracab.py
+++ b/kloppy/_providers/tracab.py
@@ -1,8 +1,13 @@
-from typing import Optional
+from typing import Optional, Union, Type
+
 
 from kloppy.domain import TrackingDataset
-from kloppy.infra.serializers.tracking.tracab import (
-    TRACABDeserializer,
+from kloppy.infra.serializers.tracking.tracab.tracab_dat import (
+    TRACABDatDeserializer,
+    TRACABInputs,
+)
+from kloppy.infra.serializers.tracking.tracab.tracab_json import (
+    TRACABJSONDeserializer,
     TRACABInputs,
 )
 from kloppy.io import FileLike, open_as_file
@@ -15,8 +20,16 @@ def load(
     limit: Optional[int] = None,
     coordinates: Optional[str] = None,
     only_alive: Optional[bool] = True,
+    data_version: Optional[str] = None,
 ) -> TrackingDataset:
-    deserializer = TRACABDeserializer(
+    if data_version == "dat":
+        deserializer_class = TRACABDatDeserializer
+    elif data_version == "json":
+        deserializer_class = TRACABJSONDeserializer
+    else:
+        deserializer_class = identify_deserializer(meta_data, raw_data)
+
+    deserializer = deserializer_class(
         sample_rate=sample_rate,
         limit=limit,
         coordinate_system=coordinates,
@@ -28,3 +41,21 @@ def load(
         return deserializer.deserialize(
             inputs=TRACABInputs(meta_data=meta_data_fp, raw_data=raw_data_fp)
         )
+
+
+def identify_deserializer(
+    meta_data: FileLike,
+    raw_data: FileLike,
+) -> Union[Type[TRACABDatDeserializer], Type[TRACABJSONDeserializer]]:
+    deserializer = None
+    if "xml" in meta_data.name and "dat" in raw_data.name:
+        deserializer = TRACABDatDeserializer
+    if "json" in meta_data.name and "json" in raw_data.name:
+        deserializer = TRACABJSONDeserializer
+
+    if deserializer is None:
+        raise ValueError(
+            "Tracab data version could not be recognized, please specify"
+        )
+
+    return deserializer

--- a/kloppy/infra/serializers/tracking/tracab/__init__.py
+++ b/kloppy/infra/serializers/tracking/tracab/__init__.py
@@ -1,0 +1,3 @@
+from .common import TRACABInputs
+from .tracab_dat import TRACABDatDeserializer
+from .tracab_json import TRACABJSONDeserializer

--- a/kloppy/infra/serializers/tracking/tracab/common.py
+++ b/kloppy/infra/serializers/tracking/tracab/common.py
@@ -1,0 +1,6 @@
+from typing import NamedTuple, IO
+
+
+class TRACABInputs(NamedTuple):
+    meta_data: IO[bytes]
+    raw_data: IO[bytes]

--- a/kloppy/infra/serializers/tracking/tracab/tracab_dat.py
+++ b/kloppy/infra/serializers/tracking/tracab/tracab_dat.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Tuple, Dict, NamedTuple, IO, Optional, Union
+from typing import Dict, Optional, Union
 
 from lxml import objectify
 
@@ -25,17 +25,13 @@ from kloppy.exceptions import DeserializationError
 
 from kloppy.utils import Readable, performance_logging
 
-from .deserializer import TrackingDataDeserializer
+from .common import TRACABInputs
+from ..deserializer import TrackingDataDeserializer
 
 logger = logging.getLogger(__name__)
 
 
-class TRACABInputs(NamedTuple):
-    meta_data: IO[bytes]
-    raw_data: IO[bytes]
-
-
-class TRACABDeserializer(TrackingDataDeserializer[TRACABInputs]):
+class TRACABDatDeserializer(TrackingDataDeserializer[TRACABInputs]):
     def __init__(
         self,
         limit: Optional[int] = None,

--- a/kloppy/infra/serializers/tracking/tracab/tracab_json.py
+++ b/kloppy/infra/serializers/tracking/tracab/tracab_json.py
@@ -1,0 +1,253 @@
+import logging
+import json
+import html
+from typing import Dict, Optional, Union
+
+from kloppy.domain import (
+    TrackingDataset,
+    DatasetFlag,
+    AttackingDirection,
+    Frame,
+    Point,
+    Point3D,
+    Team,
+    BallState,
+    Period,
+    Orientation,
+    Metadata,
+    Ground,
+    Player,
+    Provider,
+    PlayerData,
+    Position,
+)
+from kloppy.exceptions import DeserializationError
+
+from kloppy.utils import Readable, performance_logging
+
+from .common import TRACABInputs
+from ..deserializer import TrackingDataDeserializer
+
+logger = logging.getLogger(__name__)
+
+
+class TRACABJSONDeserializer(TrackingDataDeserializer[TRACABInputs]):
+    def __init__(
+        self,
+        limit: Optional[int] = None,
+        sample_rate: Optional[float] = None,
+        coordinate_system: Optional[Union[str, Provider]] = None,
+        only_alive: Optional[bool] = True,
+    ):
+        super().__init__(limit, sample_rate, coordinate_system)
+        self.only_alive = only_alive
+
+    @property
+    def provider(self) -> Provider:
+        return Provider.TRACAB
+
+    @classmethod
+    def _create_frame(cls, teams, period, raw_frame, frame_rate):
+        frame_id = raw_frame["FrameCount"]
+        raw_players_data = raw_frame["PlayerPositions"]
+        raw_ball_position = raw_frame["BallPosition"][0]
+
+        players_data = {}
+        for player_data in raw_players_data:
+            if player_data["Team"] == 1:
+                team = teams[0]
+            elif player_data["Team"] == 0:
+                team = teams[1]
+            elif player_data["Team"] in (-1, 4):
+                continue
+            else:
+                raise DeserializationError(
+                    f"Unknown Player Team ID: {player_data['Team']}"
+                )
+
+            jersey_no = player_data["JerseyNumber"]
+            x = player_data["X"]
+            y = player_data["Y"]
+            speed = player_data["Speed"]
+
+            player = team.get_player_by_jersey_number(jersey_no)
+            if player:
+                players_data[player] = PlayerData(
+                    coordinates=Point(float(x), float(y)), speed=float(speed)
+                )
+            else:
+                # continue
+                raise DeserializationError(
+                    f"Player not found for player jersey no {jersey_no} of team: {team.name}"
+                )
+
+        ball_x = raw_ball_position["X"]
+        ball_y = raw_ball_position["Y"]
+        ball_z = raw_ball_position["Z"]
+        ball_speed = raw_ball_position["Speed"]
+        if raw_ball_position["BallOwningTeam"] == "H":
+            ball_owning_team = teams[0]
+        elif raw_ball_position["BallOwningTeam"] == "A":
+            ball_owning_team = teams[1]
+        else:
+            raise DeserializationError(
+                f"Unknown ball owning team: {raw_ball_position['BallOwningTeam']}"
+            )
+        if raw_ball_position["BallStatus"] == "Alive":
+            ball_state = BallState.ALIVE
+        elif raw_ball_position["BallStatus"] == "Dead":
+            ball_state = BallState.DEAD
+        else:
+            raise DeserializationError(
+                f"Unknown ball state: {raw_ball_position['BallStatus']}"
+            )
+
+        return Frame(
+            frame_id=frame_id,
+            timestamp=frame_id / frame_rate - period.start_timestamp,
+            ball_coordinates=Point3D(
+                float(ball_x), float(ball_y), float(ball_z)
+            ),
+            ball_state=ball_state,
+            ball_owning_team=ball_owning_team,
+            ball_speed=ball_speed,
+            players_data=players_data,
+            period=period,
+            other_data={},
+        )
+
+    @staticmethod
+    def __validate_inputs(inputs: Dict[str, Readable]):
+        if "metadata" not in inputs:
+            raise ValueError("Please specify a value for 'metadata'")
+        if "raw_data" not in inputs:
+            raise ValueError("Please specify a value for 'raw_data'")
+
+    def create_team(self, team_data, ground):
+        team = Team(
+            team_id=str(team_data["TeamID"]),
+            name=html.unescape(team_data["ShortName"]),
+            ground=ground,
+        )
+
+        def parse_player_position(
+            starting_position: str, current_position: str
+        ):
+            if starting_position != "S":
+                return Position(
+                    position_id=starting_position, name=starting_position
+                )
+            elif current_position != "S" and current_position != "O":
+                return Position(
+                    position_id=current_position, name=current_position
+                )
+            else:
+                return None
+
+        team.players = [
+            Player(
+                player_id=str(player["PlayerID"]),
+                team=team,
+                first_name=html.unescape(player["FirstName"]),
+                last_name=html.unescape(player["LastName"]),
+                name=html.unescape(
+                    player["FirstName"] + " " + player["LastName"]
+                ),
+                jersey_no=int(player["JerseyNo"]),
+                starting=True if player["StartingPosition"] != "S" else False,
+                position=parse_player_position(
+                    player["StartingPosition"], player["CurrentPosition"]
+                ),
+            )
+            for player in team_data["Players"]
+        ]
+
+        return team
+
+    def deserialize(self, inputs: TRACABInputs) -> TrackingDataset:
+        meta_data = json.load(inputs.meta_data)
+        raw_data = json.load(inputs.raw_data)
+
+        with performance_logging("Loading metadata", logger=logger):
+            frame_rate = meta_data["FrameRate"]
+            pitch_size_width = meta_data["PitchShortSide"] / 100
+            pitch_size_length = meta_data["PitchLongSide"] / 100
+
+            periods = []
+            for period_id in [1, 2, 3, 4]:
+                period_start_frame = meta_data[f"Phase{period_id}StartFrame"]
+                period_end_frame = meta_data[f"Phase{period_id}EndFrame"]
+                if period_start_frame != 0 or period_end_frame != 0:
+                    periods.append(
+                        Period(
+                            id=period_id,
+                            start_timestamp=period_start_frame / frame_rate,
+                            end_timestamp=period_end_frame / frame_rate,
+                            attacking_direction=AttackingDirection.HOME_AWAY
+                            if meta_data[f"Phase{period_id}HomeGKLeft"]
+                            else AttackingDirection.AWAY_HOME,
+                        )
+                    )
+
+            home_team = self.create_team(meta_data["HomeTeam"], Ground.HOME)
+            away_team = self.create_team(meta_data["AwayTeam"], Ground.AWAY)
+            teams = [home_team, away_team]
+
+            transformer = self.get_transformer(
+                length=pitch_size_length, width=pitch_size_width
+            )
+
+        with performance_logging("Loading data", logger=logger):
+            raw_data = raw_data["FrameData"]
+
+            def _iter():
+                n = 0
+                sample = 1.0 / self.sample_rate
+
+                for frame in raw_data:
+                    if (
+                        self.only_alive
+                        and frame["BallPosition"][0]["BallStatus"] == "Dead"
+                    ):
+                        continue
+
+                    frame_id = frame["FrameCount"]
+                    for _period in periods:
+                        if _period.contains(frame_id / frame_rate):
+                            if n % sample == 0:
+                                yield _period, frame
+                            n += 1
+
+            frames = []
+            for n, (_period, _frame) in enumerate(_iter()):
+                frame = self._create_frame(teams, _period, _frame, frame_rate)
+
+                frame = transformer.transform_frame(frame)
+
+                frames.append(frame)
+
+                if self.limit and n >= self.limit:
+                    break
+
+        orientation = (
+            Orientation.HOME_TEAM
+            if periods[1].attacking_direction == AttackingDirection.HOME_AWAY
+            else Orientation.AWAY_TEAM
+        )
+
+        metadata = Metadata(
+            teams=teams,
+            periods=periods,
+            pitch_dimensions=transformer.get_to_coordinate_system().pitch_dimensions,
+            score=None,
+            frame_rate=frame_rate,
+            orientation=orientation,
+            provider=Provider.TRACAB,
+            flags=DatasetFlag.BALL_OWNING_TEAM | DatasetFlag.BALL_STATE,
+            coordinate_system=transformer.get_to_coordinate_system(),
+        )
+
+        return TrackingDataset(
+            records=frames,
+            metadata=metadata,
+        )

--- a/kloppy/tests/files/tracab_meta.json
+++ b/kloppy/tests/files/tracab_meta.json
@@ -1,0 +1,464 @@
+{
+  "GameID": 1,
+  "CompetitionID": 1,
+  "SeasonID": 2023,
+  "FrameRate": 25,
+  "PitchShortSide": 6800,
+  "PitchLongSide": 10500,
+  "Phase1StartFrame": 1848508,
+  "Phase1EndFrame": 1916408,
+  "Phase2StartFrame": 1942114,
+  "Phase2EndFrame": 2017933,
+  "Phase3StartFrame": 0,
+  "Phase3EndFrame": 0,
+  "Phase4StartFrame": 0,
+  "Phase4EndFrame": 0,
+  "Phase5StartFrame": 0,
+  "Phase5EndFrame": 0,
+  "Phase1HomeGKLeft": false,
+  "Phase2HomeGKLeft": true,
+  "Phase3HomeGKLeft": null,
+  "Phase4HomeGKLeft": null,
+  "Phase5HomeGKLeft": null,
+  "HomeTeam": {
+    "LongName": "Long Name Home",
+    "ShortName": "Short Name Home",
+    "TeamID": 1,
+    "Players": [
+      {
+        "PlayerID": 8216,
+        "FirstName": "Player",
+        "LastName": "One",
+        "JerseyNo": 1,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "G",
+        "CurrentPosition": "G"
+      },
+      {
+        "PlayerID": 8302,
+        "FirstName": "Player",
+        "LastName": "Two",
+        "JerseyNo": 2,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "D",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 12544,
+        "FirstName": "Player",
+        "LastName": "Three",
+        "JerseyNo": 5,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "D",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 12142,
+        "FirstName": "Player",
+        "LastName": "Four",
+        "JerseyNo": 7,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 1976302,
+        "StartingPosition": "M",
+        "CurrentPosition": "O"
+      },
+      {
+        "PlayerID": 8172,
+        "FirstName": "Player",
+        "LastName": "Five",
+        "JerseyNo": 8,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "M",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 12736,
+        "FirstName": "Player",
+        "LastName": "Six",
+        "JerseyNo": 13,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "D",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 13282,
+        "FirstName": "Player",
+        "LastName": "Seven",
+        "JerseyNo": 16,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "M",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 12170,
+        "FirstName": "Player",
+        "LastName": "Eight",
+        "JerseyNo": 20,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2001211,
+        "StartingPosition": "M",
+        "CurrentPosition": "O"
+      },
+      {
+        "PlayerID": 12524,
+        "FirstName": "Player",
+        "LastName": "Nine",
+        "JerseyNo": 55,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 1976390,
+        "StartingPosition": "D",
+        "CurrentPosition": "O"
+      },
+      {
+        "PlayerID": 9340,
+        "FirstName": "Player",
+        "LastName": "Ten",
+        "JerseyNo": 77,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "M",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 11909,
+        "FirstName": "Player",
+        "LastName": "Eleven",
+        "JerseyNo": 90,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 1976494,
+        "StartingPosition": "A",
+        "CurrentPosition": "O"
+      },
+      {
+        "PlayerID": 12814,
+        "FirstName": "Player",
+        "LastName": "Twelve",
+        "JerseyNo": 22,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      },
+      {
+        "PlayerID": 11650,
+        "FirstName": "Player",
+        "LastName": "Thirteen",
+        "JerseyNo": 6,
+        "StartFrameCount": 2001211,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "S",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 8183,
+        "FirstName": "Player",
+        "LastName": "Fourteen",
+        "JerseyNo": 11,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      },
+      {
+        "PlayerID": 13245,
+        "FirstName": "Player",
+        "LastName": "Fifteen",
+        "JerseyNo": 17,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      },
+      {
+        "PlayerID": 13246,
+        "FirstName": "Player",
+        "LastName": "Sixteen",
+        "JerseyNo": 18,
+        "StartFrameCount": 1976494,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "S",
+        "CurrentPosition": "A"
+      },
+      {
+        "PlayerID": 12809,
+        "FirstName": "Player",
+        "LastName": "Seventeen",
+        "JerseyNo": 21,
+        "StartFrameCount": 1976302,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "S",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 8106,
+        "FirstName": "Player",
+        "LastName": "Eighteen",
+        "JerseyNo": 25,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      },
+      {
+        "PlayerID": 12816,
+        "FirstName": "Player",
+        "LastName": "Nineteen",
+        "JerseyNo": 27,
+        "StartFrameCount": 1976390,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "S",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 12102,
+        "FirstName": "Player",
+        "LastName": "Twenty",
+        "JerseyNo": 39,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      }
+    ]
+  },
+  "AwayTeam": {
+    "LongName": "Long Name Away",
+    "ShortName": "Short Name Away",
+    "TeamID": 2,
+    "Players": [
+      {
+        "PlayerID": 10524,
+        "FirstName": "Away Player",
+        "LastName": "One",
+        "JerseyNo": 12,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "G",
+        "CurrentPosition": "G"
+      },
+      {
+        "PlayerID": 12660,
+        "FirstName": "Away Player",
+        "LastName": "Two",
+        "JerseyNo": 4,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "D",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 13275,
+        "FirstName": "Away Player",
+        "LastName": "Three",
+        "JerseyNo": 5,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "D",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 12314,
+        "FirstName": "Away Player",
+        "LastName": "Four",
+        "JerseyNo": 9,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "A",
+        "CurrentPosition": "A"
+      },
+      {
+        "PlayerID": 12352,
+        "FirstName": "Away Player",
+        "LastName": "Five",
+        "JerseyNo": 17,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2011156,
+        "StartingPosition": "M",
+        "CurrentPosition": "O"
+      },
+      {
+        "PlayerID": 12535,
+        "FirstName": "Away Player",
+        "LastName": "Six",
+        "JerseyNo": 19,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "D",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 11979,
+        "FirstName": "Away Player",
+        "LastName": "Seven",
+        "JerseyNo": 22,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 1941284,
+        "StartingPosition": "M",
+        "CurrentPosition": "O"
+      },
+      {
+        "PlayerID": 12128,
+        "FirstName": "Away Player",
+        "LastName": "Eight",
+        "JerseyNo": 24,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "M",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 13281,
+        "FirstName": "Away Player",
+        "LastName": "Nine",
+        "JerseyNo": 26,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 1984022,
+        "StartingPosition": "M",
+        "CurrentPosition": "O"
+      },
+      {
+        "PlayerID": 9080,
+        "FirstName": "Away Player",
+        "LastName": "Ten",
+        "JerseyNo": 27,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "D",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 12604,
+        "FirstName": "Away Player",
+        "LastName": "Eleven",
+        "JerseyNo": 33,
+        "StartFrameCount": 1848508,
+        "EndFrameCount": 1940954,
+        "StartingPosition": "M",
+        "CurrentPosition": "O"
+      },
+      {
+        "PlayerID": 12360,
+        "FirstName": "Away Player",
+        "LastName": "Twelve",
+        "JerseyNo": 35,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      },
+      {
+        "PlayerID": 12282,
+        "FirstName": "Away Player",
+        "LastName": "Thirteen",
+        "JerseyNo": 2,
+        "StartFrameCount": 1940954,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "S",
+        "CurrentPosition": "D"
+      },
+      {
+        "PlayerID": 13283,
+        "FirstName": "Away Player",
+        "LastName": "Fourteen",
+        "JerseyNo": 3,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      },
+      {
+        "PlayerID": 13276,
+        "FirstName": "Away Player",
+        "LastName": "Fifteen",
+        "JerseyNo": 7,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      },
+      {
+        "PlayerID": 13142,
+        "FirstName": "Away Player",
+        "LastName": "Sixteen",
+        "JerseyNo": 21,
+        "StartFrameCount": 2011156,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "S",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 13307,
+        "FirstName": "Away Player",
+        "LastName": "Seventeen",
+        "JerseyNo": 23,
+        "StartFrameCount": 1984022,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "S",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 12595,
+        "FirstName": "Away Player",
+        "LastName": "Eighteen",
+        "JerseyNo": 25,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      },
+      {
+        "PlayerID": 9654,
+        "FirstName": "Away Player",
+        "LastName": "Nineteen",
+        "JerseyNo": 28,
+        "StartFrameCount": 1941284,
+        "EndFrameCount": 2017933,
+        "StartingPosition": "S",
+        "CurrentPosition": "M"
+      },
+      {
+        "PlayerID": 12636,
+        "FirstName": "Away Player",
+        "LastName": "Twenty",
+        "JerseyNo": 31,
+        "StartFrameCount": 0,
+        "EndFrameCount": 0,
+        "StartingPosition": "S",
+        "CurrentPosition": "S"
+      }
+    ]
+  },
+  "Referees": [
+    {
+      "PlayerID": 0,
+      "FirstName": "Referee",
+      "LastName": "Main",
+      "JerseyNo": 1,
+      "StartFrameCount": 1848508,
+      "EndFrameCount": 2017933
+    },
+    {
+      "PlayerID": 9999991,
+      "FirstName": "Referee",
+      "LastName": "Head",
+      "JerseyNo": 0,
+      "StartFrameCount": 1848508,
+      "EndFrameCount": 2017933
+    },
+    {
+      "PlayerID": 9999993,
+      "FirstName": "Referee",
+      "LastName": "2nd Assistant",
+      "JerseyNo": 2,
+      "StartFrameCount": 1848508,
+      "EndFrameCount": 2017933
+    }
+  ],
+  "Kickoff": "2023-12-15 20:32:20"
+}

--- a/kloppy/tests/files/tracab_raw.json
+++ b/kloppy/tests/files/tracab_raw.json
@@ -3686,6 +3686,478 @@
       ]
     },
     {
+      "FrameCount": 1942114,
+      "GameRunning": 1,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": -5281,
+          "Y": 16,
+          "Speed": 0.29
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": 2371,
+          "Y": 48,
+          "Speed": 0.12
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": 23,
+          "Y": -1557,
+          "Speed": 1.16
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3,
+          "Y": 2589,
+          "Speed": 0.52
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -292,
+          "Y": 1960,
+          "Speed": 0.15
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -1706,
+          "Y": 1835,
+          "Speed": 0.86
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": 1988,
+          "Y": -1654,
+          "Speed": 0.06
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -59,
+          "Y": -1822,
+          "Speed": 0.04
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -18,
+          "Y": -952,
+          "Speed": 0.13
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -1931,
+          "Y": -597,
+          "Speed": 0.6
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": 1235,
+          "Y": -677,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -916,
+          "Y": -245,
+          "Speed": 0.57
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -1911,
+          "Y": 447,
+          "Speed": 0.58
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -38,
+          "Y": -47,
+          "Speed": 0.32
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": 4790,
+          "Y": 5,
+          "Speed": 0.03
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": 871,
+          "Y": 3027,
+          "Speed": 0.3
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 28,
+          "X": 1837,
+          "Y": 1159,
+          "Speed": 0.42
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 2,
+          "X": 604,
+          "Y": -36,
+          "Speed": 0.1
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -1638,
+          "Y": -1782,
+          "Speed": 0.09
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -2,
+          "Y": 895,
+          "Speed": 0.41
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": 514,
+          "Y": -3189,
+          "Speed": 0.19
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -734,
+          "Y": 542,
+          "Speed": 0.16
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 807.18,
+          "X": 240,
+          "Y": -6,
+          "Z": 15
+        },
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 807.18,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 807.18,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 807.18,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 807.18,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1942115,
+      "GameRunning": 1,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": -5280,
+          "Y": 18,
+          "Speed": 0.37
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": 2369,
+          "Y": 48,
+          "Speed": 0.12
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": 23,
+          "Y": -1551,
+          "Speed": 1.19
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -6,
+          "Y": 2592,
+          "Speed": 0.57
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -290,
+          "Y": 1960,
+          "Speed": 0.13
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -1706,
+          "Y": 1834,
+          "Speed": 0.82
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": 1988,
+          "Y": -1654,
+          "Speed": 0.06
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -59,
+          "Y": -1820,
+          "Speed": 0.08
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -14,
+          "Y": -948,
+          "Speed": 0.2
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -1929,
+          "Y": -595,
+          "Speed": 0.62
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": 1237,
+          "Y": -676,
+          "Speed": 0.03
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -915,
+          "Y": -246,
+          "Speed": 0.57
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -1909,
+          "Y": 447,
+          "Speed": 0.58
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -41,
+          "Y": -47,
+          "Speed": 0.36
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": 4790,
+          "Y": 5,
+          "Speed": 0.03
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": 869,
+          "Y": 3029,
+          "Speed": 0.35
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 28,
+          "X": 1839,
+          "Y": 1159,
+          "Speed": 0.44
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 2,
+          "X": 603,
+          "Y": -37,
+          "Speed": 0.13
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -1639,
+          "Y": -1783,
+          "Speed": 0.13
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": 1,
+          "Y": 889,
+          "Speed": 0.48
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": 512,
+          "Y": -3190,
+          "Speed": 0.26
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -734,
+          "Y": 541,
+          "Speed": 0.18
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 747.39,
+          "X": 269,
+          "Y": -7,
+          "Z": 18
+        },
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 747.39,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 747.39,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 747.39,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetAway",
+          "BallOwningTeam": "A",
+          "BallStatus": "Dead",
+          "Speed": 747.39,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
       "FrameCount": 2017933,
       "GameRunning": 1,
       "Phase": 3,

--- a/kloppy/tests/files/tracab_raw.json
+++ b/kloppy/tests/files/tracab_raw.json
@@ -1,0 +1,3934 @@
+{
+  "FrameData": [
+    {
+      "FrameCount": 1848508,
+      "GameRunning": 1,
+      "Phase": 2,
+      "PlayerPositions": [
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": 6,
+          "Y": -913,
+          "Speed": 1.02
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -1947,
+          "Y": 2020,
+          "Speed": 0.46
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": 256,
+          "Y": -958,
+          "Speed": 0.09
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": 1738,
+          "Y": -2548,
+          "Speed": 0.51
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": 2221,
+          "Y": -603,
+          "Speed": 0.28
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -4722,
+          "Y": 28,
+          "Speed": 0.38
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": 1580,
+          "Y": 2284,
+          "Speed": 0.42
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -777,
+          "Y": 759,
+          "Speed": 0.56
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -2123,
+          "Y": 639,
+          "Speed": 0.1
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 5270,
+          "Y": 27,
+          "Speed": 0.15
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": 18,
+          "Y": 3182,
+          "Speed": 0.45
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": 2242,
+          "Y": 815,
+          "Speed": 0.33
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": 866,
+          "Y": -108,
+          "Speed": 0.24
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -926,
+          "Y": -31,
+          "Speed": 0.13
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -46,
+          "Y": 7,
+          "Speed": 0.27
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -2008,
+          "Y": -633,
+          "Speed": 0.35
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -1924,
+          "Y": -2321,
+          "Speed": 0.32
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": 43,
+          "Y": 1066,
+          "Speed": 0.32
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": 53,
+          "Y": -3165,
+          "Speed": 0.32
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -667,
+          "Y": -726,
+          "Speed": 0.92
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -404,
+          "Y": -2581,
+          "Speed": 0.2
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -364,
+          "Y": 1432,
+          "Speed": 0.48
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 11,
+          "X": 2710,
+          "Y": 3722,
+          "Z": 11
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1848509,
+      "GameRunning": 1,
+      "Phase": 2,
+      "PlayerPositions": [
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": 14,
+          "Y": -905,
+          "Speed": 1.33
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -1946,
+          "Y": 2023,
+          "Speed": 0.47
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": 256,
+          "Y": -957,
+          "Speed": 0.13
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": 1736,
+          "Y": -2552,
+          "Speed": 0.5
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": 2221,
+          "Y": -602,
+          "Speed": 0.28
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -4722,
+          "Y": 28,
+          "Speed": 0.35
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": 1581,
+          "Y": 2284,
+          "Speed": 0.42
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -775,
+          "Y": 761,
+          "Speed": 0.62
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -2123,
+          "Y": 641,
+          "Speed": 0.13
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 5270,
+          "Y": 28,
+          "Speed": 0.15
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": 14,
+          "Y": 3186,
+          "Speed": 0.49
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": 2244,
+          "Y": 813,
+          "Speed": 0.33
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": 865,
+          "Y": -107,
+          "Speed": 0.24
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -926,
+          "Y": -30,
+          "Speed": 0.15
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -41,
+          "Y": 9,
+          "Speed": 0.27
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -2005,
+          "Y": -633,
+          "Speed": 0.35
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -1923,
+          "Y": -2323,
+          "Speed": 0.35
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": 41,
+          "Y": 1066,
+          "Speed": 0.37
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": 50,
+          "Y": -3164,
+          "Speed": 0.38
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -663,
+          "Y": -727,
+          "Speed": 0.96
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -404,
+          "Y": -2579,
+          "Speed": 0.26
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -366,
+          "Y": 1434,
+          "Speed": 0.51
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 2710,
+          "Y": 3722,
+          "Z": 11
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1848510,
+      "GameRunning": 1,
+      "Phase": 2,
+      "PlayerPositions": [
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": 24,
+          "Y": -897,
+          "Speed": 1.58
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -1946,
+          "Y": 2026,
+          "Speed": 0.48
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": 258,
+          "Y": -957,
+          "Speed": 0.13
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": 1735,
+          "Y": -2555,
+          "Speed": 0.54
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": 2221,
+          "Y": -601,
+          "Speed": 0.28
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -4722,
+          "Y": 29,
+          "Speed": 0.32
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": 1583,
+          "Y": 2284,
+          "Speed": 0.42
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -771,
+          "Y": 763,
+          "Speed": 0.64
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -2123,
+          "Y": 642,
+          "Speed": 0.08
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 5270,
+          "Y": 30,
+          "Speed": 0.13
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": 9,
+          "Y": 3190,
+          "Speed": 0.62
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": 2247,
+          "Y": 811,
+          "Speed": 0.36
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": 864,
+          "Y": -106,
+          "Speed": 0.24
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -926,
+          "Y": -28,
+          "Speed": 0.15
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -39,
+          "Y": 11,
+          "Speed": 0.3
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -2002,
+          "Y": -631,
+          "Speed": 0.35
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -1921,
+          "Y": -2325,
+          "Speed": 0.34
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": 39,
+          "Y": 1065,
+          "Speed": 0.4
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": 47,
+          "Y": -3160,
+          "Speed": 0.44
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -658,
+          "Y": -727,
+          "Speed": 0.99
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -404,
+          "Y": -2578,
+          "Speed": 0.29
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -367,
+          "Y": 1437,
+          "Speed": 0.57
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 2710,
+          "Y": 3722,
+          "Z": 11
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "SetHome",
+          "BallOwningTeam": "H",
+          "BallStatus": "Alive",
+          "Speed": 11,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916408,
+      "GameRunning": 1,
+      "Phase": 2,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -702,
+          "Y": 726,
+          "Speed": 1.8
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4476,
+          "Y": 411,
+          "Speed": 1.58
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -497,
+          "Y": 222,
+          "Speed": 1.06
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1477,
+          "Y": 796,
+          "Speed": 1.29
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2980,
+          "Y": 1199,
+          "Speed": 1.46
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3596,
+          "Y": 430,
+          "Speed": 0.13
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3807,
+          "Y": 488,
+          "Speed": 1.18
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3245,
+          "Y": 1361,
+          "Speed": 1.45
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3102,
+          "Y": -716,
+          "Speed": 1.19
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3766,
+          "Y": 799,
+          "Speed": 1.42
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3721,
+          "Y": 1330,
+          "Speed": 1.63
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 3968,
+          "Y": -182,
+          "Speed": 1.72
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4059,
+          "Y": -3008,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3327,
+          "Y": 1367,
+          "Speed": 1.67
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2218,
+          "Y": 876,
+          "Speed": 1.93
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5144,
+          "Y": 419,
+          "Speed": 0.83
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2510,
+          "Y": -3219,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -4027,
+          "Y": 44,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3655,
+          "Y": -689,
+          "Speed": 1.59
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3176,
+          "Y": -642,
+          "Speed": 1.24
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2167,
+          "Y": -1363,
+          "Speed": 1.48
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2822,
+          "Y": -268,
+          "Speed": 1.28
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3187,
+          "Y": 630,
+          "Speed": 1.34
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3343,
+          "Y": -326,
+          "Speed": 1.9
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 106.9,
+          "X": -4490,
+          "Y": 436,
+          "Z": 5
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 106.9,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 106.9,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 106.9,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 106.9,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916409,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -699,
+          "Y": 721,
+          "Speed": 1.77
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4473,
+          "Y": 407,
+          "Speed": 1.58
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -501,
+          "Y": 225,
+          "Speed": 1.08
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1477,
+          "Y": 790,
+          "Speed": 1.31
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2977,
+          "Y": 1193,
+          "Speed": 1.46
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3596,
+          "Y": 430,
+          "Speed": 0.13
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3804,
+          "Y": 484,
+          "Speed": 1.18
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3243,
+          "Y": 1356,
+          "Speed": 1.47
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3097,
+          "Y": -717,
+          "Speed": 1.23
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3762,
+          "Y": 796,
+          "Speed": 1.4
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3720,
+          "Y": 1324,
+          "Speed": 1.62
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 3974,
+          "Y": -184,
+          "Speed": 1.71
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4061,
+          "Y": -3001,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3323,
+          "Y": 1360,
+          "Speed": 1.7
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2216,
+          "Y": 869,
+          "Speed": 1.95
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5140,
+          "Y": 417,
+          "Speed": 0.83
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2516,
+          "Y": -3213,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -4024,
+          "Y": 40,
+          "Speed": 1.23
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3650,
+          "Y": -693,
+          "Speed": 1.61
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3171,
+          "Y": -642,
+          "Speed": 1.23
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2161,
+          "Y": -1368,
+          "Speed": 1.53
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2819,
+          "Y": -273,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3183,
+          "Y": 627,
+          "Speed": 1.31
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3338,
+          "Y": -331,
+          "Speed": 1.86
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 85.18,
+          "X": -4494,
+          "Y": 435,
+          "Z": 2
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 85.18,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 85.18,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 85.18,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 85.18,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916410,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -696,
+          "Y": 714,
+          "Speed": 1.77
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4470,
+          "Y": 404,
+          "Speed": 1.58
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -503,
+          "Y": 228,
+          "Speed": 1.03
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1479,
+          "Y": 785,
+          "Speed": 1.3
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2975,
+          "Y": 1189,
+          "Speed": 1.41
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3596,
+          "Y": 430,
+          "Speed": 0.13
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3801,
+          "Y": 480,
+          "Speed": 1.18
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3242,
+          "Y": 1353,
+          "Speed": 1.47
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3092,
+          "Y": -715,
+          "Speed": 1.2
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3757,
+          "Y": 793,
+          "Speed": 1.4
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3717,
+          "Y": 1317,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 3980,
+          "Y": -186,
+          "Speed": 1.72
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4064,
+          "Y": -2993,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3320,
+          "Y": 1353,
+          "Speed": 1.7
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2212,
+          "Y": 862,
+          "Speed": 1.95
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5138,
+          "Y": 416,
+          "Speed": 0.83
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2522,
+          "Y": -3208,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -4019,
+          "Y": 36,
+          "Speed": 1.23
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3644,
+          "Y": -696,
+          "Speed": 1.63
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3167,
+          "Y": -642,
+          "Speed": 1.22
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2158,
+          "Y": -1371,
+          "Speed": 1.53
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2816,
+          "Y": -277,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3179,
+          "Y": 622,
+          "Speed": 1.31
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3332,
+          "Y": -334,
+          "Speed": 1.83
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 78.03,
+          "X": -4498,
+          "Y": 440,
+          "Z": 1
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 78.03,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 78.03,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 78.03,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 78.03,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916411,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -693,
+          "Y": 708,
+          "Speed": 1.75
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4467,
+          "Y": 400,
+          "Speed": 1.56
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -506,
+          "Y": 231,
+          "Speed": 1.04
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1479,
+          "Y": 779,
+          "Speed": 1.31
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2971,
+          "Y": 1184,
+          "Speed": 1.46
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3595,
+          "Y": 431,
+          "Speed": 0.1
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3797,
+          "Y": 477,
+          "Speed": 1.18
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3241,
+          "Y": 1350,
+          "Speed": 1.47
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3088,
+          "Y": -715,
+          "Speed": 1.2
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3753,
+          "Y": 791,
+          "Speed": 1.38
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3715,
+          "Y": 1310,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 3986,
+          "Y": -187,
+          "Speed": 1.71
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4065,
+          "Y": -2986,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3318,
+          "Y": 1346,
+          "Speed": 1.72
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2210,
+          "Y": 854,
+          "Speed": 1.93
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5135,
+          "Y": 415,
+          "Speed": 0.83
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2529,
+          "Y": -3201,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -4016,
+          "Y": 33,
+          "Speed": 1.21
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3639,
+          "Y": -700,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3160,
+          "Y": -642,
+          "Speed": 1.22
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2153,
+          "Y": -1375,
+          "Speed": 1.52
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2813,
+          "Y": -282,
+          "Speed": 1.29
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3175,
+          "Y": 618,
+          "Speed": 1.31
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3326,
+          "Y": -339,
+          "Speed": 1.83
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 41.64,
+          "X": -4494,
+          "Y": 436,
+          "Z": 2
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 41.64,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 41.64,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 41.64,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 41.64,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916412,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -690,
+          "Y": 701,
+          "Speed": 1.72
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4463,
+          "Y": 395,
+          "Speed": 1.53
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -509,
+          "Y": 234,
+          "Speed": 1.04
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1479,
+          "Y": 772,
+          "Speed": 1.31
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2968,
+          "Y": 1179,
+          "Speed": 1.46
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3594,
+          "Y": 430,
+          "Speed": 0.13
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3794,
+          "Y": 473,
+          "Speed": 1.21
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3240,
+          "Y": 1348,
+          "Speed": 1.43
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3084,
+          "Y": -715,
+          "Speed": 1.2
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3748,
+          "Y": 788,
+          "Speed": 1.36
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3712,
+          "Y": 1302,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 3994,
+          "Y": -189,
+          "Speed": 1.71
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4067,
+          "Y": -2979,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3314,
+          "Y": 1340,
+          "Speed": 1.72
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2207,
+          "Y": 847,
+          "Speed": 1.93
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5133,
+          "Y": 413,
+          "Speed": 0.83
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2534,
+          "Y": -3197,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -4012,
+          "Y": 27,
+          "Speed": 1.21
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3634,
+          "Y": -704,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3155,
+          "Y": -642,
+          "Speed": 1.22
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2149,
+          "Y": -1379,
+          "Speed": 1.49
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2809,
+          "Y": -288,
+          "Speed": 1.31
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3171,
+          "Y": 612,
+          "Speed": 1.31
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3320,
+          "Y": -342,
+          "Speed": 1.78
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 29.98,
+          "X": -4492,
+          "Y": 433,
+          "Z": 3
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 29.98,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 29.98,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 29.98,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 29.98,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916413,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -687,
+          "Y": 695,
+          "Speed": 1.71
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4460,
+          "Y": 391,
+          "Speed": 1.53
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -513,
+          "Y": 236,
+          "Speed": 1.02
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1480,
+          "Y": 766,
+          "Speed": 1.31
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2965,
+          "Y": 1174,
+          "Speed": 1.46
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3594,
+          "Y": 430,
+          "Speed": 0.13
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3791,
+          "Y": 469,
+          "Speed": 1.18
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3239,
+          "Y": 1346,
+          "Speed": 1.41
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3079,
+          "Y": -715,
+          "Speed": 1.19
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3744,
+          "Y": 785,
+          "Speed": 1.38
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3709,
+          "Y": 1295,
+          "Speed": 1.65
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 3999,
+          "Y": -191,
+          "Speed": 1.68
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4068,
+          "Y": -2972,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3312,
+          "Y": 1332,
+          "Speed": 1.73
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2204,
+          "Y": 841,
+          "Speed": 1.91
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5129,
+          "Y": 411,
+          "Speed": 0.8
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2540,
+          "Y": -3192,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -4007,
+          "Y": 22,
+          "Speed": 1.23
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3629,
+          "Y": -708,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3147,
+          "Y": -646,
+          "Speed": 1.26
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2143,
+          "Y": -1382,
+          "Speed": 1.52
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2806,
+          "Y": -293,
+          "Speed": 1.31
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3167,
+          "Y": 608,
+          "Speed": 1.31
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3313,
+          "Y": -346,
+          "Speed": 1.78
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 114.88,
+          "X": -4489,
+          "Y": 429,
+          "Z": 4
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 114.88,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 114.88,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 114.88,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 114.88,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916414,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -685,
+          "Y": 688,
+          "Speed": 1.71
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4456,
+          "Y": 385,
+          "Speed": 1.56
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -516,
+          "Y": 239,
+          "Speed": 1.02
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1481,
+          "Y": 760,
+          "Speed": 1.3
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2961,
+          "Y": 1169,
+          "Speed": 1.46
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3593,
+          "Y": 430,
+          "Speed": 0.1
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3787,
+          "Y": 464,
+          "Speed": 1.23
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3237,
+          "Y": 1344,
+          "Speed": 1.4
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3075,
+          "Y": -715,
+          "Speed": 1.19
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3740,
+          "Y": 781,
+          "Speed": 1.38
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3706,
+          "Y": 1288,
+          "Speed": 1.65
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 4005,
+          "Y": -194,
+          "Speed": 1.68
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4069,
+          "Y": -2965,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3310,
+          "Y": 1325,
+          "Speed": 1.75
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2202,
+          "Y": 834,
+          "Speed": 1.9
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5125,
+          "Y": 407,
+          "Speed": 0.82
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2545,
+          "Y": -3186,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -4004,
+          "Y": 18,
+          "Speed": 1.23
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3623,
+          "Y": -712,
+          "Speed": 1.66
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3140,
+          "Y": -647,
+          "Speed": 1.29
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2140,
+          "Y": -1385,
+          "Speed": 1.49
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2804,
+          "Y": -298,
+          "Speed": 1.34
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3163,
+          "Y": 604,
+          "Speed": 1.31
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3308,
+          "Y": -349,
+          "Speed": 1.74
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 121.28,
+          "X": -4486,
+          "Y": 425,
+          "Z": 4
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 121.28,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 121.28,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 121.28,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 121.28,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916415,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -683,
+          "Y": 682,
+          "Speed": 1.68
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4451,
+          "Y": 381,
+          "Speed": 1.55
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -519,
+          "Y": 242,
+          "Speed": 1.04
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1481,
+          "Y": 754,
+          "Speed": 1.3
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2958,
+          "Y": 1164,
+          "Speed": 1.46
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3593,
+          "Y": 431,
+          "Speed": 0.06
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3784,
+          "Y": 459,
+          "Speed": 1.23
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3236,
+          "Y": 1341,
+          "Speed": 1.28
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3069,
+          "Y": -714,
+          "Speed": 1.23
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3734,
+          "Y": 778,
+          "Speed": 1.4
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3704,
+          "Y": 1282,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 4012,
+          "Y": -195,
+          "Speed": 1.68
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4070,
+          "Y": -2957,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3308,
+          "Y": 1317,
+          "Speed": 1.78
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2200,
+          "Y": 828,
+          "Speed": 1.88
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5122,
+          "Y": 406,
+          "Speed": 0.82
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2550,
+          "Y": -3181,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -4000,
+          "Y": 13,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3616,
+          "Y": -716,
+          "Speed": 1.66
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3134,
+          "Y": -649,
+          "Speed": 1.33
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2136,
+          "Y": -1389,
+          "Speed": 1.46
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2801,
+          "Y": -304,
+          "Speed": 1.36
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3159,
+          "Y": 599,
+          "Speed": 1.33
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3302,
+          "Y": -352,
+          "Speed": 1.71
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 360.73,
+          "X": -4460,
+          "Y": 403,
+          "Z": 2
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 360.73,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 360.73,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 360.73,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 360.73,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916416,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -679,
+          "Y": 676,
+          "Speed": 1.7
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4448,
+          "Y": 377,
+          "Speed": 1.55
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -522,
+          "Y": 244,
+          "Speed": 0.99
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1482,
+          "Y": 748,
+          "Speed": 1.33
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2955,
+          "Y": 1159,
+          "Speed": 1.49
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3592,
+          "Y": 430,
+          "Speed": 0.07
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3781,
+          "Y": 456,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3233,
+          "Y": 1337,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3065,
+          "Y": -714,
+          "Speed": 1.19
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3730,
+          "Y": 774,
+          "Speed": 1.42
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3701,
+          "Y": 1275,
+          "Speed": 1.67
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 4018,
+          "Y": -198,
+          "Speed": 1.69
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4070,
+          "Y": -2949,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3307,
+          "Y": 1310,
+          "Speed": 1.77
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2198,
+          "Y": 821,
+          "Speed": 1.87
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5118,
+          "Y": 404,
+          "Speed": 0.84
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2555,
+          "Y": -3175,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -3997,
+          "Y": 9,
+          "Speed": 1.28
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3610,
+          "Y": -719,
+          "Speed": 1.68
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3127,
+          "Y": -652,
+          "Speed": 1.38
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2131,
+          "Y": -1392,
+          "Speed": 1.46
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2798,
+          "Y": -309,
+          "Speed": 1.39
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3156,
+          "Y": 595,
+          "Speed": 1.33
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3296,
+          "Y": -356,
+          "Speed": 1.71
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 437.01,
+          "X": -4452,
+          "Y": 392,
+          "Z": 4
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 437.01,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 437.01,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 437.01,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 437.01,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916417,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -677,
+          "Y": 670,
+          "Speed": 1.68
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4443,
+          "Y": 372,
+          "Speed": 1.53
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -524,
+          "Y": 246,
+          "Speed": 0.97
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1482,
+          "Y": 742,
+          "Speed": 1.36
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2951,
+          "Y": 1154,
+          "Speed": 1.49
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3591,
+          "Y": 430,
+          "Speed": 0.09
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3777,
+          "Y": 451,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3233,
+          "Y": 1334,
+          "Speed": 1.14
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3059,
+          "Y": -715,
+          "Speed": 1.23
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3725,
+          "Y": 770,
+          "Speed": 1.42
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3699,
+          "Y": 1269,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 4025,
+          "Y": -201,
+          "Speed": 1.69
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4071,
+          "Y": -2942,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3304,
+          "Y": 1302,
+          "Speed": 1.78
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2196,
+          "Y": 815,
+          "Speed": 1.87
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5116,
+          "Y": 401,
+          "Speed": 0.84
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2561,
+          "Y": -3171,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -3994,
+          "Y": 4,
+          "Speed": 1.31
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3604,
+          "Y": -722,
+          "Speed": 1.66
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3119,
+          "Y": -656,
+          "Speed": 1.45
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2127,
+          "Y": -1396,
+          "Speed": 1.44
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2795,
+          "Y": -313,
+          "Speed": 1.39
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3151,
+          "Y": 591,
+          "Speed": 1.36
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3289,
+          "Y": -361,
+          "Speed": 1.73
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 378.66,
+          "X": -4452,
+          "Y": 394,
+          "Z": 2
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 378.66,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 378.66,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 378.66,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 378.66,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916418,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -675,
+          "Y": 664,
+          "Speed": 1.68
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4439,
+          "Y": 367,
+          "Speed": 1.55
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -526,
+          "Y": 248,
+          "Speed": 0.94
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1482,
+          "Y": 737,
+          "Speed": 1.39
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2948,
+          "Y": 1148,
+          "Speed": 1.51
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3591,
+          "Y": 429,
+          "Speed": 0.09
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3775,
+          "Y": 448,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3231,
+          "Y": 1330,
+          "Speed": 1.1
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3054,
+          "Y": -715,
+          "Speed": 1.23
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3720,
+          "Y": 766,
+          "Speed": 1.43
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3695,
+          "Y": 1263,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 4032,
+          "Y": -202,
+          "Speed": 1.72
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4071,
+          "Y": -2935,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3302,
+          "Y": 1295,
+          "Speed": 1.8
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2193,
+          "Y": 807,
+          "Speed": 1.88
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5113,
+          "Y": 400,
+          "Speed": 0.87
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2566,
+          "Y": -3165,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -3990,
+          "Y": 0,
+          "Speed": 1.33
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3599,
+          "Y": -723,
+          "Speed": 1.66
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3112,
+          "Y": -659,
+          "Speed": 1.51
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2122,
+          "Y": -1398,
+          "Speed": 1.44
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2792,
+          "Y": -319,
+          "Speed": 1.42
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3147,
+          "Y": 587,
+          "Speed": 1.4
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3283,
+          "Y": -366,
+          "Speed": 1.76
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 151.74,
+          "X": -4456,
+          "Y": 385,
+          "Z": 8
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 151.74,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 151.74,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 151.74,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 151.74,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916419,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -672,
+          "Y": 657,
+          "Speed": 1.7
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4434,
+          "Y": 363,
+          "Speed": 1.53
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -528,
+          "Y": 251,
+          "Speed": 0.94
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1482,
+          "Y": 730,
+          "Speed": 1.42
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2945,
+          "Y": 1144,
+          "Speed": 1.49
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3590,
+          "Y": 429,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3773,
+          "Y": 444,
+          "Speed": 1.26
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3231,
+          "Y": 1328,
+          "Speed": 0.99
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3048,
+          "Y": -715,
+          "Speed": 1.27
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3714,
+          "Y": 761,
+          "Speed": 1.45
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3693,
+          "Y": 1258,
+          "Speed": 1.64
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 4037,
+          "Y": -206,
+          "Speed": 1.7
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4071,
+          "Y": -2928,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3300,
+          "Y": 1288,
+          "Speed": 1.82
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2190,
+          "Y": 800,
+          "Speed": 1.88
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5110,
+          "Y": 399,
+          "Speed": 0.86
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2573,
+          "Y": -3160,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -3986,
+          "Y": -4,
+          "Speed": 1.33
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3592,
+          "Y": -725,
+          "Speed": 1.66
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3107,
+          "Y": -660,
+          "Speed": 1.54
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2118,
+          "Y": -1402,
+          "Speed": 1.44
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2788,
+          "Y": -324,
+          "Speed": 1.45
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3144,
+          "Y": 583,
+          "Speed": 1.43
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3277,
+          "Y": -370,
+          "Speed": 1.79
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 66.2,
+          "X": -4453,
+          "Y": 385,
+          "Z": 6
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 66.2,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 66.2,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 66.2,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 66.2,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 1916420,
+      "GameRunning": 0,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": -669,
+          "Y": 650,
+          "Speed": 1.7
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": -4430,
+          "Y": 358,
+          "Speed": 1.53
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -531,
+          "Y": 253,
+          "Speed": 0.92
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": -1482,
+          "Y": 723,
+          "Speed": 1.45
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -2940,
+          "Y": 1140,
+          "Speed": 1.51
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 17,
+          "X": -3590,
+          "Y": 429,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": -3770,
+          "Y": 440,
+          "Speed": 1.28
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 33,
+          "X": -3230,
+          "Y": 1324,
+          "Speed": 0.97
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": -3043,
+          "Y": -714,
+          "Speed": 1.31
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 90,
+          "X": -3710,
+          "Y": 759,
+          "Speed": 1.43
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 22,
+          "X": -3689,
+          "Y": 1252,
+          "Speed": 1.67
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": 4044,
+          "Y": -209,
+          "Speed": 1.7
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -4071,
+          "Y": -2920,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 7,
+          "X": -3298,
+          "Y": 1282,
+          "Speed": 1.82
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": -2188,
+          "Y": 792,
+          "Speed": 1.9
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": -5107,
+          "Y": 397,
+          "Speed": 0.89
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": 2577,
+          "Y": -3156,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": -3983,
+          "Y": -8,
+          "Speed": 1.33
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": -3588,
+          "Y": -726,
+          "Speed": 1.63
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": -3101,
+          "Y": -661,
+          "Speed": 1.53
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 55,
+          "X": -2113,
+          "Y": -1404,
+          "Speed": 1.44
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 20,
+          "X": -2785,
+          "Y": -329,
+          "Speed": 1.47
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 26,
+          "X": -3140,
+          "Y": 579,
+          "Speed": 1.43
+        },
+        {
+          "Team": 4,
+          "JerseyNumber": 0,
+          "X": 5550,
+          "Y": 4400,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": -3270,
+          "Y": -375,
+          "Speed": 1.84
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 176.34,
+          "X": -4447,
+          "Y": 374,
+          "Z": 6
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 176.34,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 176.34,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 176.34,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 176.34,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    },
+    {
+      "FrameCount": 2017933,
+      "GameRunning": 1,
+      "Phase": 3,
+      "PlayerPositions": [
+        {
+          "Team": 1,
+          "JerseyNumber": 1,
+          "X": -3081,
+          "Y": -272,
+          "Speed": 1.45
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 23,
+          "X": 1461,
+          "Y": 268,
+          "Speed": 0.59
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 21,
+          "X": 2711,
+          "Y": 2210,
+          "Speed": 1.08
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 24,
+          "X": 1321,
+          "Y": 1321,
+          "Speed": 1.89
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 6,
+          "X": 1090,
+          "Y": -955,
+          "Speed": 0.98
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 27,
+          "X": 2060,
+          "Y": -2279,
+          "Speed": 1.29
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 5,
+          "X": 1956,
+          "Y": -420,
+          "Speed": 1.82
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 28,
+          "X": 1294,
+          "Y": 1030,
+          "Speed": 0.82
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -1954,
+          "Y": -3164,
+          "Speed": 0
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 13,
+          "X": -124,
+          "Y": -1318,
+          "Speed": 1.02
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 8,
+          "X": 881,
+          "Y": 734,
+          "Speed": 1.32
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 21,
+          "X": 2314,
+          "Y": -1471,
+          "Speed": 1.07
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 9,
+          "X": 390,
+          "Y": -194,
+          "Speed": 0.82
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 4,
+          "X": 2369,
+          "Y": 737,
+          "Speed": 1.5
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 77,
+          "X": 2681,
+          "Y": -1870,
+          "Speed": 0.16
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 18,
+          "X": 2680,
+          "Y": -260,
+          "Speed": 1.13
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 2,
+          "X": 2560,
+          "Y": 1766,
+          "Speed": 1.3
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 12,
+          "X": 4688,
+          "Y": 313,
+          "Speed": 1.59
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 16,
+          "X": 925,
+          "Y": -1402,
+          "Speed": 0.9
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -1493,
+          "Y": -2956,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 2,
+          "X": 2002,
+          "Y": -230,
+          "Speed": 1.55
+        },
+        {
+          "Team": 1,
+          "JerseyNumber": 5,
+          "X": -18,
+          "Y": 579,
+          "Speed": 1.18
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -2793,
+          "Y": -3303,
+          "Speed": 0
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 19,
+          "X": 2458,
+          "Y": -1083,
+          "Speed": 1.49
+        },
+        {
+          "Team": 0,
+          "JerseyNumber": 27,
+          "X": 2624,
+          "Y": 1571,
+          "Speed": 1.36
+        },
+        {
+          "Team": -1,
+          "JerseyNumber": 0,
+          "X": -2402,
+          "Y": -3174,
+          "Speed": 0
+        }
+      ],
+      "BallPosition": [
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 275.15,
+          "X": 2600,
+          "Y": 1577,
+          "Z": 10
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 275.15,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 275.15,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 275.15,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        },
+        {
+          "BallContactInfo": "",
+          "BallOwningTeam": "H",
+          "BallStatus": "Dead",
+          "Speed": 275.15,
+          "X": 5550,
+          "Y": 4400,
+          "Z": 0
+        }
+      ]
+    }
+  ],
+  "PackageID": "d27d5170-bab1-11ee-b39d-d10edbcdad1e",
+  "Filename": "TF10-55-2023-13495-1848508-2017931.json",
+  "GameID": "13495",
+  "CompetitionID": "55",
+  "SeasonID": "2023",
+  "PackageTime": "1706098339",
+  "NumberOfFrames": 169423,
+  "PitchShortSide": 680,
+  "PitchLongSide": 1050
+}

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -18,19 +18,122 @@ from kloppy.domain import (
 from kloppy import tracab
 
 
-class TestTracabTracking:
-    @pytest.fixture
-    def meta_data(self, base_dir) -> str:
-        return base_dir / "files/tracab_meta.xml"
+@pytest.fixture(scope="session")
+def json_meta_data(base_dir: Path) -> Path:
+    return base_dir / "files" / "tracab_meta.json"
 
-    @pytest.fixture
-    def raw_data(self, base_dir) -> str:
-        return base_dir / "files/tracab_raw.dat"
 
-    def test_correct_deserialization(self, meta_data: Path, raw_data: Path):
+@pytest.fixture(scope="session")
+def json_raw_data(base_dir: Path) -> Path:
+    return base_dir / "files" / "tracab_raw.json"
+
+
+@pytest.fixture(scope="session")
+def xml_meta_data(base_dir: Path) -> Path:
+    return base_dir / "files" / "tracab_meta.xml"
+
+
+@pytest.fixture(scope="session")
+def dat_raw_data(base_dir: Path) -> Path:
+    return base_dir / "files" / "tracab_raw.dat"
+
+
+def test_correct_auto_recognize_deserialization(
+    json_meta_data: Path,
+    json_raw_data: Path,
+    xml_meta_data: Path,
+    dat_raw_data: Path,
+):
+    dataset = tracab.load(
+        meta_data=json_meta_data, raw_data=json_raw_data, only_alive=False
+    )
+    assert len(dataset.records) == 5
+    dataset = tracab.load(
+        meta_data=xml_meta_data, raw_data=dat_raw_data, only_alive=False
+    )
+    assert len(dataset.records) == 6
+
+
+class TestTracabJSONTracking:
+    def test_correct_deserialization(
+        self, json_meta_data: Path, json_raw_data: Path
+    ):
         dataset = tracab.load(
-            meta_data=meta_data,
-            raw_data=raw_data,
+            meta_data=json_meta_data,
+            raw_data=json_raw_data,
+            coordinates="tracab",
+            only_alive=False,
+            data_version="json",
+        )
+        assert dataset.metadata.provider == Provider.TRACAB
+        assert dataset.dataset_type == DatasetType.TRACKING
+        assert len(dataset.records) == 5
+        assert len(dataset.metadata.periods) == 2
+        assert dataset.metadata.periods[0] == Period(
+            id=1,
+            start_timestamp=73940.32,
+            end_timestamp=76656.32,
+            attacking_direction=AttackingDirection.AWAY_HOME,
+        )
+
+        assert dataset.metadata.periods[1] == Period(
+            id=2,
+            start_timestamp=77684.56,
+            end_timestamp=80717.32,
+            attacking_direction=AttackingDirection.HOME_AWAY,
+        )
+
+        player_home_1 = dataset.metadata.teams[0].get_player_by_jersey_number(
+            1
+        )
+        assert dataset.records[0].players_data[
+            player_home_1
+        ].coordinates == Point(x=5270.0, y=27.0)
+
+        player_away_12 = dataset.metadata.teams[1].get_player_by_jersey_number(
+            12
+        )
+        assert dataset.records[0].players_data[
+            player_away_12
+        ].coordinates == Point(x=-4722.0, y=28.0)
+        assert dataset.records[0].ball_state == BallState.DEAD
+        assert dataset.records[1].ball_state == BallState.ALIVE
+        # Shouldn't this be closer to (0,0,0)?
+        assert dataset.records[1].ball_coordinates == Point3D(
+            x=2710.0, y=3722.0, z=11.0
+        )
+
+        # make sure player data is only in the frame when the player is at the pitch
+        assert "12170" in [
+            player.player_id
+            for player in dataset.records[0].players_data.keys()
+        ]
+        assert "12170" not in [
+            player.player_id
+            for player in dataset.records[4].players_data.keys()
+        ]
+
+    def test_correct_normalized_deserialization(
+        self, json_meta_data: Path, json_raw_data: Path
+    ):
+        dataset = tracab.load(
+            meta_data=json_meta_data, raw_data=json_raw_data, only_alive=False
+        )
+        player_home_1 = dataset.metadata.teams[0].get_player_by_jersey_number(
+            1
+        )
+        assert dataset.records[0].players_data[
+            player_home_1
+        ].coordinates == Point(x=1.0019047619047619, y=0.49602941176470583)
+
+
+class TestTracabDATTracking:
+    def test_correct_deserialization(
+        self, xml_meta_data: Path, dat_raw_data: Path
+    ):
+        dataset = tracab.load(
+            meta_data=xml_meta_data,
+            raw_data=dat_raw_data,
             coordinates="tracab",
             only_alive=False,
         )
@@ -90,10 +193,10 @@ class TestTracabTracking:
         ]
 
     def test_correct_normalized_deserialization(
-        self, meta_data: Path, raw_data: Path
+        self, xml_meta_data: Path, dat_raw_data: Path
     ):
         dataset = tracab.load(
-            meta_data=meta_data, raw_data=raw_data, only_alive=False
+            meta_data=xml_meta_data, raw_data=dat_raw_data, only_alive=False
         )
 
         player_home_19 = dataset.metadata.teams[0].get_player_by_jersey_number(


### PR DESCRIPTION
**Goal**
Add support to serialize tracking data from Tracab, where both the meta and the raw data are in JSON format. 

**Description**
Refactored the code, so we can both serialize tracking data from Tracab, if a) the meta data is XML and raw data .dat or b) the meta data is JSON and raw data JSON. 

I've refactored the code to support two versions of input data similar to how we handle it for the Wyscout v2 and v3 event data models.

**Questions**
I'm uncertain about the implementation, which determines the orientation for my Tracab JSON deserializer. I'm confused again on HOME_TEAM / AWAY_TEAM / FIXED_HOME_AWAY.

In the meta data it is defined whether home or away team plays from left to right in the different periods. In the example file we have in our tests, we can read in the meta data that: `"Phase1HomeGKLeft": false` & `"Phase2HomeGKLeft": true`. This means that the home team GK has approx `"X": 5000` at the start of the first half and approx `"X": -5000` at the start of the second half, in the raw data.

What should the orientation then be? Should it be AWAY_TEAM for this example?