### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
             python-version: "3.7"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
This pull request upgrades the `checkout` action from version 3 to version 4 and the `setup-python` action from version 3 to version 5.