### PR TITLE
[StatsPerform] Fix shot block event

### DIFF
--- a/kloppy/infra/serializers/event/statsperform/deserializer.py
+++ b/kloppy/infra/serializers/event/statsperform/deserializer.py
@@ -753,12 +753,22 @@ class StatsPerformDeserializer(EventDataDeserializer[StatsPerformInputs]):
                             **generic_event_kwargs,
                         )
                     elif raw_event.type_id in KEEPER_EVENTS:
-                        goalkeeper_event_kwargs = _parse_goalkeeper_events(
-                            raw_event
-                        )
-                        event = self.event_factory.build_goalkeeper_event(
-                            **goalkeeper_event_kwargs, **generic_event_kwargs
-                        )
+                        # Qualifier 94 means the "save" event is a shot block by a defender
+                        if 94 in raw_event.qualifiers:
+                            event = self.event_factory.build_generic(
+                                **generic_event_kwargs,
+                                result=None,
+                                qualifiers=None,
+                                event_name="block",
+                            )
+                        else:
+                            goalkeeper_event_kwargs = _parse_goalkeeper_events(
+                                raw_event
+                            )
+                            event = self.event_factory.build_goalkeeper_event(
+                                **goalkeeper_event_kwargs,
+                                **generic_event_kwargs,
+                            )
                     elif (raw_event.type_id == EVENT_TYPE_BALL_TOUCH) & (
                         raw_event.outcome == 0
                     ):

--- a/kloppy/tests/files/opta_f24.xml
+++ b/kloppy/tests/files/opta_f24.xml
@@ -64,6 +64,10 @@
       <Q id="1149162593" qualifier_id="213" value="4.9" />
       <Q id="1140451930" qualifier_id="141" value="7.4" />
     </Event>
+    <Event id="1515097981" event_id="70" type_id="10" period_id="1" min="0" sec="10" player_id="164266" team_id="569" outcome="1" x="8.9" y="48.0" timestamp="2018-09-23T15:02:22.579" last_modified="2018-09-23T15:02:30" version="1537711350409">
+      <Q id="5001563785" qualifier_id="94" />
+      <Q id="5001563787" qualifier_id="56" value="Back" />
+    </Event>
     <Event id="1444075194" event_id="8" type_id="1" period_id="1" min="0" sec="16" player_id="82830" team_id="569" outcome="0" x="47.3" y="10.7" timestamp="2018-09-23T15:02:30.404" last_modified="2018-09-23T15:02:32" version="1537711352109">
       <Q id="2068850442" qualifier_id="56" value="Right" />
       <Q id="2106816650" qualifier_id="213" value="0.2" />

--- a/kloppy/tests/test_adapter.py
+++ b/kloppy/tests/test_adapter.py
@@ -57,4 +57,4 @@ class TestAdapter:
             # Asserts borrowed from `test_opta.py`
             assert dataset.metadata.provider == Provider.OPTA
             assert dataset.dataset_type == DatasetType.EVENT
-            assert len(dataset.events) == 36
+            assert len(dataset.events) == 37

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -469,3 +469,13 @@ class TestOptaMiscontrolEvent:
         """Test if the miscontrol event is correctly deserialized"""
         event = dataset.get_event_by_id("2509132175")
         assert event.event_type == EventType.MISCONTROL
+
+
+class TestOptaBlockEvent:
+    """Tests related to deserialzing miscontrol events"""
+
+    def test_correct_deserialization(self, dataset: EventDataset):
+        """Test if the miscontrol event is correctly deserialized"""
+        event = dataset.get_event_by_id("1515097981")
+        assert event.event_type == EventType.GENERIC
+        assert event.event_name == "block"

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -236,7 +236,7 @@ class TestOptaEvent:
 
 
 class TestOptaPassEvent:
-    """Tests related to deserialzing pass events"""
+    """Tests related to deserializing pass events"""
 
     def test_deserialize_all(self, dataset: EventDataset):
         """It should deserialize all pass events"""
@@ -273,7 +273,7 @@ class TestOptaPassEvent:
 
 
 class TestOptaClearanceEvent:
-    """Tests related to deserialzing clearance events"""
+    """Tests related to deserializing clearance events"""
 
     def test_deserialize_all(self, dataset: EventDataset):
         """It should deserialize all clearance events"""
@@ -287,7 +287,7 @@ class TestOptaClearanceEvent:
 
 
 class TestOptaShotEvent:
-    """Tests related to deserialzing shot events"""
+    """Tests related to deserializing shot events"""
 
     def test_deserialize_all(self, dataset: EventDataset):
         """It should deserialize all shot events"""
@@ -397,7 +397,7 @@ class TestOptaShotEvent:
 
 
 class TestOptaDuelEvent:
-    """Tests related to deserialzing duel events"""
+    """Tests related to deserializing duel events"""
 
     def test_deserialize_all(self, dataset: EventDataset):
         """It should deserialize all duel events"""
@@ -417,7 +417,7 @@ class TestOptaDuelEvent:
 
 
 class TestOptaGoalkeeperEvent:
-    """Tests related to deserialzing goalkeeper events"""
+    """Tests related to deserializing goalkeeper events"""
 
     def test_deserialize_all(self, dataset: EventDataset):
         """It should deserialize all goalkeeper events"""
@@ -454,7 +454,7 @@ class TestOptaGoalkeeperEvent:
 
 
 class TestOptaInterceptionEvent:
-    """Tests related to deserialzing interception events"""
+    """Tests related to deserializing interception events"""
 
     def test_correct_deserialization(self, dataset: EventDataset):
         """Test if the interception event is correctly deserialized"""
@@ -463,7 +463,7 @@ class TestOptaInterceptionEvent:
 
 
 class TestOptaMiscontrolEvent:
-    """Tests related to deserialzing miscontrol events"""
+    """Tests related to deserializing miscontrol events"""
 
     def test_correct_deserialization(self, dataset: EventDataset):
         """Test if the miscontrol event is correctly deserialized"""
@@ -472,10 +472,10 @@ class TestOptaMiscontrolEvent:
 
 
 class TestOptaBlockEvent:
-    """Tests related to deserialzing miscontrol events"""
+    """Tests related to deserializing block events"""
 
     def test_correct_deserialization(self, dataset: EventDataset):
-        """Test if the miscontrol event is correctly deserialized"""
+        """Test if the block event is correctly deserialized"""
         event = dataset.get_event_by_id("1515097981")
         assert event.event_type == EventType.GENERIC
         assert event.event_name == "block"


### PR DESCRIPTION
Fix so that no GoalkeeperEvent is created for a shot block.

<img width="804" alt="image" src="https://github.com/PySport/kloppy/assets/46134788/4c4f3c8f-f2ce-4744-8a1f-c1f4ba5a96c7">