### PR TITLE
Fix/skillcorner timestamp

### DIFF
--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -220,13 +220,13 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
                 data.append(obj)
             return data
         else:
-            data = json.load(file)
+            data = self.__load_json(file)
             for line in data:
                 if "timestamp" in line:
                     line["time"] = line.pop("timestamp")
             return data
-        
-    def __load_json_meta(self, file):
+
+    def __load_json(self, file):
         return json.load(file)
 
     @classmethod
@@ -295,7 +295,7 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
         )
 
     def deserialize(self, inputs: SkillCornerInputs) -> TrackingDataset:
-        metadata = self.__load_json_meta(inputs.meta_data)
+        metadata = self.__load_json(inputs.meta_data)
         raw_data = self.__load_json_raw(inputs.raw_data)
 
         with performance_logging("Loading metadata", logger=logger):

--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -209,7 +209,7 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
 
         return attacking_directions
 
-    def __load_json(self, file):
+    def __load_json_raw(self, file):
         if Path(file.name).suffix == ".jsonl":
             data = []
             for line in file:
@@ -220,7 +220,14 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
                 data.append(obj)
             return data
         else:
-            return json.load(file)
+            data = json.load(file)
+            for line in data:
+                if "timestamp" in line:
+                    line["time"] = line.pop("timestamp")
+            return data
+        
+    def __load_json_meta(self, file):
+        return json.load(file)
 
     @classmethod
     def __get_periods(cls, tracking):
@@ -288,8 +295,8 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
         )
 
     def deserialize(self, inputs: SkillCornerInputs) -> TrackingDataset:
-        metadata = self.__load_json(inputs.meta_data)
-        raw_data = self.__load_json(inputs.raw_data)
+        metadata = self.__load_json_meta(inputs.meta_data)
+        raw_data = self.__load_json_raw(inputs.raw_data)
 
         with performance_logging("Loading metadata", logger=logger):
             periods = self.__get_periods(raw_data)

--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -209,25 +209,24 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
 
         return attacking_directions
 
+    @staticmethod
+    def __replace_timestamp(obj):
+        if "timestamp" in obj:
+            obj["time"] = obj.pop("timestamp")
+        return obj
+
     def __load_json_raw(self, file):
         if Path(file.name).suffix == ".jsonl":
             data = []
             for line in file:
                 obj = json.loads(line)
-                # for each line rename timestamp to time to make it compatible with existing loader
-                if "timestamp" in obj:
-                    obj["time"] = obj.pop("timestamp")
-                data.append(obj)
+                data.append(self.__replace_timestamp(obj))
             return data
         else:
-            data = self.__load_json(file)
+            data = json.load(file)
             for line in data:
-                if "timestamp" in line:
-                    line["time"] = line.pop("timestamp")
+                line = self.__replace_timestamp(line)
             return data
-
-    def __load_json(self, file):
-        return json.load(file)
 
     @classmethod
     def __get_periods(cls, tracking):
@@ -295,7 +294,7 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
         )
 
     def deserialize(self, inputs: SkillCornerInputs) -> TrackingDataset:
-        metadata = self.__load_json(inputs.meta_data)
+        metadata = json.load(inputs.meta_data)
         raw_data = self.__load_json_raw(inputs.raw_data)
 
         with performance_logging("Loading metadata", logger=logger):

--- a/kloppy/tests/test_skillcorner.py
+++ b/kloppy/tests/test_skillcorner.py
@@ -24,12 +24,14 @@ class TestSkillCornerTracking:
     @pytest.fixture
     def raw_data(self, base_dir) -> str:
         return base_dir / "files/skillcorner_structured_data.json"
-    
+
     @pytest.fixture
     def raw_data_timestamp(self, base_dir) -> str:
         return base_dir / "files/skillcorner_structured_data_timestamp.json"
-    
-    def test_correct_deserialization_timestamp(self, raw_data_timestamp: Path, meta_data: Path):
+
+    def test_correct_deserialization_timestamp(
+        self, raw_data_timestamp: Path, meta_data: Path
+    ):
         skillcorner.load(
             meta_data=meta_data,
             raw_data=raw_data_timestamp,

--- a/kloppy/tests/test_skillcorner.py
+++ b/kloppy/tests/test_skillcorner.py
@@ -24,6 +24,18 @@ class TestSkillCornerTracking:
     @pytest.fixture
     def raw_data(self, base_dir) -> str:
         return base_dir / "files/skillcorner_structured_data.json"
+    
+    @pytest.fixture
+    def raw_data_timestamp(self, base_dir) -> str:
+        return base_dir / "files/skillcorner_structured_data_timestamp.json"
+    
+    def test_correct_deserialization_timestamp(self, raw_data_timestamp: Path, meta_data: Path):
+        skillcorner.load(
+            meta_data=meta_data,
+            raw_data=raw_data_timestamp,
+            coordinates="skillcorner",
+            include_empty_frames=True,
+        )
 
     def test_correct_deserialization(self, raw_data: Path, meta_data: Path):
         dataset = skillcorner.load(


### PR DESCRIPTION
I noticed that at some point SkillCorner changed all their "time" keys to "timestamp", not only in the "jsonl" files.

So, I rewrote `__load_json()` and added `__load_json_raw()` the latter renames any "timestamp" key back to "time" to make it compatible with every time the "time" key is required in the deserializer.

Also added a test and a test file for the "timestamp" situation. This test simply loads the dataset, the rest should be the same as the other tests.

Note: I removed a lot of 2nd half frames from the test file, because the file size was greater than 50MB.