### PR TITLE
Accurate transformation of pitch dimensions

### DIFF
--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -28,7 +28,17 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
-from .pitch import PitchDimensions, Point, Dimension
+from .pitch import (
+    PitchDimensions,
+    Unit,
+    Point,
+    Dimension,
+    NormalizedPitchDimensions,
+    MetricPitchDimensions,
+    ImperialPitchDimensions,
+    OptaPitchDimensions,
+    WyscoutPitchDimensions,
+)
 from .formation import FormationType
 from ...exceptions import (
     OrientationError,
@@ -488,16 +498,20 @@ class KloppyCoordinateSystem(CoordinateSystem):
     @property
     def pitch_dimensions(self) -> PitchDimensions:
         if self.length is not None and self.width is not None:
-            return PitchDimensions(
+            return NormalizedPitchDimensions(
                 x_dim=Dimension(0, 1),
                 y_dim=Dimension(0, 1),
-                length=self.length,
-                width=self.width,
+                pitch_length=self.length,
+                pitch_width=self.width,
+                standardized=False,
             )
         else:
-            return PitchDimensions(
+            return NormalizedPitchDimensions(
                 x_dim=Dimension(0, 1),
                 y_dim=Dimension(0, 1),
+                pitch_length=105,
+                pitch_width=68,
+                standardized=True,
             )
 
 
@@ -524,12 +538,13 @@ class TracabCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
-            x_dim=Dimension(-1 * self.length * 100 / 2, self.length * 100 / 2),
-            y_dim=Dimension(-1 * self.width * 100 / 2, self.width * 100 / 2),
-            length=self.length,
-            width=self.width,
-        )
+        return MetricPitchDimensions(
+            x_dim=Dimension(-1 * self.length / 2, self.length / 2),
+            y_dim=Dimension(-1 * self.width / 2, self.width / 2),
+            pitch_length=self.length,
+            pitch_width=self.width,
+            standardized=False,
+        ).convert(to_unit=Unit.CENTIMETERS)
 
 
 @dataclass
@@ -548,11 +563,12 @@ class SecondSpectrumCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
+        return MetricPitchDimensions(
             x_dim=Dimension(-1 * self.length / 2, self.length / 2),
             y_dim=Dimension(-1 * self.width / 2, self.width / 2),
-            length=self.length,
-            width=self.width,
+            pitch_length=self.length,
+            pitch_width=self.width,
+            standardized=False,
         )
 
 
@@ -572,10 +588,7 @@ class OptaCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
-            x_dim=Dimension(0, 100),
-            y_dim=Dimension(0, 100),
-        )
+        return OptaPitchDimensions()
 
 
 @dataclass
@@ -594,11 +607,12 @@ class SportecEventDataCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
+        return MetricPitchDimensions(
             x_dim=Dimension(0, self.length),
             y_dim=Dimension(0, self.width),
-            length=self.length,
-            width=self.width,
+            pitch_length=self.length,
+            pitch_width=self.width,
+            standardized=False,
         )
 
 
@@ -618,11 +632,12 @@ class SportecTrackingDataCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
+        return MetricPitchDimensions(
             x_dim=Dimension(-self.length / 2, self.length / 2),
             y_dim=Dimension(-self.width / 2, self.width / 2),
-            length=self.length,
-            width=self.width,
+            pitch_length=self.length,
+            pitch_width=self.width,
+            standardized=False,
         )
 
 
@@ -642,9 +657,10 @@ class StatsBombCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
+        return ImperialPitchDimensions(
             x_dim=Dimension(0, 120),
             y_dim=Dimension(0, 80),
+            standardized=True,
         )
 
 
@@ -663,10 +679,7 @@ class WyscoutCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
-            x_dim=Dimension(0, 100),
-            y_dim=Dimension(0, 100),
-        )
+        return WyscoutPitchDimensions()
 
 
 @dataclass
@@ -685,11 +698,12 @@ class SkillCornerCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
+        return MetricPitchDimensions(
             x_dim=Dimension(-1 * self.length / 2, self.length / 2),
             y_dim=Dimension(-1 * self.width / 2, self.width / 2),
-            length=self.length,
-            width=self.width,
+            pitch_length=self.length,
+            pitch_width=self.width,
+            standardized=False,
         )
 
 
@@ -709,9 +723,12 @@ class DatafactoryCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
+        return NormalizedPitchDimensions(
             x_dim=Dimension(-1, 1),
             y_dim=Dimension(-1, 1),
+            pitch_length=105,
+            pitch_width=68,
+            standardized=True,
         )
 
 
@@ -731,11 +748,11 @@ class StatsPerformCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return PitchDimensions(
+        return NormalizedPitchDimensions(
             x_dim=Dimension(0, 100),
             y_dim=Dimension(0, 100),
-            length=self.length,
-            width=self.width,
+            pitch_length=self.length,
+            pitch_width=self.width,
         )
 
 

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -446,9 +446,8 @@ class Origin(Enum):
 
 @dataclass
 class CoordinateSystem(ABC):
-    normalized: bool
-    length: float = None
-    width: float = None
+    pitch_length: Optional[float] = None
+    pitch_width: Optional[float] = None
 
     def __eq__(self, other):
         if isinstance(other, CoordinateSystem):
@@ -480,6 +479,10 @@ class CoordinateSystem(ABC):
     def pitch_dimensions(self) -> PitchDimensions:
         raise NotImplementedError
 
+    @property
+    def normalized(self) -> bool:
+        return isinstance(self.pitch_dimensions, NormalizedPitchDimensions)
+
 
 @dataclass
 class KloppyCoordinateSystem(CoordinateSystem):
@@ -497,12 +500,12 @@ class KloppyCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        if self.length is not None and self.width is not None:
+        if self.pitch_length is not None and self.pitch_width is not None:
             return NormalizedPitchDimensions(
                 x_dim=Dimension(0, 1),
                 y_dim=Dimension(0, 1),
-                pitch_length=self.length,
-                pitch_width=self.width,
+                pitch_length=self.pitch_length,
+                pitch_width=self.pitch_width,
                 standardized=False,
             )
         else:
@@ -539,10 +542,10 @@ class TracabCoordinateSystem(CoordinateSystem):
     @property
     def pitch_dimensions(self) -> PitchDimensions:
         return MetricPitchDimensions(
-            x_dim=Dimension(-1 * self.length / 2, self.length / 2),
-            y_dim=Dimension(-1 * self.width / 2, self.width / 2),
-            pitch_length=self.length,
-            pitch_width=self.width,
+            x_dim=Dimension(-1 * self.pitch_length / 2, self.pitch_length / 2),
+            y_dim=Dimension(-1 * self.pitch_width / 2, self.pitch_width / 2),
+            pitch_length=self.pitch_length,
+            pitch_width=self.pitch_width,
             standardized=False,
         ).convert(to_unit=Unit.CENTIMETERS)
 
@@ -564,10 +567,10 @@ class SecondSpectrumCoordinateSystem(CoordinateSystem):
     @property
     def pitch_dimensions(self) -> PitchDimensions:
         return MetricPitchDimensions(
-            x_dim=Dimension(-1 * self.length / 2, self.length / 2),
-            y_dim=Dimension(-1 * self.width / 2, self.width / 2),
-            pitch_length=self.length,
-            pitch_width=self.width,
+            x_dim=Dimension(-1 * self.pitch_length / 2, self.pitch_length / 2),
+            y_dim=Dimension(-1 * self.pitch_width / 2, self.pitch_width / 2),
+            pitch_length=self.pitch_length,
+            pitch_width=self.pitch_width,
             standardized=False,
         )
 
@@ -588,7 +591,9 @@ class OptaCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return OptaPitchDimensions()
+        return OptaPitchDimensions(
+            pitch_length=self.pitch_length, pitch_width=self.pitch_width
+        )
 
 
 @dataclass
@@ -608,10 +613,10 @@ class SportecEventDataCoordinateSystem(CoordinateSystem):
     @property
     def pitch_dimensions(self) -> PitchDimensions:
         return MetricPitchDimensions(
-            x_dim=Dimension(0, self.length),
-            y_dim=Dimension(0, self.width),
-            pitch_length=self.length,
-            pitch_width=self.width,
+            x_dim=Dimension(0, self.pitch_length),
+            y_dim=Dimension(0, self.pitch_width),
+            pitch_length=self.pitch_length,
+            pitch_width=self.pitch_width,
             standardized=False,
         )
 
@@ -633,10 +638,10 @@ class SportecTrackingDataCoordinateSystem(CoordinateSystem):
     @property
     def pitch_dimensions(self) -> PitchDimensions:
         return MetricPitchDimensions(
-            x_dim=Dimension(-self.length / 2, self.length / 2),
-            y_dim=Dimension(-self.width / 2, self.width / 2),
-            pitch_length=self.length,
-            pitch_width=self.width,
+            x_dim=Dimension(-self.pitch_length / 2, self.pitch_length / 2),
+            y_dim=Dimension(-self.pitch_width / 2, self.pitch_width / 2),
+            pitch_length=self.pitch_length,
+            pitch_width=self.pitch_width,
             standardized=False,
         )
 
@@ -660,6 +665,8 @@ class StatsBombCoordinateSystem(CoordinateSystem):
         return ImperialPitchDimensions(
             x_dim=Dimension(0, 120),
             y_dim=Dimension(0, 80),
+            pitch_length=self.pitch_length,
+            pitch_width=self.pitch_width,
             standardized=True,
         )
 
@@ -679,7 +686,9 @@ class WyscoutCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return WyscoutPitchDimensions()
+        return WyscoutPitchDimensions(
+            pitch_length=self.pitch_length, pitch_width=self.pitch_width
+        )
 
 
 @dataclass
@@ -699,10 +708,10 @@ class SkillCornerCoordinateSystem(CoordinateSystem):
     @property
     def pitch_dimensions(self) -> PitchDimensions:
         return MetricPitchDimensions(
-            x_dim=Dimension(-1 * self.length / 2, self.length / 2),
-            y_dim=Dimension(-1 * self.width / 2, self.width / 2),
-            pitch_length=self.length,
-            pitch_width=self.width,
+            x_dim=Dimension(-1 * self.pitch_length / 2, self.pitch_length / 2),
+            y_dim=Dimension(-1 * self.pitch_width / 2, self.pitch_width / 2),
+            pitch_length=self.pitch_length,
+            pitch_width=self.pitch_width,
             standardized=False,
         )
 
@@ -723,13 +732,22 @@ class DatafactoryCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
-        return NormalizedPitchDimensions(
-            x_dim=Dimension(-1, 1),
-            y_dim=Dimension(-1, 1),
-            pitch_length=105,
-            pitch_width=68,
-            standardized=True,
-        )
+        if self.pitch_length is not None and self.pitch_width is not None:
+            return NormalizedPitchDimensions(
+                x_dim=Dimension(-1, 1),
+                y_dim=Dimension(-1, 1),
+                pitch_length=self.pitch_length,
+                pitch_width=self.pitch_width,
+                standardized=False,
+            )
+        else:
+            return NormalizedPitchDimensions(
+                x_dim=Dimension(-1, 1),
+                y_dim=Dimension(-1, 1),
+                pitch_length=105,
+                pitch_width=68,
+                standardized=True,
+            )
 
 
 @dataclass
@@ -748,11 +766,13 @@ class StatsPerformCoordinateSystem(CoordinateSystem):
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
+        # FIXME: This does not seem correct
         return NormalizedPitchDimensions(
             x_dim=Dimension(0, 100),
             y_dim=Dimension(0, 100),
-            pitch_length=self.length,
-            pitch_width=self.width,
+            pitch_length=105,
+            pitch_width=68,
+            standardized=True,
         )
 
 
@@ -775,45 +795,51 @@ class DatasetType(Enum):
 
 
 def build_coordinate_system(
-    provider: Provider, dataset_type: DatasetType = DatasetType.EVENT, **kwargs
-):
-    if provider == Provider.TRACAB:
-        return TracabCoordinateSystem(normalized=False, **kwargs)
+    provider: Provider,
+    dataset_type: DatasetType = DatasetType.EVENT,
+    pitch_length: Optional[float] = None,
+    pitch_width: Optional[float] = None,
+) -> CoordinateSystem:
+    """Build a coordinate system for a given provider and dataset type.
 
-    if provider == Provider.KLOPPY:
-        return KloppyCoordinateSystem(normalized=True, **kwargs)
+    Args:
+        provider: The provider of the dataset.
+        dataset_type: The type of the dataset.
+        pitch_length: The real length of the pitch.
+        pitch_width: The real width of the pitch.
 
-    if provider == Provider.METRICA:
-        return MetricaCoordinateSystem(normalized=True, **kwargs)
+    Returns:
+        The coordinate system for the given provider and dataset type.
+    """
+    coordinate_systems = {
+        Provider.TRACAB: TracabCoordinateSystem,
+        Provider.KLOPPY: KloppyCoordinateSystem,
+        Provider.METRICA: MetricaCoordinateSystem,
+        Provider.OPTA: OptaCoordinateSystem,
+        Provider.SPORTEC: {
+            DatasetType.EVENT: SportecEventDataCoordinateSystem,
+            DatasetType.TRACKING: SportecTrackingDataCoordinateSystem,
+        },
+        Provider.STATSBOMB: StatsBombCoordinateSystem,
+        Provider.WYSCOUT: WyscoutCoordinateSystem,
+        Provider.SKILLCORNER: SkillCornerCoordinateSystem,
+        Provider.DATAFACTORY: DatafactoryCoordinateSystem,
+        Provider.SECONDSPECTRUM: SecondSpectrumCoordinateSystem,
+        Provider.STATSPERFORM: StatsPerformCoordinateSystem,
+    }
 
-    if provider == Provider.OPTA:
-        return OptaCoordinateSystem(normalized=False, **kwargs)
-
-    if provider == Provider.SPORTEC:
-        if dataset_type == DatasetType.TRACKING:
-            return SportecTrackingDataCoordinateSystem(
-                normalized=False, **kwargs
+    if provider in coordinate_systems:
+        if isinstance(coordinate_systems[provider], dict):
+            assert dataset_type in coordinate_systems[provider]
+            return coordinate_systems[provider][dataset_type](
+                pitch_length=pitch_length, pitch_width=pitch_width
             )
         else:
-            return SportecEventDataCoordinateSystem(normalized=False, **kwargs)
-
-    if provider == Provider.STATSBOMB:
-        return StatsBombCoordinateSystem(normalized=False, **kwargs)
-
-    if provider == Provider.WYSCOUT:
-        return WyscoutCoordinateSystem(normalized=False, **kwargs)
-
-    if provider == Provider.SKILLCORNER:
-        return SkillCornerCoordinateSystem(normalized=False, **kwargs)
-
-    if provider == Provider.DATAFACTORY:
-        return DatafactoryCoordinateSystem(normalized=False, **kwargs)
-
-    if provider == Provider.SECONDSPECTRUM:
-        return SecondSpectrumCoordinateSystem(normalized=False, **kwargs)
-
-    if provider == Provider.STATSPERFORM:
-        return StatsPerformCoordinateSystem(normalized=False, **kwargs)
+            return coordinate_systems[provider](
+                pitch_length=pitch_length, pitch_width=pitch_width
+            )
+    else:
+        raise ValueError(f"Invalid provider: {provider}")
 
 
 class DatasetFlag(Flag):

--- a/kloppy/domain/models/pitch.py
+++ b/kloppy/domain/models/pitch.py
@@ -6,6 +6,9 @@ from typing import Optional
 
 from kloppy.exceptions import KloppyError
 
+DEFAULT_PITCH_LENGTH = 105.0
+DEFAULT_PITCH_WIDTH = 68.0
+
 
 class Unit(Enum):
     """Unit to measure distances on a pitch."""
@@ -268,14 +271,14 @@ class PitchDimensions:
             ),
         ]
 
-    def to_base(
+    def to_metric_base(
         self,
         point: Point,
-        pitch_length: float = 105.0,
-        pitch_width: float = 68.0,
+        pitch_length: float = DEFAULT_PITCH_LENGTH,
+        pitch_width: float = DEFAULT_PITCH_WIDTH,
     ) -> Point:
         """
-        Convert a point from the pitch dimensions to the IFAB pitch dimensions.
+        Convert a point from this pitch dimensions to the IFAB pitch dimensions.
 
         Arguments:
             point: The point to convert
@@ -382,14 +385,14 @@ class PitchDimensions:
                 ),
             )
 
-    def from_base(
+    def from_metric_base(
         self,
         point: Point,
-        pitch_length: float = 105.0,
-        pitch_width: float = 68.0,
+        pitch_length: float = DEFAULT_PITCH_LENGTH,
+        pitch_width: float = DEFAULT_PITCH_WIDTH,
     ) -> Point:
         """
-        Convert a point from the IFAB pitch dimensions to the regular pitch dimensions.
+        Convert a point from the IFAB pitch dimensions to this pitch dimensions.
 
         Arguments:
             point: The point to convert
@@ -517,13 +520,13 @@ class PitchDimensions:
                 "This may lead to incorrect results.",
                 stacklevel=2,
             )
-            pitch_length = 105
-            pitch_width = 68
+            pitch_length = DEFAULT_PITCH_LENGTH
+            pitch_width = DEFAULT_PITCH_WIDTH
         else:
             pitch_length = self.pitch_length
             pitch_width = self.pitch_width
-        point1_ifab = self.to_base(point1, pitch_length, pitch_width)
-        point2_ifab = self.to_base(point2, pitch_length, pitch_width)
+        point1_ifab = self.to_metric_base(point1, pitch_length, pitch_width)
+        point2_ifab = self.to_metric_base(point2, pitch_length, pitch_width)
         dist = point1_ifab.distance_to(point2_ifab)
         return Unit.METERS.convert(unit, dist)
 

--- a/kloppy/domain/models/pitch.py
+++ b/kloppy/domain/models/pitch.py
@@ -1,53 +1,56 @@
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 from math import sqrt
 from typing import Optional
 
 
-@dataclass
-class Dimension:
-    """
-    Attributes:
-        min: Minimal possible value within this dimension
-        max: Maximal possible value within this dimension
-    """
+class Unit(Enum):
+    """Unit to measure distances on a pitch."""
 
-    min: float
-    max: float
+    METERS = "m"
+    YARDS = "y"
+    CENTIMETERS = "cm"
+    FEET = "ft"
+    NORMED = "normed"
 
-    def __eq__(self, other):
-        if isinstance(self, Dimension):
-            return self.min == other.min and self.max == other.max
+    def convert(
+        self, to_unit: "Unit", value: float, base: Optional[float] = None
+    ) -> float:
+        """Converts a value from one unit to another.
 
-        return False
-
-    def to_base(self, value: float) -> float:
-        return (value - self.min) / (self.max - self.min)
-
-    def from_base(self, value: float) -> float:
-        return value * (self.max - self.min) + self.min
-
-
-@dataclass
-class PitchDimensions:
-    """
-    Attributes:
-        x_dim: See [`Dimension`][kloppy.domain.models.pitch.Dimension]
-        y_dim: See [`Dimension`][kloppy.domain.models.pitch.Dimension]
-        x_per_meter: number of units per meter in the x dimension
-        y_per_meter: number of units per meter in the y dimension
-    """
-
-    x_dim: Dimension
-    y_dim: Dimension
-    length: float = None
-    width: float = None
-
-    def __eq__(self, other):
-        if isinstance(self, PitchDimensions):
-            return self.x_dim == other.x_dim and self.y_dim == other.y_dim
-
-        return False
+        Arguments:
+            to_unit: The unit to convert to
+            value: The value to convert
+            base: The base value, required when converting to or from a normed unit
+        Returns:
+            The value converted to the target unit
+        """
+        conversion_factors = {
+            (Unit.METERS, Unit.METERS): 1,
+            (Unit.METERS, Unit.YARDS): 1.09361,
+            (Unit.METERS, Unit.CENTIMETERS): 100,
+            (Unit.METERS, Unit.FEET): 3.281,
+        }
+        if self == to_unit:
+            return value
+        elif self == Unit.NORMED:
+            if base is None:
+                raise ValueError("Base value is required for a normed unit")
+            return value * base
+        elif to_unit == Unit.NORMED:
+            if base is None:
+                raise ValueError("Base value is required for a normed unit")
+            return value / base
+        factor_to_meter = conversion_factors.get((Unit.METERS, self))
+        factor_from_meter = conversion_factors.get((Unit.METERS, to_unit))
+        assert (
+            factor_to_meter is not None
+        ), f"Conversion factor for {self} is not defined"
+        assert (
+            factor_from_meter is not None
+        ), f"Conversion factor for {to_unit} is not defined"
+        return value / factor_to_meter * factor_from_meter
 
 
 @dataclass(frozen=True)
@@ -83,3 +86,527 @@ class Point3D(Point):
     """
 
     z: Optional[float]
+
+
+@dataclass(frozen=True)
+class Dimension:
+    """
+    Attributes:
+        min: Minimal possible value within this dimension
+        max: Maximal possible value within this dimension
+    """
+
+    min: float
+    max: float
+
+    def to_base(self, value: float) -> float:
+        return (value - self.min) / (self.max - self.min)
+
+    def from_base(self, value: float) -> float:
+        return value * (self.max - self.min) + self.min
+
+
+@dataclass
+class PitchDimensions:
+    """Specifies the dimensions of a pitch.
+
+    Attributes:
+        x_dim: Limits of pitch boundaries in longitudinal direction.
+            See [`Dimension`][kloppy.domain.models.pitch.Dimension]
+        y_dim: Limits of pitch boundaries in lateral direction.
+            See [`Dimension`][kloppy.domain.models.pitch.Dimension]
+        standardized: Used to denote standardized pitch dimensions where data
+            is scaled along the axes independent of the actual dimensions of
+            the pitch. To get non-distored calculations, the `length` and
+            `width` of the pitch need to be specified.
+        unit: The unit in which distances are measured along the axes of the pitch.
+        goal_width: Width of the goal.
+        goal_height: Height of the goal.
+        six_yard_width: Width of the six yard box.
+        six_yard_length: Length of the six yard box.
+        penalty_area_width: Width of the penalty area.
+        penalty_area_length: Length of the penalty area.
+        circle_radius: Radius of the center circle (in the longitudinal direction).
+        corner_radius: Radius of the corner arcs.
+        penalty_spot_distance: Distance from the goal line to the penalty spot.
+        penalty_arc_radius: Radius of the penalty arc (in the longitudinal direction).
+        pitch_length: True length of the pitch, in meters.
+        pitch_width: True width of the pitch, in meters.
+    """
+
+    x_dim: Dimension
+    y_dim: Dimension
+    standardized: bool
+    unit: Unit
+
+    goal_width: float
+    goal_height: Optional[float]
+    six_yard_width: float
+    six_yard_length: float
+    penalty_area_width: float
+    penalty_area_length: float
+    circle_radius: float
+    corner_radius: float
+    penalty_spot_distance: float
+    penalty_arc_radius: float
+
+    pitch_length: Optional[float] = None
+    pitch_width: Optional[float] = None
+
+    def convert(self, to_unit: Unit) -> "PitchDimensions":
+        """Convert the pitch dimensions to another unit.
+
+        Arguments:
+            to_unit: The unit to convert to
+
+        Returns:
+            The pitch dimensions in the target unit
+        """
+        return PitchDimensions(
+            x_dim=Dimension(
+                min=self.unit.convert(to_unit, self.x_dim.min),
+                max=self.unit.convert(to_unit, self.x_dim.max),
+            ),
+            y_dim=Dimension(
+                min=self.unit.convert(to_unit, self.y_dim.min),
+                max=self.unit.convert(to_unit, self.y_dim.max),
+            ),
+            standardized=self.standardized,
+            unit=to_unit,
+            goal_width=self.unit.convert(to_unit, self.goal_width),
+            goal_height=self.unit.convert(to_unit, self.goal_height)
+            if self.goal_height is not None
+            else None,
+            six_yard_width=self.unit.convert(to_unit, self.six_yard_width),
+            six_yard_length=self.unit.convert(to_unit, self.six_yard_length),
+            penalty_area_width=self.unit.convert(
+                to_unit, self.penalty_area_width
+            ),
+            penalty_area_length=self.unit.convert(
+                to_unit, self.penalty_area_length
+            ),
+            circle_radius=self.unit.convert(to_unit, self.circle_radius),
+            corner_radius=self.unit.convert(to_unit, self.corner_radius),
+            penalty_spot_distance=self.unit.convert(
+                to_unit, self.penalty_spot_distance
+            ),
+            penalty_arc_radius=self.unit.convert(
+                to_unit, self.penalty_arc_radius
+            ),
+            pitch_length=self.pitch_length,
+            pitch_width=self.pitch_width,
+        )
+
+    def _transformation_zones_x(self, length: float):
+        penalty_arc = self.penalty_spot_distance + self.penalty_arc_radius
+        return [
+            # goal line to 6 yard box
+            (self.x_dim.min, self.x_dim.min + self.six_yard_length),
+            # 6 yard box to penalty spot
+            (
+                self.x_dim.min + self.six_yard_length,
+                self.x_dim.min + self.penalty_spot_distance,
+            ),
+            # penalty spot to penalty area
+            (
+                self.x_dim.min + self.penalty_spot_distance,
+                self.x_dim.min + self.penalty_area_length,
+            ),
+            # penalty area to penalty arc
+            (
+                self.x_dim.min + self.penalty_area_length,
+                self.x_dim.min + penalty_arc,
+            ),
+            # penalty arc to center circle
+            (
+                self.x_dim.min + penalty_arc,
+                self.x_dim.min + length / 2 - self.circle_radius,
+            ),
+            # center circle to center line
+            (
+                self.x_dim.min + length / 2 - self.circle_radius,
+                self.x_dim.min + length / 2,
+            ),
+        ]
+
+    def _transformation_zones_y(self, width: float):
+        return [
+            # side line to penalty area
+            (
+                self.y_dim.min,
+                self.y_dim.min + (width - self.penalty_area_width) / 2,
+            ),
+            # penalty area to six yard box
+            (
+                self.y_dim.min + (width - self.penalty_area_width) / 2,
+                self.y_dim.min + (width - self.six_yard_width) / 2,
+            ),
+            # six yard box to inside goalpost
+            (
+                self.y_dim.min + (width - self.six_yard_width) / 2,
+                self.y_dim.min + (width - self.goal_width) / 2,
+            ),
+            # inside goalpost to center
+            (
+                self.y_dim.min + (width - self.goal_width) / 2,
+                self.y_dim.min + width / 2,
+            ),
+        ]
+
+    def to_base(
+        self,
+        point: Point,
+        pitch_length: float = 105.0,
+        pitch_width: float = 68.0,
+    ) -> Point:
+        """
+        Convert a point from the pitch dimensions to the IFAB pitch dimensions.
+
+        Arguments:
+            point: The point to convert
+
+        Returns:
+            The point in the IFAB pitch dimensions
+        """
+        ifab_dims = MetricPitchDimensions(
+            x_dim=Dimension(0, pitch_length),
+            y_dim=Dimension(0, pitch_width),
+            pitch_length=pitch_length,
+            pitch_width=pitch_width,
+            standardized=False,
+        )
+        x_ifab_zones = ifab_dims._transformation_zones_x(pitch_length)
+        y_ifab_zones = ifab_dims._transformation_zones_y(pitch_width)
+        x_from_zones = self._transformation_zones_x(
+            self.x_dim.max - self.x_dim.min
+        )
+        y_from_zones = self._transformation_zones_y(
+            self.y_dim.max - self.y_dim.min
+        )
+
+        def transform(v, from_zones, from_length, ifab_zones, ifab_length):
+            mirror = False
+            if v > from_zones[-1][1]:
+                v = from_length - (v - from_zones[0][0]) + from_zones[0][0]
+                mirror = True
+            # find the zone the v coordinate is in
+            zone = next(
+                (
+                    idx
+                    for idx, zone in enumerate(from_zones)
+                    if zone[0] <= v <= zone[1]
+                )
+            )
+            scale = (
+                # length of the zone in IFAB dimensions
+                (ifab_zones[zone][1] - ifab_zones[zone][0])
+                # length of the zone in the original dimensions
+                / (from_zones[zone][1] - from_zones[zone][0])
+            )
+            # ifab = smallest IFAB value of the zone + (v - smallest v value of the zone) * scaling factor of the zone
+            ifab = ifab_zones[zone][0] + (v - from_zones[zone][0]) * scale
+            if mirror:
+                ifab = ifab_length - ifab
+            return ifab
+
+        if isinstance(point, Point3D):
+            return Point3D(
+                x=transform(
+                    point.x,
+                    x_from_zones,
+                    self.x_dim.max - self.x_dim.min,
+                    x_ifab_zones,
+                    pitch_length,
+                ),
+                y=transform(
+                    point.y,
+                    y_from_zones,
+                    self.y_dim.max - self.y_dim.min,
+                    y_ifab_zones,
+                    pitch_width,
+                ),
+                z=point.z * 2.44 / self.goal_height
+                if self.goal_height is not None
+                else point.z,
+            )
+        else:
+            return Point(
+                x=transform(
+                    point.x,
+                    x_from_zones,
+                    self.x_dim.max - self.x_dim.min,
+                    x_ifab_zones,
+                    pitch_length,
+                ),
+                y=transform(
+                    point.y,
+                    y_from_zones,
+                    self.y_dim.max - self.y_dim.min,
+                    y_ifab_zones,
+                    pitch_width,
+                ),
+            )
+
+    def from_base(
+        self,
+        point: Point,
+        pitch_length: float = 105.0,
+        pitch_width: float = 68.0,
+    ) -> Point:
+        """
+        Convert a point from the IFAB pitch dimensions to the regular pitch dimensions.
+
+        Arguments:
+            point: The point to convert
+
+        Returns:
+            The point in the regular pitch dimensions
+        """
+        ifab_dims = MetricPitchDimensions(
+            x_dim=Dimension(0, pitch_length),
+            y_dim=Dimension(0, pitch_width),
+            pitch_length=pitch_length,
+            pitch_width=pitch_width,
+            standardized=False,
+        )
+        x_ifab_zones = ifab_dims._transformation_zones_x(pitch_length)
+        y_ifab_zones = ifab_dims._transformation_zones_y(pitch_width)
+        x_to_zones = self._transformation_zones_x(
+            self.x_dim.max - self.x_dim.min
+        )
+        y_to_zones = self._transformation_zones_y(
+            self.y_dim.max - self.y_dim.min
+        )
+
+        def transform(v, to_zones, to_length, ifab_zones, ifab_length):
+            mirror = False
+            if v > ifab_length / 2:
+                v = ifab_length - v
+                mirror = True
+            # find the zone the v coordinate is in
+            zone = next(
+                (
+                    idx
+                    for idx, zone in enumerate(ifab_zones)
+                    if zone[0] <= v <= zone[1]
+                )
+            )
+            scale = (
+                # length of the zone in the original dimensions
+                (to_zones[zone][1] - to_zones[zone][0])
+                # length of the zone in IFAB dimensions
+                / (ifab_zones[zone][1] - ifab_zones[zone][0])
+            )
+            # ifab = smallest IFAB value of the zone + (v - smallest v value of the zone) * scaling factor of the zone
+            v = to_zones[zone][0] + (v - ifab_zones[zone][0]) * scale
+            if mirror:
+                v = to_length - v
+            return v
+
+        if isinstance(point, Point3D):
+            return Point3D(
+                x=transform(
+                    point.x,
+                    x_to_zones,
+                    self.x_dim.max - self.x_dim.min,
+                    x_ifab_zones,
+                    pitch_length,
+                ),
+                y=transform(
+                    point.y,
+                    y_to_zones,
+                    self.y_dim.max - self.y_dim.min,
+                    y_ifab_zones,
+                    pitch_width,
+                ),
+                z=point.z * self.goal_height / 2.44
+                if self.goal_height is not None
+                else point.z,
+            )
+        else:
+            return Point(
+                x=transform(
+                    point.x,
+                    x_to_zones,
+                    self.x_dim.max - self.x_dim.min,
+                    x_ifab_zones,
+                    pitch_length,
+                ),
+                y=transform(
+                    point.y,
+                    y_to_zones,
+                    self.y_dim.max - self.y_dim.min,
+                    y_ifab_zones,
+                    pitch_width,
+                ),
+            )
+
+    def distance_between(
+        self, point1: Point, point2: Point, unit: Unit = Unit.METERS
+    ) -> float:
+        """
+        Calculate the distance between two points in the coordinate system.
+
+        Arguments:
+            point1: The first point
+            point2: The second point
+            unit: The unit to measure the distance in
+
+        Returns:
+            The distance between the two points in the given unit
+        """
+        if self.pitch_length is None or self.pitch_width is None:
+            warnings.warn(
+                "The pitch length and width are not specified. "
+                "Assuming a standard pitch size of 105x68 meters. "
+                "This may lead to incorrect results.",
+                stacklevel=2,
+            )
+            pitch_length = 105
+            pitch_width = 68
+        else:
+            pitch_length = self.pitch_length
+            pitch_width = self.pitch_width
+        point1_ifab = self.to_base(point1, pitch_length, pitch_width)
+        point2_ifab = self.to_base(point2, pitch_length, pitch_width)
+        dist = point1_ifab.distance_to(point2_ifab)
+        return Unit.METERS.convert(unit, dist)
+
+
+@dataclass
+class MetricPitchDimensions(PitchDimensions):
+    """The standard pitch dimensions in meters by IFAB regulations.
+
+    For national matches, the length of the pitch can be between 90 and 120
+    meters, and the width can be between 45 and 90 meters. For international
+    matches, the length can be between 100 and 110 meters, and the width can
+    be between 64 and 75 meters. All other dimensions are fixed.
+
+    See https://www.theifab.com/laws/latest/the-field-of-play.
+    """
+
+    unit: Unit = Unit.METERS
+
+    goal_width: float = 7.32
+    goal_height: Optional[float] = 2.44
+    six_yard_width: float = 18.32
+    six_yard_length: float = 5.5
+    penalty_area_width: float = 40.32
+    penalty_area_length: float = 16.5
+    circle_radius: float = 9.15
+    corner_radius: float = 1
+    penalty_spot_distance: float = 11
+    penalty_arc_radius: float = 9.15
+
+
+@dataclass
+class ImperialPitchDimensions(PitchDimensions):
+    """The standard pitch dimensions in yards by IFAB regulations.
+
+    For national matches, the length of the pitch can be between 100 and 130
+    yards, and the width can be between 50 and 100 yards. For international
+    matches, the length can be between 110 and 120 yards, and the width can
+    be between 70 and 80 yards. All other dimensions are fixed.
+
+    See https://www.theifab.com/laws/latest/the-field-of-play.
+    """
+
+    unit: Unit = Unit.YARDS
+
+    goal_width: float = 8
+    goal_height: Optional[float] = 2.66
+    six_yard_width: float = 20
+    six_yard_length: float = 6
+    penalty_area_width: float = 44
+    penalty_area_length: float = 18
+    circle_radius: float = 10
+    corner_radius: float = 1
+    penalty_spot_distance: float = 12
+    penalty_arc_radius: float = 10
+
+
+@dataclass
+class NormalizedPitchDimensions(MetricPitchDimensions):
+    """The standard pitch dimensions in normalized units.
+
+    The pitch dimensions are normalized to a unit square, where the length
+    and width of the pitch are 1. All other dimensions are scaled accordingly.
+    """
+
+    x_dim: Dimension = Dimension(0, 1)
+    y_dim: Dimension = Dimension(0, 1)
+    standardized: bool = False
+    unit: Unit = Unit.NORMED
+
+    def __post_init__(self):
+        if self.pitch_length is None or self.pitch_width is None:
+            raise ValueError("The pitch length and width need to be specified")
+        dim_width = self.y_dim.max - self.y_dim.min
+        dim_length = self.x_dim.max - self.x_dim.min
+        self.goal_width = self.goal_width / self.pitch_width * dim_width
+        self.six_yard_width = (
+            self.six_yard_width / self.pitch_width * dim_width
+        )
+        self.six_yard_length = (
+            self.six_yard_length / self.pitch_length * dim_length
+        )
+        self.penalty_area_width = (
+            self.penalty_area_width / self.pitch_width * dim_width
+        )
+        self.penalty_area_length = (
+            self.penalty_area_length / self.pitch_length * dim_length
+        )
+        self.circle_radius = (
+            self.circle_radius / self.pitch_length * dim_length
+        )
+        self.corner_radius = (
+            self.corner_radius / self.pitch_length * dim_length
+        )
+        self.penalty_spot_distance = (
+            self.penalty_spot_distance / self.pitch_length * dim_length
+        )
+        self.penalty_arc_radius = (
+            self.penalty_arc_radius / self.pitch_length * dim_length
+        )
+
+
+@dataclass
+class OptaPitchDimensions(PitchDimensions):
+    """The pitch dimensions used by Opta."""
+
+    x_dim: Dimension = Dimension(0, 100)
+    y_dim: Dimension = Dimension(0, 100)
+    standardized: bool = True
+    unit: Unit = Unit.NORMED
+
+    goal_width: float = 9.6
+    goal_height: Optional[float] = 38
+    six_yard_width: float = 26.4
+    six_yard_length: float = 5.8
+    penalty_area_width: float = 57.8
+    penalty_area_length: float = 17.0
+    circle_radius: float = 9.00
+    corner_radius: float = 0.97
+    penalty_spot_distance: float = 11.5
+    penalty_arc_radius: float = 8.9
+
+
+@dataclass
+class WyscoutPitchDimensions(PitchDimensions):
+    """The pitch dimensions used by Wyscout."""
+
+    x_dim: Dimension = Dimension(0, 100)
+    y_dim: Dimension = Dimension(0, 100)
+    standardized: bool = True
+    unit: Unit = Unit.NORMED
+
+    goal_width: float = 12.0
+    goal_height: Optional[float] = None
+    six_yard_width: float = 26.0
+    six_yard_length: float = 6.0
+    penalty_area_width: float = 62.0
+    penalty_area_length: float = 16.0
+    circle_radius: float = 8.84  # inferred
+    corner_radius: float = 0.97  # inferred
+    penalty_spot_distance: float = 10.0
+    penalty_arc_radius: float = 7.74  # inferred

--- a/kloppy/domain/services/transformers/dataset.py
+++ b/kloppy/domain/services/transformers/dataset.py
@@ -239,23 +239,20 @@ class DatasetTransformer:
         if not point:
             return None
 
-        x = self._from_pitch_dimensions.x_dim.to_base(point.x)
-        y = self._from_pitch_dimensions.y_dim.to_base(point.y)
+        point_base = self._from_pitch_dimensions.to_base(point)
 
         if (
             self._from_coordinate_system.vertical_orientation
             != self._to_coordinate_system.vertical_orientation
         ):
-            y = 1 - y
+            point_base = replace(
+                point_base,
+                y=68 - point_base.y,
+            )
 
-        if not self._to_coordinate_system.normalized:
-            x = self._to_pitch_dimensions.x_dim.from_base(x)
-            y = self._to_pitch_dimensions.y_dim.from_base(y)
+        point_to = self._to_pitch_dimensions.from_base(point_base)
 
-        if isinstance(point, Point3D):
-            return Point3D(x=x, y=y, z=point.z)
-        else:
-            return Point(x=x, y=y)
+        return point_to
 
     def __flip_frame(self, frame: Frame):
         players_data = {}
@@ -470,24 +467,24 @@ class DatasetTransformerBuilder:
 
     def build(
         self,
-        length: float,
-        width: float,
         provider: Provider,
         dataset_type: DatasetType,
+        pitch_length: Optional[float] = None,
+        pitch_width: Optional[float] = None,
     ):
         from_coordinate_system = build_coordinate_system(
             # This comment forces black to keep the arguments as multi-line
             provider,
-            length=length,
-            width=width,
             dataset_type=dataset_type,
+            pitch_length=pitch_length,
+            pitch_width=pitch_width,
         )
 
         to_coordinate_system = build_coordinate_system(
             self.to_coordinate_system,
-            length=length,
-            width=width,
             dataset_type=self.to_dataset_type or dataset_type,
+            pitch_length=pitch_length,
+            pitch_width=pitch_width,
         )
 
         return DatasetTransformer(

--- a/kloppy/domain/services/transformers/dataset.py
+++ b/kloppy/domain/services/transformers/dataset.py
@@ -102,16 +102,10 @@ class DatasetTransformer:
         if point is None:
             return None
 
-        x_base = self._from_pitch_dimensions.x_dim.to_base(point.x)
-        y_base = self._from_pitch_dimensions.y_dim.to_base(point.y)
+        point_base = self._from_pitch_dimensions.to_base(point)
+        point_to = self._to_pitch_dimensions.from_base(point_base)
 
-        x = self._to_pitch_dimensions.x_dim.from_base(x_base)
-        y = self._to_pitch_dimensions.y_dim.from_base(y_base)
-
-        if isinstance(point, Point3D):
-            return Point3D(x=x, y=y, z=point.z)
-        else:
-            return Point(x=x, y=y)
+        return point_to
 
     def flip_point(
         self, point: Union[Point, Point3D, None]

--- a/kloppy/domain/services/transformers/dataset.py
+++ b/kloppy/domain/services/transformers/dataset.py
@@ -21,6 +21,8 @@ from kloppy.domain import (
     Provider,
     build_coordinate_system,
     DatasetType,
+    DEFAULT_PITCH_LENGTH,
+    DEFAULT_PITCH_WIDTH,
 )
 from kloppy.domain.models.event import Event
 from kloppy.exceptions import KloppyError
@@ -102,8 +104,21 @@ class DatasetTransformer:
         if point is None:
             return None
 
-        point_base = self._from_pitch_dimensions.to_base(point)
-        point_to = self._to_pitch_dimensions.from_base(point_base)
+        base_pitch_length = (
+            self._from_pitch_dimensions.pitch_length or DEFAULT_PITCH_LENGTH
+        )
+        base_pitch_width = (
+            self._from_pitch_dimensions.pitch_width or DEFAULT_PITCH_WIDTH
+        )
+
+        point_base = self._from_pitch_dimensions.to_metric_base(
+            point, pitch_length=base_pitch_length, pitch_width=base_pitch_width
+        )
+        point_to = self._to_pitch_dimensions.from_metric_base(
+            point_base,
+            pitch_length=base_pitch_length,
+            pitch_width=base_pitch_width,
+        )
 
         return point_to
 
@@ -239,7 +254,16 @@ class DatasetTransformer:
         if not point:
             return None
 
-        point_base = self._from_pitch_dimensions.to_base(point)
+        base_pitch_length = (
+            self._from_pitch_dimensions.pitch_length or DEFAULT_PITCH_LENGTH
+        )
+        base_pitch_width = (
+            self._from_pitch_dimensions.pitch_width or DEFAULT_PITCH_WIDTH
+        )
+
+        point_base = self._from_pitch_dimensions.to_metric_base(
+            point, pitch_length=base_pitch_length, pitch_width=base_pitch_width
+        )
 
         if (
             self._from_coordinate_system.vertical_orientation
@@ -247,10 +271,14 @@ class DatasetTransformer:
         ):
             point_base = replace(
                 point_base,
-                y=68 - point_base.y,
+                y=base_pitch_width - point_base.y,
             )
 
-        point_to = self._to_pitch_dimensions.from_base(point_base)
+        point_to = self._to_pitch_dimensions.from_metric_base(
+            point_base,
+            pitch_length=base_pitch_length,
+            pitch_width=base_pitch_width,
+        )
 
         return point_to
 

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -1,9 +1,7 @@
 from typing import Union, Optional
-from collections.abc import Sequence
 
 from .domain import (
     Dataset,
-    Dimension,
     Orientation,
     PitchDimensions,
     DatasetTransformer,
@@ -16,7 +14,7 @@ from .domain import (
 def transform(
     dataset: Dataset,
     to_orientation: Optional[Union[Orientation, str]] = None,
-    to_pitch_dimensions: Optional[Union[PitchDimensions, Sequence]] = None,
+    to_pitch_dimensions: Optional[PitchDimensions] = None,
     to_coordinate_system: Optional[
         Union[CoordinateSystem, Provider, str]
     ] = None,
@@ -24,15 +22,6 @@ def transform(
     # convert raw orientation to object
     if to_orientation is not None and isinstance(to_orientation, str):
         to_orientation = Orientation[to_orientation.upper()]
-
-    # convert raw pitch dimensions to object
-    if to_pitch_dimensions is not None and isinstance(
-        to_pitch_dimensions, Sequence
-    ):
-        to_pitch_dimensions = PitchDimensions(
-            x_dim=Dimension(*to_pitch_dimensions[0]),
-            y_dim=Dimension(*to_pitch_dimensions[1]),
-        )
 
     # convert raw coordinate system to object
     if to_coordinate_system is not None:

--- a/kloppy/helpers.py
+++ b/kloppy/helpers.py
@@ -28,14 +28,14 @@ def transform(
         if isinstance(to_coordinate_system, str):
             to_coordinate_system = build_coordinate_system(
                 provider=Provider[to_coordinate_system.upper()],
-                length=dataset.metadata.coordinate_system.length,
-                width=dataset.metadata.coordinate_system.width,
+                pitch_length=dataset.metadata.coordinate_system.pitch_length,
+                pitch_width=dataset.metadata.coordinate_system.pitch_width,
             )
         elif isinstance(to_coordinate_system, Provider):
             to_coordinate_system = build_coordinate_system(
                 provider=to_coordinate_system,
-                length=dataset.metadata.coordinate_system.length,
-                width=dataset.metadata.coordinate_system.width,
+                pitch_length=dataset.metadata.coordinate_system.pitch_length,
+                pitch_width=dataset.metadata.coordinate_system.pitch_width,
             )
 
     return DatasetTransformer.transform_dataset(

--- a/kloppy/infra/serializers/event/datafactory/deserializer.py
+++ b/kloppy/infra/serializers/event/datafactory/deserializer.py
@@ -353,7 +353,7 @@ class DatafactoryDeserializer(EventDataDeserializer[DatafactoryInputs]):
         return Provider.DATAFACTORY
 
     def deserialize(self, inputs: DatafactoryInputs) -> EventDataset:
-        transformer = self.get_transformer(length=2, width=2)
+        transformer = self.get_transformer()
 
         with performance_logging("load data", logger=logger):
             data = json.load(inputs.event_data)

--- a/kloppy/infra/serializers/event/deserializer.py
+++ b/kloppy/infra/serializers/event/deserializer.py
@@ -44,13 +44,16 @@ class EventDataDeserializer(ABC, Generic[T]):
         return event.event_type in self.event_types
 
     def get_transformer(
-        self, length: float, width: float, provider: Optional[Provider] = None
+        self,
+        pitch_length: Optional[float] = None,
+        pitch_width: Optional[float] = None,
+        provider: Optional[Provider] = None,
     ) -> DatasetTransformer:
         return self.transformer_builder.build(
-            length=length,
-            width=width,
             provider=provider or self.provider,
             dataset_type=DatasetType.EVENT,
+            pitch_length=pitch_length,
+            pitch_width=pitch_width,
         )
 
     @property

--- a/kloppy/infra/serializers/event/metrica/json_deserializer.py
+++ b/kloppy/infra/serializers/event/metrica/json_deserializer.py
@@ -255,8 +255,8 @@ class MetricaJsonEventDataDeserializer(
             )
 
             transformer = self.get_transformer(
-                length=metadata.pitch_dimensions.pitch_length,
-                width=metadata.pitch_dimensions.pitch_width,
+                pitch_length=metadata.pitch_dimensions.pitch_length,
+                pitch_width=metadata.pitch_dimensions.pitch_width,
             )
 
         with performance_logging("parse data", logger=logger):

--- a/kloppy/infra/serializers/event/metrica/json_deserializer.py
+++ b/kloppy/infra/serializers/event/metrica/json_deserializer.py
@@ -255,8 +255,8 @@ class MetricaJsonEventDataDeserializer(
             )
 
             transformer = self.get_transformer(
-                length=metadata.pitch_dimensions.length,
-                width=metadata.pitch_dimensions.width,
+                length=metadata.pitch_dimensions.pitch_length,
+                width=metadata.pitch_dimensions.pitch_width,
             )
 
         with performance_logging("parse data", logger=logger):

--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -689,7 +689,7 @@ class OptaDeserializer(EventDataDeserializer[OptaInputs]):
         return Provider.OPTA
 
     def deserialize(self, inputs: OptaInputs) -> EventDataset:
-        transformer = self.get_transformer(length=100, width=100)
+        transformer = self.get_transformer()
 
         with performance_logging("load data", logger=logger):
             f7_root = objectify.fromstring(inputs.f7_data.read())

--- a/kloppy/infra/serializers/event/sportec/deserializer.py
+++ b/kloppy/infra/serializers/event/sportec/deserializer.py
@@ -387,7 +387,8 @@ class SportecEventDataDeserializer(
             sportec_metadata = sportec_metadata_from_xml_elm(match_root)
             teams = home_team, away_team = sportec_metadata.teams
             transformer = self.get_transformer(
-                length=sportec_metadata.x_max, width=sportec_metadata.y_max
+                pitch_length=sportec_metadata.x_max,
+                pitch_width=sportec_metadata.y_max,
             )
 
             periods = []

--- a/kloppy/infra/serializers/event/statsbomb/deserializer.py
+++ b/kloppy/infra/serializers/event/statsbomb/deserializer.py
@@ -38,7 +38,7 @@ class StatsBombDeserializer(EventDataDeserializer[StatsBombInputs]):
 
     def deserialize(self, inputs: StatsBombInputs) -> EventDataset:
         # Intialize coordinate system transformer
-        self.transformer = self.get_transformer(length=120, width=80)
+        self.transformer = self.get_transformer()
 
         # Load data from JSON files
         # and determine fidelity versions for x/y coordinates

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v2.py
@@ -474,7 +474,7 @@ class WyscoutDeserializerV2(EventDataDeserializer[WyscoutInputs]):
         return Provider.WYSCOUT
 
     def deserialize(self, inputs: WyscoutInputs) -> EventDataset:
-        transformer = self.get_transformer(length=100, width=100)
+        transformer = self.get_transformer()
 
         with performance_logging("load data", logger=logger):
             raw_events = json.load(inputs.event_data)

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -464,7 +464,7 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
         return Provider.WYSCOUT
 
     def deserialize(self, inputs: WyscoutInputs) -> EventDataset:
-        transformer = self.get_transformer(length=100, width=100)
+        transformer = self.get_transformer()
 
         with performance_logging("load data", logger=logger):
             raw_events = json.load(inputs.event_data)

--- a/kloppy/infra/serializers/tracking/deserializer.py
+++ b/kloppy/infra/serializers/tracking/deserializer.py
@@ -30,13 +30,16 @@ class TrackingDataDeserializer(ABC, Generic[T]):
         self.transformer_builder = DatasetTransformerBuilder(coordinate_system)
 
     def get_transformer(
-        self, length: float, width: float, provider: Optional[Provider] = None
+        self,
+        pitch_length: Optional[float] = None,
+        pitch_width: Optional[float] = None,
+        provider: Optional[Provider] = None,
     ) -> DatasetTransformer:
         return self.transformer_builder.build(
-            length=length,
-            width=width,
             provider=provider or self.provider,
             dataset_type=DatasetType.TRACKING,
+            pitch_length=pitch_length,
+            pitch_width=pitch_width,
         )
 
     @property

--- a/kloppy/infra/serializers/tracking/metrica_csv.py
+++ b/kloppy/infra/serializers/tracking/metrica_csv.py
@@ -146,14 +146,10 @@ class MetricaCSVTrackingDataDeserializer(
     def deserialize(
         self, inputs: MetricaCSVTrackingDataInputs
     ) -> TrackingDataset:
-        # TODO: consider passing this in __init__
-        length = 105
-        width = 68
-
         # consider reading this from data
         frame_rate = 25
 
-        transformer = self.get_transformer(length=length, width=width)
+        transformer = self.get_transformer()
 
         with performance_logging("prepare", logger=logger):
             home_iterator = self.__create_iterator(

--- a/kloppy/infra/serializers/tracking/metrica_epts/deserializer.py
+++ b/kloppy/infra/serializers/tracking/metrica_epts/deserializer.py
@@ -99,8 +99,8 @@ class MetricaEPTSTrackingDataDeserializer(
 
             if metadata.provider and metadata.pitch_dimensions:
                 transformer = self.get_transformer(
-                    length=metadata.pitch_dimensions.length,
-                    width=metadata.pitch_dimensions.width,
+                    length=metadata.pitch_dimensions.pitch_length,
+                    width=metadata.pitch_dimensions.pitch_width,
                     provider=metadata.coordinate_system.provider,
                 )
             else:

--- a/kloppy/infra/serializers/tracking/metrica_epts/deserializer.py
+++ b/kloppy/infra/serializers/tracking/metrica_epts/deserializer.py
@@ -99,9 +99,8 @@ class MetricaEPTSTrackingDataDeserializer(
 
             if metadata.provider and metadata.pitch_dimensions:
                 transformer = self.get_transformer(
-                    length=metadata.pitch_dimensions.pitch_length,
-                    width=metadata.pitch_dimensions.pitch_width,
-                    provider=metadata.coordinate_system.provider,
+                    pitch_length=metadata.pitch_dimensions.pitch_length,
+                    pitch_width=metadata.pitch_dimensions.pitch_width,
                 )
             else:
                 transformer = None

--- a/kloppy/infra/serializers/tracking/metrica_epts/metadata.py
+++ b/kloppy/infra/serializers/tracking/metrica_epts/metadata.py
@@ -6,6 +6,7 @@ import warnings
 from kloppy.domain import (
     Period,
     PitchDimensions,
+    NormalizedPitchDimensions,
     Dimension,
     Score,
     Ground,
@@ -170,11 +171,11 @@ def _load_pitch_dimensions(
     field_size_elm = field_size_path.find(metadata_elm).find("FieldSize")
 
     if field_size_elm is not None and normalized:
-        return PitchDimensions(
+        return NormalizedPitchDimensions(
             x_dim=Dimension(0, 1),
             y_dim=Dimension(0, 1),
-            length=int(field_size_elm.find("Width")),
-            width=int(field_size_elm.find("Height")),
+            pitch_length=int(field_size_elm.find("Width")),
+            pitch_width=int(field_size_elm.find("Height")),
         )
     else:
         return None
@@ -304,8 +305,8 @@ def load_metadata(
     if provider and pitch_dimensions:
         from_coordinate_system = build_coordinate_system(
             provider,
-            length=pitch_dimensions.length,
-            width=pitch_dimensions.width,
+            length=pitch_dimensions.pitch_length,
+            width=pitch_dimensions.pitch_width,
         )
     else:
         from_coordinate_system = None

--- a/kloppy/infra/serializers/tracking/metrica_epts/metadata.py
+++ b/kloppy/infra/serializers/tracking/metrica_epts/metadata.py
@@ -305,8 +305,8 @@ def load_metadata(
     if provider and pitch_dimensions:
         from_coordinate_system = build_coordinate_system(
             provider,
-            length=pitch_dimensions.pitch_length,
-            width=pitch_dimensions.pitch_width,
+            pitch_length=pitch_dimensions.pitch_length,
+            pitch_width=pitch_dimensions.pitch_width,
         )
     else:
         from_coordinate_system = None

--- a/kloppy/infra/serializers/tracking/secondspectrum.py
+++ b/kloppy/infra/serializers/tracking/secondspectrum.py
@@ -231,7 +231,7 @@ class SecondSpectrumDeserializer(
         # Handles the tracking frame data
         with performance_logging("Loading data", logger=logger):
             transformer = self.get_transformer(
-                length=pitch_size_width, width=pitch_size_height
+                pitch_length=pitch_size_width, pitch_width=pitch_size_height
             )
 
             def _iter():

--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -300,7 +300,7 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
             pitch_size_length = metadata["pitch_length"]
 
             transformer = self.get_transformer(
-                length=pitch_size_length, width=pitch_size_width
+                pitch_length=pitch_size_length, pitch_width=pitch_size_width
             )
 
             home_team_id = metadata["home_team"]["id"]

--- a/kloppy/infra/serializers/tracking/sportec/deserializer.py
+++ b/kloppy/infra/serializers/tracking/sportec/deserializer.py
@@ -122,7 +122,8 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
             teams = home_team, away_team = sportec_metadata.teams
             periods = sportec_metadata.periods
             transformer = self.get_transformer(
-                length=sportec_metadata.x_max, width=sportec_metadata.y_max
+                pitch_length=sportec_metadata.x_max,
+                pitch_width=sportec_metadata.y_max,
             )
 
         with performance_logging("parse raw data", logger=logger):

--- a/kloppy/infra/serializers/tracking/statsperform.py
+++ b/kloppy/infra/serializers/tracking/statsperform.py
@@ -277,15 +277,10 @@ class StatsPerformDeserializer(TrackingDataDeserializer[StatsPerformInputs]):
 
         with performance_logging("Loading tracking data", logger=logger):
             frame_rate = self.__get_frame_rate(tracking_data)
-            pitch_size_length = 100
-            pitch_size_width = 100
 
             periods = self.__get_periods(tracking_data)
 
-            transformer = self.get_transformer(
-                length=pitch_size_length,
-                width=pitch_size_width,
-            )
+            transformer = self.get_transformer()
 
             def _iter():
                 n = 0

--- a/kloppy/infra/serializers/tracking/tracab.py
+++ b/kloppy/infra/serializers/tracking/tracab.py
@@ -158,7 +158,7 @@ class TRACABDeserializer(TrackingDataDeserializer[TRACABInputs]):
 
         with performance_logging("Loading data", logger=logger):
             transformer = self.get_transformer(
-                length=pitch_size_width, width=pitch_size_height
+                pitch_length=pitch_size_width, pitch_width=pitch_size_height
             )
 
             def _iter():

--- a/kloppy/tests/test_datafactory.py
+++ b/kloppy/tests/test_datafactory.py
@@ -63,4 +63,5 @@ class TestDatafactory:
     def test_correct_normalized_deserialization(self, event_data: str):
         dataset = datafactory.load(event_data=event_data)
 
-        assert dataset.events[0].coordinates == Point(0.505, 0.505)
+        assert dataset.events[0].coordinates.x == pytest.approx(0.505, 0.001)
+        assert dataset.events[0].coordinates.y == pytest.approx(0.505, 0.001)

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -276,9 +276,8 @@ class TestHelpers:
             to_coordinate_system=Provider.METRICA
         )
         transformerd_coordinate_system = MetricaCoordinateSystem(
-            normalized=True,
-            length=dataset.metadata.coordinate_system.length,
-            width=dataset.metadata.coordinate_system.width,
+            pitch_length=dataset.metadata.coordinate_system.pitch_length,
+            pitch_width=dataset.metadata.coordinate_system.pitch_width,
         )
 
         assert transformed_dataset.records[0].players_data[
@@ -419,8 +418,12 @@ class TestHelpers:
         incomplete_passes = df[
             (df.event_type == "PASS") & (df.result == "INCOMPLETE")
         ].reset_index()
-        assert incomplete_passes.loc[0, "end_coordinates_y"] == 0.90625
-        assert incomplete_passes.loc[0, "end_coordinates_x"] == 0.7125
+        assert incomplete_passes.loc[0, "end_coordinates_y"] == pytest.approx(
+            0.91519, 1e-4
+        )
+        assert incomplete_passes.loc[0, "end_coordinates_x"] == pytest.approx(
+            0.70945, 1e-4
+        )
 
     def test_to_pandas_additional_columns(self):
         tracking_data = self._get_tracking_dataset()

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -15,7 +15,7 @@ from kloppy.domain import (
     Point,
     AttackingDirection,
     TrackingDataset,
-    PitchDimensions,
+    NormalizedPitchDimensions,
     Dimension,
     Orientation,
     Provider,
@@ -53,8 +53,11 @@ class TestHelpers:
         ]
         metadata = Metadata(
             flags=(DatasetFlag.BALL_OWNING_TEAM),
-            pitch_dimensions=PitchDimensions(
-                x_dim=Dimension(0, 100), y_dim=Dimension(-50, 50)
+            pitch_dimensions=NormalizedPitchDimensions(
+                x_dim=Dimension(0, 100),
+                y_dim=Dimension(-50, 50),
+                pitch_length=105,
+                pitch_width=68,
             ),
             orientation=Orientation.HOME_AWAY,
             frame_rate=25,
@@ -107,7 +110,12 @@ class TestHelpers:
         # orientation change AND dimension scale
         transformed_dataset = tracking_data.transform(
             to_orientation="AWAY_HOME",
-            to_pitch_dimensions=[[0, 1], [0, 1]],
+            to_pitch_dimensions=NormalizedPitchDimensions(
+                x_dim=Dimension(min=0, max=1),
+                y_dim=Dimension(min=0, max=1),
+                pitch_length=105,
+                pitch_width=68,
+            ),
         )
 
         assert transformed_dataset.frames[0].ball_coordinates == Point3D(
@@ -122,8 +130,11 @@ class TestHelpers:
         assert transformed_dataset.metadata.coordinate_system is None
         assert (
             transformed_dataset.metadata.pitch_dimensions
-            == PitchDimensions(
-                x_dim=Dimension(min=0, max=1), y_dim=Dimension(min=0, max=1)
+            == NormalizedPitchDimensions(
+                x_dim=Dimension(min=0, max=1),
+                y_dim=Dimension(min=0, max=1),
+                pitch_length=105,
+                pitch_width=68,
             )
         )
 
@@ -131,8 +142,11 @@ class TestHelpers:
         tracking_data = self._get_tracking_dataset()
 
         transformed_dataset = tracking_data.transform(
-            to_pitch_dimensions=PitchDimensions(
-                x_dim=Dimension(min=0, max=1), y_dim=Dimension(min=0, max=1)
+            to_pitch_dimensions=NormalizedPitchDimensions(
+                x_dim=Dimension(min=0, max=1),
+                y_dim=Dimension(min=0, max=1),
+                pitch_length=105,
+                pitch_width=68,
             ),
         )
 
@@ -144,16 +158,25 @@ class TestHelpers:
         )
         assert (
             transformed_dataset.metadata.pitch_dimensions
-            == PitchDimensions(
-                x_dim=Dimension(min=0, max=1), y_dim=Dimension(min=0, max=1)
+            == NormalizedPitchDimensions(
+                x_dim=Dimension(min=0, max=1),
+                y_dim=Dimension(min=0, max=1),
+                pitch_length=105,
+                pitch_width=68,
             )
         )
 
     def test_transform_to_orientation(self):
+        to_pitch_dimensions = NormalizedPitchDimensions(
+            x_dim=Dimension(min=0, max=1),
+            y_dim=Dimension(min=0, max=1),
+            pitch_length=105,
+            pitch_width=68,
+        )
         # Create a dataset with the KLOPPY pitch dimensions
         # and HOME_AWAY orientation
         original = self._get_tracking_dataset().transform(
-            to_pitch_dimensions=[[0, 1], [0, 1]],
+            to_pitch_dimensions=to_pitch_dimensions,
         )
         assert original.metadata.orientation == Orientation.HOME_AWAY
         assert original.frames[0].ball_coordinates == Point3D(x=1, y=0, z=0)
@@ -165,7 +188,7 @@ class TestHelpers:
         # Transform to AWAY_HOME orientation
         transform1 = original.transform(
             to_orientation=Orientation.AWAY_HOME,
-            to_pitch_dimensions=[[0, 1], [0, 1]],
+            to_pitch_dimensions=to_pitch_dimensions,
         )
         assert transform1.metadata.orientation == Orientation.AWAY_HOME
         # all coordinates should be flipped
@@ -182,7 +205,7 @@ class TestHelpers:
         # Transform to STATIC_AWAY_HOME orientation
         transform2 = transform1.transform(
             to_orientation=Orientation.STATIC_AWAY_HOME,
-            to_pitch_dimensions=[[0, 1], [0, 1]],
+            to_pitch_dimensions=to_pitch_dimensions,
         )
         assert transform2.metadata.orientation == Orientation.STATIC_AWAY_HOME
         # all coordintes in the second half should be flipped
@@ -195,7 +218,7 @@ class TestHelpers:
         # Transform to BALL_OWNING_TEAM orientation
         transform3 = transform2.transform(
             to_orientation=Orientation.BALL_OWNING_TEAM,
-            to_pitch_dimensions=[[0, 1], [0, 1]],
+            to_pitch_dimensions=to_pitch_dimensions,
         )
         assert transform3.metadata.orientation == Orientation.BALL_OWNING_TEAM
         # the coordinates of frame 1 should be flipped
@@ -213,7 +236,7 @@ class TestHelpers:
         # this should be identical to BALL_OWNING_TEAM for tracking data
         transform4 = transform3.transform(
             to_orientation=Orientation.ACTION_EXECUTING_TEAM,
-            to_pitch_dimensions=[[0, 1], [0, 1]],
+            to_pitch_dimensions=to_pitch_dimensions,
         )
         assert (
             transform4.metadata.orientation
@@ -227,7 +250,7 @@ class TestHelpers:
         # Transform back to the original HOME_AWAY orientation
         transform5 = transform4.transform(
             to_orientation=Orientation.HOME_AWAY,
-            to_pitch_dimensions=[[0, 1], [0, 1]],
+            to_pitch_dimensions=to_pitch_dimensions,
         )
         # we should be back at the original
         for frame1, frame2 in zip(original.frames, transform5.frames):

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -282,7 +282,7 @@ class TestHelpers:
 
         assert transformed_dataset.records[0].players_data[
             player_home_19
-        ].coordinates == Point(x=0.3766, y=0.5489999999999999)
+        ].coordinates == Point(x=0.37660000000000005, y=0.5489999999999999)
         assert (
             transformed_dataset.metadata.orientation
             == dataset.metadata.orientation

--- a/kloppy/tests/test_metadata.py
+++ b/kloppy/tests/test_metadata.py
@@ -40,6 +40,20 @@ class TestPitchdimensions:
         assert round(ifab_point.x, 2) == 62.78
         assert round(ifab_point.y, 2) == 41.72
 
+    def test_to_base_dimensions_out_of_bounds(self):
+        pitch = NormalizedPitchDimensions(
+            x_dim=Dimension(-100, 100),
+            y_dim=Dimension(-50, 50),
+            pitch_length=120,
+            pitch_width=80,
+        )
+        ifab_point = pitch.to_base(Point(-100, 0))
+        assert ifab_point == Point(0, 34)
+        ifab_point = pitch.to_base(Point(-105, 0))
+        assert ifab_point == Point(-2.625, 34)
+        ifab_point = pitch.to_base(Point(105, 0))
+        assert ifab_point == Point(107.625, 34)
+
     def test_from_base_dimensions(self):
         pitch = OptaPitchDimensions()
 
@@ -54,6 +68,20 @@ class TestPitchdimensions:
         )
         assert round(ifab_point.x, 2) == 60
         assert round(ifab_point.y, 2) == 61
+
+    def test_from_base_dimensions_out_of_bounds(self):
+        pitch = NormalizedPitchDimensions(
+            x_dim=Dimension(-100, 100),
+            y_dim=Dimension(-50, 50),
+            pitch_length=120,
+            pitch_width=80,
+        )
+        point = pitch.from_base(Point(0, 34))
+        assert point == Point(-100, 0)
+        point = pitch.from_base(Point(-2.625, 34))
+        assert point == Point(-105, 0)
+        point = pitch.from_base(Point(107.625, 34))
+        assert point == Point(105, 0)
 
     def test_distance_between(self):
         pitch = OptaPitchDimensions(pitch_length=105, pitch_width=68)

--- a/kloppy/tests/test_metadata.py
+++ b/kloppy/tests/test_metadata.py
@@ -1,21 +1,109 @@
-from kloppy.domain import Dimension, PitchDimensions
+from math import sqrt
+import pytest
+
+from kloppy.domain import (
+    Dimension,
+    NormalizedPitchDimensions,
+    Point,
+    Point3D,
+    OptaPitchDimensions,
+    Unit,
+    MetricPitchDimensions,
+)
+from kloppy.domain.services.transformers import DatasetTransformer
 
 
 class TestPitchdimensions:
-    def test_pitchdimensions_properties(self):
-        pitch_without_scale = PitchDimensions(
-            x_dim=Dimension(-100, 100), y_dim=Dimension(-50, 50)
-        )
-
-        assert pitch_without_scale.length is None
-        assert pitch_without_scale.width is None
-
-        pitch_with_scale = PitchDimensions(
+    def test_normalized_pitchdimensions(self):
+        pitch_with_scale = NormalizedPitchDimensions(
             x_dim=Dimension(-100, 100),
             y_dim=Dimension(-50, 50),
-            length=120,
-            width=80,
+            pitch_length=120,
+            pitch_width=80,
         )
 
-        assert pitch_with_scale.length == 120
-        assert pitch_with_scale.width == 80
+        assert pitch_with_scale.pitch_length == 120
+        assert pitch_with_scale.pitch_width == 80
+
+    def test_to_base_dimensions(self):
+        pitch = OptaPitchDimensions()
+
+        ifab_point = pitch.to_base(Point(11.5, 50))
+        assert ifab_point == Point(11, 34)
+
+        ifab_point = pitch.to_base(Point3D(0, 50, 38))
+        assert ifab_point == Point3D(0, 34, 2.44)
+
+        ifab_point = pitch.to_base(
+            Point(60, 61), pitch_length=105, pitch_width=68
+        )
+        assert round(ifab_point.x, 2) == 62.78
+        assert round(ifab_point.y, 2) == 41.72
+
+    def test_from_base_dimensions(self):
+        pitch = OptaPitchDimensions()
+
+        opta_point = pitch.from_base(Point(11, 34))
+        assert opta_point == Point(11.5, 50)
+
+        opta_point = pitch.from_base(Point3D(0, 34, 2.44))
+        assert opta_point == Point3D(0, 50, 38)
+
+        ifab_point = pitch.from_base(
+            Point(62.78, 41.72), pitch_length=105, pitch_width=68
+        )
+        assert round(ifab_point.x, 2) == 60
+        assert round(ifab_point.y, 2) == 61
+
+    def test_distance_between(self):
+        pitch = OptaPitchDimensions(pitch_length=105, pitch_width=68)
+
+        distance = pitch.distance_between(
+            Point(0, 0),
+            Point(100, 100),
+        )
+        assert distance == sqrt(105**2 + 68**2)
+
+        distance = pitch.distance_between(Point(0, 50), Point(11.5, 50))
+        assert distance == 11
+
+        distance = pitch.distance_between(
+            Point(100, 50), Point(100 - 11.5, 50)
+        )
+        assert distance == 11
+
+        distance = pitch.distance_between(
+            Point(0, 50), Point(11.5, 50), unit=Unit.CENTIMETERS
+        )
+        assert distance == 1100
+
+        pitch = NormalizedPitchDimensions(
+            x_dim=Dimension(-100, 100),
+            y_dim=Dimension(-50, 50),
+            pitch_length=120,
+            pitch_width=80,
+        )
+        distance = pitch.distance_between(
+            Point(-100, -50),
+            Point(100, 50),
+        )
+        assert distance == sqrt(120**2 + 80**2)
+
+    def test_transform(self):
+        transformer = DatasetTransformer(
+            from_pitch_dimensions=OptaPitchDimensions(),
+            to_pitch_dimensions=MetricPitchDimensions(
+                x_dim=Dimension(0, 105),
+                y_dim=Dimension(0, 68),
+                pitch_length=105,
+                pitch_width=68,
+                standardized=False,
+            ),
+        )
+        # the corner of the penalty area should remain the corner of
+        # the penalty area in the new coordinate system
+        transformed_point = transformer.change_point_dimensions(
+            Point(17, 78.9)
+        )
+        assert transformed_point.x == pytest.approx(16.5)
+        assert transformed_point.y == pytest.approx(54.16)

--- a/kloppy/tests/test_metadata.py
+++ b/kloppy/tests/test_metadata.py
@@ -25,62 +25,62 @@ class TestPitchdimensions:
         assert pitch_with_scale.pitch_length == 120
         assert pitch_with_scale.pitch_width == 80
 
-    def test_to_base_dimensions(self):
+    def test_to_metric_base_dimensions(self):
         pitch = OptaPitchDimensions()
 
-        ifab_point = pitch.to_base(Point(11.5, 50))
+        ifab_point = pitch.to_metric_base(Point(11.5, 50))
         assert ifab_point == Point(11, 34)
 
-        ifab_point = pitch.to_base(Point3D(0, 50, 38))
+        ifab_point = pitch.to_metric_base(Point3D(0, 50, 38))
         assert ifab_point == Point3D(0, 34, 2.44)
 
-        ifab_point = pitch.to_base(
+        ifab_point = pitch.to_metric_base(
             Point(60, 61), pitch_length=105, pitch_width=68
         )
         assert round(ifab_point.x, 2) == 62.78
         assert round(ifab_point.y, 2) == 41.72
 
-    def test_to_base_dimensions_out_of_bounds(self):
+    def test_to_metric_base_dimensions_out_of_bounds(self):
         pitch = NormalizedPitchDimensions(
             x_dim=Dimension(-100, 100),
             y_dim=Dimension(-50, 50),
             pitch_length=120,
             pitch_width=80,
         )
-        ifab_point = pitch.to_base(Point(-100, 0))
+        ifab_point = pitch.to_metric_base(Point(-100, 0))
         assert ifab_point == Point(0, 34)
-        ifab_point = pitch.to_base(Point(-105, 0))
+        ifab_point = pitch.to_metric_base(Point(-105, 0))
         assert ifab_point == Point(-2.625, 34)
-        ifab_point = pitch.to_base(Point(105, 0))
+        ifab_point = pitch.to_metric_base(Point(105, 0))
         assert ifab_point == Point(107.625, 34)
 
-    def test_from_base_dimensions(self):
+    def test_from_metric_base_dimensions(self):
         pitch = OptaPitchDimensions()
 
-        opta_point = pitch.from_base(Point(11, 34))
+        opta_point = pitch.from_metric_base(Point(11, 34))
         assert opta_point == Point(11.5, 50)
 
-        opta_point = pitch.from_base(Point3D(0, 34, 2.44))
+        opta_point = pitch.from_metric_base(Point3D(0, 34, 2.44))
         assert opta_point == Point3D(0, 50, 38)
 
-        ifab_point = pitch.from_base(
+        ifab_point = pitch.from_metric_base(
             Point(62.78, 41.72), pitch_length=105, pitch_width=68
         )
         assert round(ifab_point.x, 2) == 60
         assert round(ifab_point.y, 2) == 61
 
-    def test_from_base_dimensions_out_of_bounds(self):
+    def test_from_metric_base_dimensions_out_of_bounds(self):
         pitch = NormalizedPitchDimensions(
             x_dim=Dimension(-100, 100),
             y_dim=Dimension(-50, 50),
             pitch_length=120,
             pitch_width=80,
         )
-        point = pitch.from_base(Point(0, 34))
+        point = pitch.from_metric_base(Point(0, 34))
         assert point == Point(-100, 0)
-        point = pitch.from_base(Point(-2.625, 34))
+        point = pitch.from_metric_base(Point(-2.625, 34))
         assert point == Point(-105, 0)
-        point = pitch.from_base(Point(107.625, 34))
+        point = pitch.from_metric_base(Point(107.625, 34))
         assert point == Point(105, 0)
 
     def test_distance_between(self):

--- a/kloppy/tests/test_metrica_epts.py
+++ b/kloppy/tests/test_metrica_epts.py
@@ -121,9 +121,8 @@ class TestMetricaEPTSTracking:
             first_player
         ].coordinates == Point(x=0.30602, y=0.97029)
 
-        assert dataset.records[0].ball_coordinates == Point3D(
-            x=0.52867, y=0.7069, z=None
-        )
+        assert dataset.records[0].ball_coordinates.x == pytest.approx(0.52867)
+        assert dataset.records[0].ball_coordinates.y == pytest.approx(0.7069)
 
     def test_other_data_deserialization(self, meta_data: str, raw_data: str):
         dataset = metrica.load_tracking_epts(

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -25,7 +25,7 @@ from kloppy.domain import (
     Orientation,
     PassQualifier,
     PassType,
-    PitchDimensions,
+    OptaPitchDimensions,
     Point,
     Point,
     Point3D,
@@ -149,9 +149,7 @@ class TestOptaMetadata:
 
     def test_pitch_dimensions(self, dataset):
         """It should set the correct pitch dimensions"""
-        assert dataset.metadata.pitch_dimensions == PitchDimensions(
-            x_dim=Dimension(0, 100), y_dim=Dimension(0, 100)
-        )
+        assert dataset.metadata.pitch_dimensions == OptaPitchDimensions()
 
     def test_coordinate_system(self, dataset):
         """It should set the correct coordinate system"""

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -154,7 +154,7 @@ class TestOptaMetadata:
     def test_coordinate_system(self, dataset):
         """It should set the correct coordinate system"""
         assert dataset.metadata.coordinate_system == build_coordinate_system(
-            Provider.OPTA, width=100, length=100
+            Provider.OPTA
         )
 
     def test_score(self, dataset):
@@ -196,7 +196,8 @@ class TestOptaEvent:
             f24_data=base_dir / "files" / "opta_f24.xml",
         )
         event = dataset.get_event_by_id("1510681159")
-        assert event.coordinates == Point(0.501, 0.506)
+        assert event.coordinates.x == pytest.approx(0.501, 0.001)
+        assert event.coordinates.y == pytest.approx(0.50672, 0.001)
 
     def test_ball_owning_team(self, dataset: EventDataset):
         """Test if the ball owning team is correctly set"""

--- a/kloppy/tests/test_secondspectrum.py
+++ b/kloppy/tests/test_secondspectrum.py
@@ -63,7 +63,7 @@ class TestSecondSpectrumTracking:
         home_player = dataset.metadata.teams[0].players[2]
         assert home_player.player_id == "8xwx2"
         assert dataset.records[0].players_coordinates[home_player] == Point(
-            x=-8.943903672572427, y=-28.171654132650364
+            x=-8.943903672572427, y=-28.171654132650365
         )
 
         away_player = dataset.metadata.teams[1].players[3]
@@ -96,7 +96,7 @@ class TestSecondSpectrumTracking:
 
         home_player = dataset.metadata.teams[0].players[2]
         assert dataset.records[0].players_coordinates[home_player] == Point(
-            x=0.4146981051733674, y=0.9144718866065965
+            x=0.4146981051733674, y=0.9144718866065964
         )
         assert (
             dataset.records[0].players_data[home_player].speed

--- a/kloppy/tests/test_skillcorner.py
+++ b/kloppy/tests/test_skillcorner.py
@@ -113,4 +113,4 @@ class TestSkillCornerTracking:
         home_player = dataset.metadata.teams[0].players[2]
         assert dataset.records[0].players_data[
             home_player
-        ].coordinates == Point(x=0.8225688718076191, y=0.6405503322430882)
+        ].coordinates == Point(x=0.8225688718076191, y=0.6405503322430883)

--- a/kloppy/tests/test_sportec.py
+++ b/kloppy/tests/test_sportec.py
@@ -83,7 +83,7 @@ class TestSportecEventData:
             event_data=event_data, meta_data=meta_data
         )
 
-        assert dataset.events[0].coordinates == Point(0.5640999999999999, 1)
+        assert dataset.events[0].coordinates == Point(0.5641, 1)
 
     def test_pass_receiver_coordinates(
         self, event_data: Path, meta_data: Path

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -172,7 +172,7 @@ class TestStatsBombMetadata:
     def test_coordinate_system(self, dataset):
         """It should set the correct coordinate system"""
         assert dataset.metadata.coordinate_system == build_coordinate_system(
-            Provider.STATSBOMB, width=80, length=120
+            Provider.STATSBOMB
         )
 
     @pytest.mark.xfail
@@ -497,10 +497,10 @@ class TestStatsBombEvent:
         player_3089 = dataset.metadata.teams[0].get_player_by_id("3089")
         assert freeze_frame.players_coordinates[
             player_3089
-        ].x == pytest.approx(0.762, abs=1e-2)
+        ].x == pytest.approx(0.756, abs=1e-2)
         assert freeze_frame.players_coordinates[
             player_3089
-        ].y == pytest.approx(0.352, abs=1e-2)
+        ].y == pytest.approx(0.340, abs=1e-2)
 
         # The 360 freeze-frame should have standardized coordinates
         pass_event = dataset.get_event_by_id(
@@ -515,28 +515,28 @@ class TestStatsBombEvent:
         print(coordinates_per_team)
         assert coordinates_per_team == {
             "Belgium": [
-                Point(x=0.29992169834015553, y=0.5208156671179599),
-                Point(x=0.30643713954672475, y=0.7026264079766127),
-                Point(x=0.3214467545271119, y=0.3826089652330575),
-                Point(x=0.405612967947393, y=0.9422736509345233),
-                Point(x=0.4062973621807315, y=0.0482915505598324),
-                Point(x=0.42465606231382946, y=0.5964959025774841),
-                Point(x=0.4508398556294095, y=0.5289610882963541),
-                Point(x=0.4890186975946768, y=0.2568344237508965),
-                Point(x=0.4950593030298559, y=0.7029586200529815),
-                Point(x=0.4995833333333334, y=0.499375),
+                Point(x=0.30230680550305883, y=0.5224074534269804),
+                Point(x=0.3084765294211162, y=0.7184206360532097),
+                Point(x=0.3226897158515237, y=0.37349986446702277),
+                Point(x=0.4023899669270551, y=0.9477821783616865),
+                Point(x=0.40303804636433893, y=0.04368333723843663),
+                Point(x=0.4212117680196045, y=0.6039661694463063),
+                Point(x=0.4485925347438968, y=0.5311757597543106),
+                Point(x=0.48851669519900487, y=0.23786065306469226),
+                Point(x=0.494833442596935, y=0.7187789039787056),
+                Point(x=0.49956428571428574, y=0.49932720588235296),
             ],
             "Portugal": [
-                Point(x=0.5007398055585528, y=0.64528577145353),
-                Point(x=0.503027413811032, y=0.8161700273569469),
-                Point(x=0.5276528464860737, y=0.2579702535077385),
-                Point(x=0.5278342018640673, y=0.3780770836091537),
-                Point(x=0.5771632092108575, y=0.5977748576718983),
-                Point(x=0.6031968709341459, y=0.5636937522375899),
-                Point(x=0.661570167297097, y=0.3648423832684863),
-                Point(x=0.6653717429879116, y=0.7616501561039648),
-                Point(x=0.665577307051358, y=0.5960104748540174),
-                Point(x=0.6887022647928279, y=0.4433104586034662),
+                Point(x=0.5007736252412294, y=0.6565826947047873),
+                Point(x=0.5031658098709648, y=0.8337119724588331),
+                Point(x=0.5289169766111513, y=0.23908556750834548),
+                Point(x=0.5291066225207104, y=0.36861254114712655),
+                Point(x=0.5806906702033539, y=0.605345434744204),
+                Point(x=0.6059524111158714, y=0.568591301432695),
+                Point(x=0.6612283488962987, y=0.3543398250934656),
+                Point(x=0.6648282083259679, y=0.7820736977591778),
+                Point(x=0.6650228649084968, y=0.6034426689602147),
+                Point(x=0.6869207840759295, y=0.43896225927824783),
             ],
         }
 

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -11,7 +11,7 @@ from kloppy.domain import (
     TakeOnResult,
     Dimension,
     BallState,
-    PitchDimensions,
+    ImperialPitchDimensions,
     CardQualifier,
     DatasetFlag,
     CarryResult,
@@ -165,8 +165,8 @@ class TestStatsBombMetadata:
 
     def test_pitch_dimensions(self, dataset):
         """It should set the correct pitch dimensions"""
-        assert dataset.metadata.pitch_dimensions == PitchDimensions(
-            x_dim=Dimension(0, 120), y_dim=Dimension(0, 80)
+        assert dataset.metadata.pitch_dimensions == ImperialPitchDimensions(
+            x_dim=Dimension(0, 120), y_dim=Dimension(0, 80), standardized=True
         )
 
     def test_coordinate_system(self, dataset):

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -100,4 +100,4 @@ class TestTracabTracking:
 
         assert dataset.records[0].players_data[
             player_home_19
-        ].coordinates == Point(x=0.3766, y=0.5489999999999999)
+        ].coordinates == Point(x=0.37660000000000005, y=0.5489999999999999)

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -119,7 +119,9 @@ class TestWyscoutV2:
 
     def test_correct_normalized_deserialization(self, event_v2_data: Path):
         dataset = wyscout.load(event_data=event_v2_data, data_version="V2")
-        assert dataset.records[2].coordinates == Point(0.29, 0.06)
+        assert dataset.records[2].coordinates == Point(
+            0.2981354967264447, 0.06427244582043344
+        )
 
 
 class TestWyscoutV3:
@@ -144,7 +146,9 @@ class TestWyscoutV3:
 
     def test_normalized_deserialization(self, event_v3_data: Path):
         dataset = wyscout.load(event_data=event_v3_data, data_version="V3")
-        assert dataset.records[2].coordinates == Point(0.36, 0.78)
+        assert dataset.records[2].coordinates == Point(
+            0.36417591801878735, 0.7695098039215686
+        )
 
     def test_goalkeeper_event(self, dataset: EventDataset):
         goalkeeper_event = dataset.get_event_by_id(1331979498)


### PR DESCRIPTION
This PR is a complete rewrite of the "PitchDimensions" domain model. It implements the following main features.

1. It implements piecewise linear transformations in each dimension (see Stats Perform MA3 docs, appendix 7) to reduce the error when transforming between different coordinate systems.

```python
transformer = DatasetTransformer(
    from_pitch_dimensions=OptaPitchDimensions(),
    to_pitch_dimensions=MetricPitchDimensions(
        x_dim=Dimension(0, 105),
        y_dim=Dimension(0, 68),
        pitch_length=105,
        pitch_width=68,
        standardized=False,
    ),
)

transformed_point = transformer.change_point_dimensions(
    Point(17, 78.9)   # the corner of the penalty area...
)
# ... remains the corner of the penalty area
assert transformed_point == Point(16.5, 54.16)
```

2. It makes it possible to compute distances between two points without having to transform the entire dataset to a metric coordinate system.

```python
pitch = OptaPitchDimensions(pitch_length=105, pitch_width=68)
distance = pitch.distance_between(Point(0, 50), Point(11.5, 50))
assert distance == 11  # the distance from the goal line to penalty spot should be 11m
````

3. Fixes #293 
4. Allows creating pitch dimensions with unknown boundaries. This will allow solving #299 .

## BREAKING CHANGES: 
This changes the interface of the `PitchDimensions` class.