### PR TITLE
[Wyscout v3] add parsing of carry event 

### DIFF
--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -266,21 +266,10 @@ def _parse_interception(raw_event: Dict, next_event: Dict) -> Dict:
 def _parse_carry(raw_event: Dict, next_event: Dict, start_ts: Dict) -> Dict:
     qualifiers = _generic_qualifiers(raw_event)
     carry_info = raw_event["carry"]
-    if carry_info:
-        end_coordinates = Point(
-            x=float(carry_info["endLocation"]["x"]),
-            y=float(carry_info["endLocation"]["y"]),
-        )
-    elif next_event is not None:
-        end_coordinates = Point(
-            x=float(next_event["location"]["x"]),
-            y=float(next_event["location"]["y"]),
-        )
-    else:
-        end_coordinates = Point(
-            x=float(raw_event["location"]["x"]),
-            y=float(raw_event["location"]["y"]),
-        )
+    end_coordinates = Point(
+        x=float(carry_info["endLocation"]["x"]),
+        y=float(carry_info["endLocation"]["y"]),
+    )
 
     if next_event is not None:
         period_id = int(next_event["matchPeriod"].replace("H", ""))

--- a/kloppy/tests/files/wyscout_events_v3.json
+++ b/kloppy/tests/files/wyscout_events_v3.json
@@ -1088,6 +1088,81 @@
           "xg": 0
         }
       }
+    },{
+      "id": 139800001,
+      "matchId": 5352524,
+      "matchPeriod": "2H",
+      "minute": 50,
+      "second": 35,
+      "matchTimestamp": "00:50:35.129",
+      "videoTimestamp": "3078.129596",
+      "relatedEventId": null,
+      "type": {
+        "primary": "touch",
+        "secondary": [
+          "carry"
+        ]
+      },
+      "location": {
+        "x": 39,
+        "y": 74
+      },
+      "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+      "opponentTeam": {
+        "formation": "3-4-3",
+        "id": 3185,
+        "name": "Torino"
+      },
+      "player": {
+        "id": 99430,
+        "name": "Ł. Skorupski",
+        "position": "GK"
+      },
+      "pass": null,
+      "shot": null,
+      "groundDuel": null,
+      "aerialDuel": null,
+      "infraction": null,
+      "carry": {
+        "progression": 19.07,
+        "endLocation": {
+          "x": 58,
+          "y": 74
+        }
+      },
+      "possession": {
+        "id": 13970000,
+        "duration": "21.63938",
+        "types": [
+          "attack"
+        ],
+        "eventsNumber": 12,
+        "eventIndex": 11,
+        "startLocation": {
+          "x": 34,
+          "y": 67
+        },
+        "endLocation": {
+          "x": 91,
+          "y": 10
+        },
+        "team": {
+          "formation": "4-2-3-1",
+          "id": 3166,
+          "name": "Bologna"
+        },
+        "attack": {
+          "withShot": false,
+          "withShotOnGoal": false,
+          "withGoal": false,
+          "flank": "left",
+          "xg": 0
+        }
+      }
     }
   ],
   "formations": {

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -178,7 +178,7 @@ class TestWyscoutV3:
         )
         assert dataset.metadata.periods[1].end_timestamp == timedelta(
             minutes=20, seconds=47
-        ) + timedelta(minutes=50, seconds=30)
+        ) + timedelta(minutes=50, seconds=35)
 
     def test_timestamps(self, dataset: EventDataset):
         kickoff_p1 = dataset.get_event_by_id(663292348)

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -249,3 +249,8 @@ class TestWyscoutV3:
     def test_take_on_event(self, dataset: EventDataset):
         take_on_event = dataset.get_event_by_id(139800000)
         assert take_on_event.event_type == EventType.TAKE_ON
+
+    def test_carry_event(self, dataset: EventDataset):
+        carry_event = dataset.get_event_by_id(139800001)
+        assert carry_event.event_type == EventType.CARRY
+        assert carry_event.end_coordinates == Point(58.0, 74.0)


### PR DESCRIPTION
Add support for the creation of a carry event for Wyscout v3 event data.

"carry" is a secondary event type, thus I've added the potential recognition of a "carry" event at the bottom of the if / elif statements for recognizing the event type. This way, we give priority to primary event types for determining the kloppy event type.

We derive the end timestamp as the timestamp of the next event, if it is present, otherwise it is said equal to the timestamp.