### PR TITLE
[StatsPerform] Fix origin and vertical orientation of SportVU

### DIFF
--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -807,11 +807,11 @@ class SportVUCoordinateSystem(CoordinateSystem):
 
     @property
     def origin(self) -> Origin:
-        return Origin.BOTTOM_LEFT
+        return Origin.TOP_LEFT
 
     @property
     def vertical_orientation(self) -> VerticalOrientation:
-        return VerticalOrientation.BOTTOM_TO_TOP
+        return VerticalOrientation.TOP_TO_BOTTOM
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:

--- a/kloppy/tests/test_statsperform.py
+++ b/kloppy/tests/test_statsperform.py
@@ -270,7 +270,7 @@ class TestStatsPerformTracking:
         )
 
         assert tracking_dataset.records[1].ball_coordinates == Point3D(
-            x=50.615 / 105, y=1 - 35.325 / 68, z=0.0
+            x=50.615 / 105, y=35.325 / 68, z=0.0
         )
 
         # Check normalised pitch dimensions


### PR DESCRIPTION
As seen in the image is the actual `Origin.TOP_LEFT` and `VerticalOrientation.TOP_TO_BOTTOM`.  After discussion with @probberechts we've come to the conclusion that this mistake was accidentally introduced when rewriting the StatsPerform tracking data parser.

![image](https://github.com/user-attachments/assets/4df739e7-02b4-48ef-890b-ac9c40a56c53)

