### PR TITLE
Opta Incomplete / Live F7 missing Result tag fix

### DIFF
--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -704,9 +704,11 @@ class OptaDeserializer(EventDataDeserializer[OptaInputs]):
             matchdata_path = objectify.ObjectPath(
                 "SoccerFeed.SoccerDocument.MatchData"
             )
-            match_result_path = objectify.ObjectPath(
-                "SoccerFeed.SoccerDocument.MatchData.MatchInfo.Result"
+
+            result_elements = f7_root.xpath(
+                "/SoccerFeed/SoccerDocument/MatchData/MatchInfo/Result"
             )
+
             team_elms = list(
                 matchdata_path.find(f7_root).iterchildren("TeamData")
             )
@@ -726,13 +728,12 @@ class OptaDeserializer(EventDataDeserializer[OptaInputs]):
                     )
             score = Score(home=home_score, away=away_score)
             teams = [home_team, away_team]
-            try:
-              match_result_type = list(match_result_path.find(f7_root))[
-                    0
-                ].attrib["Type"]
-            except AttributeError:
+
+            if result_elements and "Type" in result_elements[0].attrib:
+                match_result_type = result_elements[0].attrib["Type"]
+            else:
                 match_result_type = None
-                
+
             periods = _create_periods(match_result_type)
 
             if len(home_team.players) == 0 or len(away_team.players) == 0:

--- a/kloppy/infra/serializers/event/opta/deserializer.py
+++ b/kloppy/infra/serializers/event/opta/deserializer.py
@@ -726,9 +726,13 @@ class OptaDeserializer(EventDataDeserializer[OptaInputs]):
                     )
             score = Score(home=home_score, away=away_score)
             teams = [home_team, away_team]
-            match_result_type = list(match_result_path.find(f7_root))[
-                0
-            ].attrib["Type"]
+            try:
+              match_result_type = list(match_result_path.find(f7_root))[
+                    0
+                ].attrib["Type"]
+            except AttributeError:
+                match_result_type = None
+                
             periods = _create_periods(match_result_type)
 
             if len(home_team.players) == 0 or len(away_team.players) == 0:


### PR DESCRIPTION
Let's try this again....

A really simple fix here. When loading opta event data (as shown below) for an incomplete f7 (read: during live matches) we get an AttributeError. 
```python
dataset = opta.load(
    f7_data="f7.xml",
    f24_data="f24.xml"
)
``` 

Error looks as follows:
```shell
Traceback (most recent call last):
  File "/workspaces/kloppy/_dev.py", line 3, in <module>
    dataset = opta.load(
  File "/workspaces/kloppy/kloppy/_providers/opta.py", line 35, in load
    return deserializer.deserialize(
  File "/workspaces/kloppy/kloppy/infra/serializers/event/opta/deserializer.py", line 729, in deserialize
    match_result_type = list(match_result_path.find(f7_root))[
  File "src/lxml/objectpath.pxi", line 55, in lxml.objectify.ObjectPath.__call__
  File "src/lxml/objectpath.pxi", line 219, in lxml.objectify._find_object_path
AttributeError: no such child: Result
``` 

Normally, in a completed game we'd have a Result tag that looks something like this:
```html
<Result Type="Aggregate" Winner="t12345" />
``` 

But, because the game is not finished yet there simply is no "Result" tag.

Doing a simple try / except block like below resolves this issue and creates a correct Kloppy EventDataset.
```python
try:
       match_result_type = list(match_result_path.find(f7_root))[
             0
      ].attrib["Type"]
except AttributeError:
      match_result_type = None
``` 

Not 100% sure if using a try-except block here is the best solution, but it works. 
