### PR TITLE
[Wyscout v3] Add support for extra time and penalties

### DIFF
--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -501,6 +501,17 @@ def _players_to_dict(players: List[Player]):
     return {player.player_id: player for player in players}
 
 
+def _parse_period_id(raw_period: str) -> int:
+    if "H" in raw_period:
+        period_id = int(raw_period.replace("H", ""))
+    elif raw_period == "P":
+        period_id = 5
+    else:
+        raise DeserializationError(f"Unknown period {raw_period}")
+
+    return period_id
+
+
 class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
     @property
     def provider(self) -> Provider:
@@ -544,14 +555,14 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
                 next_period_id = None
                 if (idx + 1) < len(raw_events["events"]):
                     next_event = raw_events["events"][idx + 1]
-                    next_period_id = int(
-                        next_event["matchPeriod"].replace("H", "")
+                    next_period_id = _parse_period_id(
+                        next_event["matchPeriod"]
                     )
 
                 team_id = str(raw_event["team"]["id"])
                 team = teams[team_id]
                 player_id = str(raw_event["player"]["id"])
-                period_id = int(raw_event["matchPeriod"].replace("H", ""))
+                period_id = _parse_period_id(raw_event["matchPeriod"])
 
                 if len(periods) == 0 or periods[-1].id != period_id:
                     periods.append(

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -272,12 +272,12 @@ def _parse_carry(raw_event: Dict, next_event: Dict, start_ts: Dict) -> Dict:
     )
 
     if next_event is not None:
-        period_id = int(next_event["matchPeriod"].replace("H", ""))
+        period_id = _parse_period_id(next_event["matchPeriod"])
         end_timestamp = _create_timestamp_timedelta(
             next_event, start_ts, period_id
         )
     else:
-        period_id = int(raw_event["matchPeriod"].replace("H", ""))
+        period_id = _parse_period_id(raw_event["matchPeriod"])
         end_timestamp = _create_timestamp_timedelta(
             raw_event, start_ts, period_id
         )
@@ -504,6 +504,8 @@ def _players_to_dict(players: List[Player]):
 def _parse_period_id(raw_period: str) -> int:
     if "H" in raw_period:
         period_id = int(raw_period.replace("H", ""))
+    elif "E" in raw_period:
+        period_id = 2 + int(raw_period.replace("E", ""))
     elif raw_period == "P":
         period_id = 5
     else:


### PR DESCRIPTION
Btw, tests for Wyscout V3 will be updated by: https://github.com/PySport/kloppy/pull/350. But this match data doesn't contain any extra time / penalties, thus including tests on actual data doesn't seem possible for this change.