### PR TITLE
[StatsPerform - Tracking] Handle missing end period for abandoned matches

### DIFF
--- a/kloppy/infra/serializers/event/statsperform/parsers/ma1_json.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/ma1_json.py
@@ -16,15 +16,21 @@ class MA1JSONParser(OptaJSONParser):
         match_details = live_data["matchDetails"]
         parsed_periods = []
         for period in match_details["period"]:
+            period_start_raw = period.get("start")
+            period_end_raw = period.get("end")
             parsed_periods.append(
                 Period(
                     id=period["id"],
                     start_timestamp=datetime.strptime(
-                        period["start"], "%Y-%m-%dT%H:%M:%SZ"
-                    ).replace(tzinfo=pytz.utc),
+                        period_start_raw, "%Y-%m-%dT%H:%M:%SZ"
+                    ).replace(tzinfo=pytz.utc)
+                    if period_start_raw
+                    else None,
                     end_timestamp=datetime.strptime(
-                        period["end"], "%Y-%m-%dT%H:%M:%SZ"
-                    ).replace(tzinfo=pytz.utc),
+                        period_start_raw, "%Y-%m-%dT%H:%M:%SZ"
+                    ).replace(tzinfo=pytz.utc)
+                    if period_end_raw
+                    else None,
                 )
             )
         return parsed_periods

--- a/kloppy/infra/serializers/event/statsperform/parsers/ma1_json.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/ma1_json.py
@@ -18,6 +18,13 @@ class MA1JSONParser(OptaJSONParser):
         for period in match_details["period"]:
             period_start_raw = period.get("start")
             period_end_raw = period.get("end")
+            if not period_end_raw:
+                game_end_suspension_stop = next(
+                    suspension_stop
+                    for suspension_stop in period["suspension"]
+                    if suspension_stop["reason"] == "early end"
+                )
+                period_end_raw = game_end_suspension_stop["start"]
             parsed_periods.append(
                 Period(
                     id=period["id"],
@@ -27,7 +34,7 @@ class MA1JSONParser(OptaJSONParser):
                     if period_start_raw
                     else None,
                     end_timestamp=datetime.strptime(
-                        period_start_raw, "%Y-%m-%dT%H:%M:%SZ"
+                        period_end_raw, "%Y-%m-%dT%H:%M:%SZ"
                     ).replace(tzinfo=pytz.utc)
                     if period_end_raw
                     else None,

--- a/kloppy/tests/prs/pr_355/statsperform_tracking_ma1.json
+++ b/kloppy/tests/prs/pr_355/statsperform_tracking_ma1.json
@@ -1,0 +1,877 @@
+{
+  "matchInfo": {
+    "id": "7ijuqohwgmplbxdj1625sxwfe",
+    "coverageLevel": "15",
+    "date": "2020-08-23Z",
+    "time": "11:00:00Z",
+    "localDate": "2020-08-23",
+    "localTime": "13:00:00",
+    "week": "1",
+    "attendanceInfoId": "2",
+    "attendanceInfo": "Limited Audience",
+    "numberOfPeriods": 2,
+    "periodLength": 45,
+    "lastUpdated": "2023-12-11T05:54:46Z",
+    "description": "Monaco vs Reims",
+    "sport": {
+      "id": "289u5typ3vp4ifwh5thalohmq",
+      "name": "Soccer"
+    },
+    "ruleset": {
+      "id": "79plas4983031idr6vw83nuel",
+      "name": "Men"
+    },
+    "competition": {
+      "id": "dm5ka0os1e3dxcp3vh05kmp33",
+      "name": "Ligue 1",
+      "knownName": "French Ligue 1",
+      "sponsorName": "LIGUE 1 Uber Eats",
+      "competitionCode": "LI1",
+      "competitionFormat": "Domestic league",
+      "country": {
+        "id": "7gww28djs405rfga69smki84o",
+        "name": "France"
+      }
+    },
+    "tournamentCalendar": {
+      "id": "5rr3izkmap6j5hfen757fq44q",
+      "startDate": "2020-08-21Z",
+      "endDate": "2021-05-23Z",
+      "name": "2020/2021"
+    },
+    "stage": {
+      "id": "5s663qdn7f3ro980aoo9bbs6i",
+      "formatId": "e2q01r9o9jwiq1fls93d1sslx",
+      "startDate": "2020-08-21Z",
+      "endDate": "2021-05-23Z",
+      "name": "Regular Season"
+    },
+    "contestant": [
+      {
+        "id": "4t4hod56fsj7utpjdor8so5q6",
+        "name": "Monaco",
+        "shortName": "Monaco",
+        "officialName": "AS Monaco FC",
+        "code": "ASM",
+        "position": "home",
+        "country": {
+          "id": "22j7jr6dlpt6w5xx8oqr80sf4",
+          "name": "Monaco"
+        }
+      },
+      {
+        "id": "3c3jcs7vc1t6vz5lev162jyv7",
+        "name": "Reims",
+        "shortName": "Reims",
+        "officialName": "Stade de Reims",
+        "code": "SR",
+        "position": "away",
+        "country": {
+          "id": "7gww28djs405rfga69smki84o",
+          "name": "France"
+        }
+      }
+    ],
+    "venue": {
+      "id": "60xx85ka3o3eycz8ysqh78m88",
+      "neutral": "no",
+      "longName": "Stade Louis II",
+      "shortName": "Stade Louis II"
+    }
+  },
+  "liveData": {
+    "matchDetails": {
+      "periodId": 14,
+      "matchStatus": "Played",
+      "winner": "draw",
+      "matchLengthMin": 98,
+      "matchLengthSec": 13,
+      "period": [
+        {
+          "id": 1,
+          "start": "2020-08-23T11:00:10Z",
+          "end": "2020-08-23T11:48:15Z",
+          "lengthMin": 48,
+          "lengthSec": 5
+        },
+        {
+          "id": 2,
+          "start": "2020-08-23T12:06:22Z",
+          "suspension": [
+            {
+              "start": "2020-08-23T12:36:22Z",
+              "end": "2020-08-23T12:40:22Z",
+              "reason": "clock affecting"
+            },
+            {
+              "start": "2020-08-23T12:45:22Z",
+              "reason": "early end"
+            }
+          ]
+        }
+      ],
+      "scores": {
+        "ht": {
+          "home": 1,
+          "away": 2
+        },
+        "ft": {
+          "home": 2,
+          "away": 2
+        },
+        "total": {
+          "home": 2,
+          "away": 2
+        }
+      }
+    },
+    "goal": [
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 1,
+        "timeMin": 5,
+        "timeMinSec": "4:17",
+        "lastUpdated": "2022-11-16T02:08:41Z",
+        "timestamp": "2020-08-23T11:04:28Z",
+        "type": "G",
+        "scorerId": "3mqhkh4iz4kesvmqui3hupgmi",
+        "scorerName": "B. Dia",
+        "assistPlayerId": "e6ok0deqkoe80184iu509gzu2",
+        "assistPlayerName": "E. Touré",
+        "optaEventId": "2205848199",
+        "homeScore": 0,
+        "awayScore": 1
+      },
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 1,
+        "timeMin": 21,
+        "timeMinSec": "20:43",
+        "lastUpdated": "2023-10-19T22:38:22Z",
+        "timestamp": "2020-08-23T11:20:54Z",
+        "type": "G",
+        "scorerId": "e6ok0deqkoe80184iu509gzu2",
+        "scorerName": "E. Touré",
+        "optaEventId": "2205854373",
+        "homeScore": 0,
+        "awayScore": 2
+      },
+      {
+        "contestantId": "4t4hod56fsj7utpjdor8so5q6",
+        "periodId": 1,
+        "timeMin": 47,
+        "timeMinSec": "46:58",
+        "lastUpdated": "2023-06-13T13:31:27Z",
+        "timestamp": "2020-08-23T11:47:09Z",
+        "type": "G",
+        "scorerId": "3djmsd2atvq16ysmocq7twsfd",
+        "scorerName": "A. Disasi",
+        "assistPlayerId": "aipyotc87m5bdvmvizd5n69k9",
+        "assistPlayerName": "A. Tchouaméni",
+        "secondAssistPlayerId": "28x7i681wkjueanvkevew3bh1",
+        "ocSecondAssistPlayerId": "290180",
+        "opSecondAssistPlayerId": "161950",
+        "secondAssistPlayerName": "A. Golovin",
+        "optaEventId": "2205864939",
+        "homeScore": 1,
+        "awayScore": 2
+      },
+      {
+        "contestantId": "4t4hod56fsj7utpjdor8so5q6",
+        "periodId": 2,
+        "timeMin": 55,
+        "timeMinSec": "54:34",
+        "lastUpdated": "2023-09-29T03:33:03Z",
+        "timestamp": "2020-08-23T12:15:57Z",
+        "type": "G",
+        "scorerId": "5g5wwp5luxo1rz1kp6chvz0x6",
+        "scorerName": "B. Badiashile",
+        "assistPlayerId": "28x7i681wkjueanvkevew3bh1",
+        "assistPlayerName": "A. Golovin",
+        "optaEventId": "2205870241",
+        "homeScore": 2,
+        "awayScore": 2
+      }
+    ],
+    "card": [
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 1,
+        "timeMin": 41,
+        "timeMinSec": "40:24",
+        "lastUpdated": "2023-07-20T09:41:21Z",
+        "timestamp": "2020-08-23T11:40:35Z",
+        "type": "YC",
+        "playerId": "8j2vmplbpj983xbxibhyvidx",
+        "playerName": "D. Kutesa",
+        "optaEventId": "2205862217",
+        "cardReason": "Video sync done"
+      },
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 2,
+        "timeMin": 76,
+        "timeMinSec": "75:42",
+        "lastUpdated": "2022-12-21T06:54:52Z",
+        "timestamp": "2020-08-23T12:37:04Z",
+        "type": "YC",
+        "playerId": "72d5uxwcmvhd6mzthxuvev1sl",
+        "playerName": "W. Faes",
+        "optaEventId": "2205872941",
+        "cardReason": "Video sync done"
+      },
+      {
+        "contestantId": "4t4hod56fsj7utpjdor8so5q6",
+        "periodId": 2,
+        "timeMin": 90,
+        "timeMinSec": "89:02",
+        "lastUpdated": "2023-06-13T13:31:27Z",
+        "timestamp": "2020-08-23T12:50:24Z",
+        "type": "YC",
+        "playerId": "3djmsd2atvq16ysmocq7twsfd",
+        "playerName": "A. Disasi",
+        "optaEventId": "2205876221",
+        "cardReason": "Video sync done"
+      },
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 2,
+        "timeMin": 90,
+        "timeMinSec": "89:46",
+        "lastUpdated": "2023-08-14T03:49:54Z",
+        "timestamp": "2020-08-23T12:51:08Z",
+        "type": "YC",
+        "playerId": "3sc349yey596xp2j6xlyt0frp",
+        "playerName": "T. Foket",
+        "optaEventId": "2205876377",
+        "cardReason": "Video sync done"
+      }
+    ],
+    "substitute": [
+      {
+        "contestantId": "4t4hod56fsj7utpjdor8so5q6",
+        "periodId": 2,
+        "timeMin": 46,
+        "timeMinSec": "45:00",
+        "lastUpdated": "2023-11-09T22:11:18Z",
+        "timestamp": "2020-08-23T12:05:59Z",
+        "playerOnId": "ct32113pfx5q9avf2c0x208ru",
+        "playerOnName": "S. Diop",
+        "playerOffId": "4wqekpzlcztenasxob7a6tyax",
+        "playerOffName": "H. Onyekuru",
+        "subReason": "Tactical"
+      },
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 2,
+        "timeMin": 56,
+        "timeMinSec": "55:15",
+        "lastUpdated": "2021-08-05T21:20:34Z",
+        "timestamp": "2020-08-23T12:16:37Z",
+        "playerOnId": "446scvw0ckoxnvnsqcqocve1h",
+        "playerOnName": "V. Berisha",
+        "playerOffId": "8j2vmplbpj983xbxibhyvidx",
+        "playerOffName": "D. Kutesa",
+        "subReason": "Tactical"
+      },
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 2,
+        "timeMin": 60,
+        "timeMinSec": "59:21",
+        "lastUpdated": "2023-08-14T03:49:55Z",
+        "timestamp": "2020-08-23T12:20:43Z",
+        "playerOnId": "5ghvrbmlh0tqos9iohj8f7zzd",
+        "playerOnName": "K. Sierhuis",
+        "playerOffId": "fe4b3ric67hz0hhih3tjf2eh",
+        "playerOffName": "M. Cafaro",
+        "subReason": "Tactical"
+      },
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 2,
+        "timeMin": 60,
+        "timeMinSec": "59:21",
+        "lastUpdated": "2023-08-14T03:49:54Z",
+        "timestamp": "2020-08-23T12:20:43Z",
+        "playerOnId": "agwvouyocx93y39g7tmwaojx1",
+        "playerOnName": "A. Zeneli",
+        "playerOffId": "e6ok0deqkoe80184iu509gzu2",
+        "playerOffName": "E. Touré",
+        "subReason": "Tactical"
+      },
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "periodId": 2,
+        "timeMin": 78,
+        "timeMinSec": "77:59",
+        "lastUpdated": "2023-11-15T11:11:34Z",
+        "timestamp": "2020-08-23T12:39:21Z",
+        "playerOnId": "7pzfyf1ipdp6hvrik5y8hdmmt",
+        "playerOnName": "Moreto Cassamá",
+        "playerOffId": "3mqhkh4iz4kesvmqui3hupgmi",
+        "playerOffName": "B. Dia",
+        "subReason": "Tactical"
+      },
+      {
+        "contestantId": "4t4hod56fsj7utpjdor8so5q6",
+        "periodId": 2,
+        "timeMin": 81,
+        "timeMinSec": "80:05",
+        "lastUpdated": "2023-06-07T19:26:19Z",
+        "timestamp": "2020-08-23T12:41:27Z",
+        "playerOnId": "ckt75xb064etqh7aep6k5pfqh",
+        "playerOnName": "W. Geubbels",
+        "playerOffId": "72m5u1rlgh6e229zpfvp7f5jp",
+        "playerOffName": "Gelson Martins",
+        "subReason": "Tactical"
+      },
+      {
+        "contestantId": "4t4hod56fsj7utpjdor8so5q6",
+        "periodId": 2,
+        "timeMin": 87,
+        "timeMinSec": "86:51",
+        "lastUpdated": "2023-03-28T07:34:02Z",
+        "timestamp": "2020-08-23T12:48:14Z",
+        "playerOnId": "88nw24pkg2ikj9c91tccvqol",
+        "playerOnName": "J. Aholou",
+        "playerOffId": "28x7i681wkjueanvkevew3bh1",
+        "playerOffName": "A. Golovin",
+        "subReason": "Tactical"
+      }
+    ],
+    "lineUp": [
+      {
+        "contestantId": "4t4hod56fsj7utpjdor8so5q6",
+        "formationUsed": "433",
+        "player": [
+          {
+            "playerId": "6wfwy94p5bm0zv3aku0urfq39",
+            "firstName": "Benjamin Pascal",
+            "lastName": "Lecomte",
+            "shortFirstName": "Benjamin",
+            "shortLastName": "Lecomte",
+            "matchName": "B. Lecomte",
+            "shirtNumber": 40,
+            "position": "Goalkeeper",
+            "positionSide": "Centre",
+            "formationPlace": "1"
+          },
+          {
+            "playerId": "dmrj53hcw8vcffxx0lfudbob9",
+            "firstName": "Fodé",
+            "lastName": "Ballo-Touré",
+            "shortFirstName": "Fodé",
+            "shortLastName": "Ballo-Touré",
+            "matchName": "F. Ballo-Touré",
+            "shirtNumber": 2,
+            "position": "Defender",
+            "positionSide": "Left",
+            "formationPlace": "3"
+          },
+          {
+            "playerId": "5g5wwp5luxo1rz1kp6chvz0x6",
+            "firstName": "Benoît Ntambue",
+            "lastName": "Badiashile Mukinayi Baya",
+            "shortFirstName": "Benoît",
+            "shortLastName": "Badiashile",
+            "matchName": "B. Badiashile",
+            "shirtNumber": 32,
+            "position": "Defender",
+            "positionSide": "Left/Centre",
+            "formationPlace": "6"
+          },
+          {
+            "playerId": "3djmsd2atvq16ysmocq7twsfd",
+            "firstName": "Axel Wilson Arthur",
+            "lastName": "Disasi Mhakinis Belho",
+            "shortFirstName": "Axel",
+            "shortLastName": "Disasi",
+            "matchName": "A. Disasi",
+            "shirtNumber": 20,
+            "position": "Defender",
+            "positionSide": "Centre/Right",
+            "formationPlace": "5"
+          },
+          {
+            "playerId": "4rlw04tze791jwt623h5ikg5x",
+            "firstName": "Ruben",
+            "lastName": "Aguilar",
+            "shortFirstName": "Ruben",
+            "shortLastName": "Aguilar",
+            "matchName": "R. Aguilar",
+            "shirtNumber": 26,
+            "position": "Defender",
+            "positionSide": "Right",
+            "formationPlace": "2"
+          },
+          {
+            "playerId": "28x7i681wkjueanvkevew3bh1",
+            "firstName": "Aleksandr",
+            "lastName": "Golovin",
+            "shortFirstName": "Aleksandr",
+            "shortLastName": "Golovin",
+            "matchName": "A. Golovin",
+            "shirtNumber": 17,
+            "position": "Midfielder",
+            "positionSide": "Left/Centre",
+            "formationPlace": "8"
+          },
+          {
+            "playerId": "b0wb7gf04synxlkq7o8gvzkoa",
+            "firstName": "Youssouf",
+            "lastName": "Fofana",
+            "shortFirstName": "Youssouf",
+            "shortLastName": "Fofana",
+            "matchName": "Y. Fofana",
+            "shirtNumber": 22,
+            "position": "Midfielder",
+            "positionSide": "Centre",
+            "formationPlace": "4"
+          },
+          {
+            "playerId": "aipyotc87m5bdvmvizd5n69k9",
+            "firstName": "Aurélien Djani",
+            "lastName": "Tchouaméni",
+            "shortFirstName": "Aurélien",
+            "shortLastName": "Tchouaméni",
+            "matchName": "A. Tchouaméni",
+            "shirtNumber": 8,
+            "position": "Midfielder",
+            "positionSide": "Centre/Right",
+            "formationPlace": "7"
+          },
+          {
+            "playerId": "4wqekpzlcztenasxob7a6tyax",
+            "firstName": "Henry",
+            "lastName": "Chukwuemeka Onyekuru",
+            "shortFirstName": "Henry",
+            "shortLastName": "Onyekuru",
+            "matchName": "H. Onyekuru",
+            "shirtNumber": 7,
+            "position": "Striker",
+            "positionSide": "Left/Centre",
+            "formationPlace": "11"
+          },
+          {
+            "playerId": "a2s2c6anax9wnlsw1s6vunl5h",
+            "firstName": "Wissam",
+            "lastName": "Ben Yedder",
+            "shortFirstName": "Wissam",
+            "shortLastName": "Ben Yedder",
+            "matchName": "W. Ben Yedder",
+            "shirtNumber": 9,
+            "position": "Striker",
+            "positionSide": "Centre",
+            "formationPlace": "9",
+            "captain": "yes"
+          },
+          {
+            "playerId": "72m5u1rlgh6e229zpfvp7f5jp",
+            "firstName": "Gelson Dany",
+            "lastName": "Batalha Martins",
+            "shortFirstName": "Gelson Dany",
+            "shortLastName": "Batalha Martins",
+            "knownName": "Gelson Martins",
+            "matchName": "Gelson Martins",
+            "shirtNumber": 11,
+            "position": "Striker",
+            "positionSide": "Centre/Right",
+            "formationPlace": "10"
+          },
+          {
+            "playerId": "88nw24pkg2ikj9c91tccvqol",
+            "firstName": "Jean-Eudes Pascal Armand",
+            "lastName": "Aholou",
+            "shortFirstName": "Jean-Eudes",
+            "shortLastName": "Aholou",
+            "matchName": "J. Aholou",
+            "shirtNumber": 6,
+            "position": "Substitute",
+            "subPosition": "Midfielder"
+          },
+          {
+            "playerId": "esb4b21x729db8od4c4xt8ciy",
+            "firstName": "Giulian",
+            "lastName": "Biancone",
+            "shortFirstName": "Giulian",
+            "shortLastName": "Biancone",
+            "matchName": "G. Biancone",
+            "shirtNumber": 41,
+            "position": "Substitute",
+            "subPosition": "Defender"
+          },
+          {
+            "playerId": "ct32113pfx5q9avf2c0x208ru",
+            "firstName": "Sofiane",
+            "lastName": "Diop",
+            "shortFirstName": "Sofiane",
+            "shortLastName": "Diop",
+            "matchName": "S. Diop",
+            "shirtNumber": 37,
+            "position": "Substitute",
+            "subPosition": "Midfielder"
+          },
+          {
+            "playerId": "ckt75xb064etqh7aep6k5pfqh",
+            "firstName": "Willem Davnis Louis Didier",
+            "lastName": "Geubbels",
+            "shortFirstName": "Willem",
+            "shortLastName": "Geubbels",
+            "matchName": "W. Geubbels",
+            "shirtNumber": 13,
+            "position": "Substitute",
+            "subPosition": "Attacker"
+          },
+          {
+            "playerId": "d5ecnjd6h89iepxrvrlfn97ft",
+            "firstName": "Radosław",
+            "lastName": "Majecki",
+            "shortFirstName": "Radoslaw",
+            "shortLastName": "Majecki",
+            "matchName": "R. Majecki",
+            "shirtNumber": 1,
+            "position": "Substitute",
+            "subPosition": "Goalkeeper"
+          },
+          {
+            "playerId": "28s6z18rcl9v8561yzu7m0voq",
+            "firstName": "Eliot",
+            "lastName": "Matazo",
+            "shortFirstName": "Eliot",
+            "shortLastName": "Matazo",
+            "matchName": "E. Matazo",
+            "shirtNumber": 36,
+            "position": "Substitute",
+            "subPosition": "Midfielder"
+          },
+          {
+            "playerId": "cyz9jisw86vjjf85xxgbae0yy",
+            "firstName": "Chrislain Iris Aurel",
+            "lastName": "Matsima",
+            "shortFirstName": "Chrislain",
+            "shortLastName": "Matsima",
+            "matchName": "C. Matsima",
+            "shirtNumber": 34,
+            "position": "Substitute",
+            "subPosition": "Defender"
+          },
+          {
+            "playerId": "d1gc59ozyrrnl82rog6fbm0dm",
+            "firstName": "Enzo Camille Alain",
+            "lastName": "Millot",
+            "shortFirstName": "Enzo",
+            "shortLastName": "Millot",
+            "matchName": "E. Millot",
+            "shirtNumber": 38,
+            "position": "Substitute",
+            "subPosition": "Midfielder"
+          },
+          {
+            "playerId": "7wjdqyl3bkhsfca5cu4riwley",
+            "firstName": "Strahinja",
+            "lastName": "Pavlović",
+            "shortFirstName": "Strahinja",
+            "shortLastName": "Pavlovic",
+            "matchName": "S. Pavlović",
+            "shirtNumber": 21,
+            "position": "Substitute",
+            "subPosition": "Defender"
+          }
+        ],
+        "teamOfficial": {
+          "id": "62kto0t4gfxx3cmza5o6g7cut",
+          "firstName": "Niko",
+          "lastName": "Kovač",
+          "shortFirstName": "Niko",
+          "shortLastName": "Kovac",
+          "type": "manager"
+        }
+      },
+      {
+        "contestantId": "3c3jcs7vc1t6vz5lev162jyv7",
+        "formationUsed": "442",
+        "player": [
+          {
+            "playerId": "6ekdnbnk56xlxforb5owt3dn9",
+            "firstName": "Predrag",
+            "lastName": "Rajković",
+            "shortFirstName": "Predrag",
+            "shortLastName": "Rajkovic",
+            "matchName": "P. Rajković",
+            "shirtNumber": 1,
+            "position": "Goalkeeper",
+            "positionSide": "Centre",
+            "formationPlace": "1"
+          },
+          {
+            "playerId": "19djqex4nu3lz6vw08f3fwv6x",
+            "firstName": "Ghislain N'Clomande",
+            "lastName": "Konan",
+            "shortFirstName": "Ghislain",
+            "shortLastName": "Konan",
+            "matchName": "G. Konan",
+            "shirtNumber": 3,
+            "position": "Defender",
+            "positionSide": "Left",
+            "formationPlace": "3"
+          },
+          {
+            "playerId": "976riwm0dz0e74d4l28y3ttcl",
+            "firstName": "Yunis",
+            "lastName": "Abdelhamid",
+            "shortFirstName": "Yunis",
+            "shortLastName": "Abdelhamid",
+            "matchName": "Y. Abdelhamid",
+            "shirtNumber": 5,
+            "position": "Defender",
+            "positionSide": "Left/Centre",
+            "formationPlace": "6",
+            "captain": "yes"
+          },
+          {
+            "playerId": "72d5uxwcmvhd6mzthxuvev1sl",
+            "firstName": "Wout Felix Lina",
+            "lastName": "Faes",
+            "shortFirstName": "Wout",
+            "shortLastName": "Faes",
+            "matchName": "W. Faes",
+            "shirtNumber": 2,
+            "position": "Defender",
+            "positionSide": "Centre/Right",
+            "formationPlace": "5"
+          },
+          {
+            "playerId": "3sc349yey596xp2j6xlyt0frp",
+            "firstName": "Thomas",
+            "lastName": "Foket",
+            "shortFirstName": "Thomas",
+            "shortLastName": "Foket",
+            "matchName": "T. Foket",
+            "shirtNumber": 32,
+            "position": "Defender",
+            "positionSide": "Right",
+            "formationPlace": "2"
+          },
+          {
+            "playerId": "fe4b3ric67hz0hhih3tjf2eh",
+            "firstName": "Mathieu",
+            "lastName": "Cafaro",
+            "shortFirstName": "Mathieu",
+            "shortLastName": "Cafaro",
+            "matchName": "M. Cafaro",
+            "shirtNumber": 24,
+            "position": "Midfielder",
+            "positionSide": "Left",
+            "formationPlace": "11"
+          },
+          {
+            "playerId": "8qmm84tue6kuz8e5nhhdhmz8p",
+            "firstName": "Marshall Nyasha",
+            "lastName": "Munetsi",
+            "shortFirstName": "Marshall",
+            "shortLastName": "Munetsi",
+            "matchName": "M. Munetsi",
+            "shirtNumber": 15,
+            "position": "Midfielder",
+            "positionSide": "Left/Centre",
+            "formationPlace": "8"
+          },
+          {
+            "playerId": "9nhlgi0k783bq8a2704bu6n6d",
+            "firstName": "Xavier",
+            "lastName": "Chavalerin",
+            "shortFirstName": "Xavier",
+            "shortLastName": "Chavalerin",
+            "matchName": "X. Chavalerin",
+            "shirtNumber": 7,
+            "position": "Midfielder",
+            "positionSide": "Centre/Right",
+            "formationPlace": "4"
+          },
+          {
+            "playerId": "8j2vmplbpj983xbxibhyvidx",
+            "firstName": "Dereck Germano",
+            "lastName": "Kutesa",
+            "shortFirstName": "Dereck",
+            "shortLastName": "Kutesa",
+            "matchName": "D. Kutesa",
+            "shirtNumber": 8,
+            "position": "Midfielder",
+            "positionSide": "Right",
+            "formationPlace": "7"
+          },
+          {
+            "playerId": "e6ok0deqkoe80184iu509gzu2",
+            "firstName": "El Bilal",
+            "lastName": "Touré",
+            "shortFirstName": "El Bilal",
+            "shortLastName": "Touré",
+            "matchName": "E. Touré",
+            "shirtNumber": 27,
+            "position": "Striker",
+            "positionSide": "Left/Centre",
+            "formationPlace": "9"
+          },
+          {
+            "playerId": "3mqhkh4iz4kesvmqui3hupgmi",
+            "firstName": "Boulaye",
+            "lastName": "Dia",
+            "shortFirstName": "Boulaye",
+            "shortLastName": "Dia",
+            "matchName": "B. Dia",
+            "shirtNumber": 11,
+            "position": "Striker",
+            "positionSide": "Centre/Right",
+            "formationPlace": "10"
+          },
+          {
+            "playerId": "446scvw0ckoxnvnsqcqocve1h",
+            "firstName": "Valon",
+            "lastName": "Berisha",
+            "shortFirstName": "Valon",
+            "shortLastName": "Berisha",
+            "matchName": "V. Berisha",
+            "shirtNumber": 14,
+            "position": "Substitute",
+            "subPosition": "Midfielder"
+          },
+          {
+            "playerId": "e1gq9zfwrm446r2tzmeiw6jmx",
+            "firstName": "Thibault",
+            "lastName": "De Smet",
+            "shortFirstName": "Thibault",
+            "shortLastName": "De Smet",
+            "matchName": "T. De Smet",
+            "shirtNumber": 28,
+            "position": "Substitute",
+            "subPosition": "Defender"
+          },
+          {
+            "playerId": "1vpmf7p9xsaynj1t9g5wm1qz9",
+            "firstName": "Tristan",
+            "lastName": "Dingomé",
+            "shortFirstName": "Tristan",
+            "shortLastName": "Dingomé",
+            "matchName": "T. Dingomé",
+            "shirtNumber": 20,
+            "position": "Substitute",
+            "subPosition": "Midfielder"
+          },
+          {
+            "playerId": "89sv092huj2obzdazmft854a1",
+            "firstName": "Yehvann",
+            "lastName": "Diouf",
+            "shortFirstName": "Yehvann",
+            "shortLastName": "Diouf",
+            "matchName": "Y. Diouf",
+            "shirtNumber": 16,
+            "position": "Substitute",
+            "subPosition": "Goalkeeper"
+          },
+          {
+            "playerId": "b3y2ov2ju75fr5u5e2rerj1ex",
+            "firstName": "Fraser David Ingham",
+            "lastName": "Hornby",
+            "shortFirstName": "Fraser",
+            "shortLastName": "Hornby",
+            "matchName": "F. Hornby",
+            "shirtNumber": 18,
+            "position": "Substitute",
+            "subPosition": "Attacker"
+          },
+          {
+            "playerId": "65aewljrlnaritfgi91zhpnmx",
+            "firstName": "Dario",
+            "lastName": "Marešić",
+            "shortFirstName": "Dario",
+            "shortLastName": "Maresic",
+            "matchName": "D. Marešić",
+            "shirtNumber": 29,
+            "position": "Substitute",
+            "subPosition": "Defender"
+          },
+          {
+            "playerId": "7pzfyf1ipdp6hvrik5y8hdmmt",
+            "firstName": "Moreto",
+            "lastName": "Moro Cassamá",
+            "shortFirstName": "Moreto",
+            "shortLastName": "Moro Cassamá",
+            "knownName": "Moreto Cassamá",
+            "matchName": "Moreto Cassamá",
+            "shirtNumber": 23,
+            "position": "Substitute",
+            "subPosition": "Midfielder"
+          },
+          {
+            "playerId": "5ghvrbmlh0tqos9iohj8f7zzd",
+            "firstName": "Kaj",
+            "lastName": "Sierhuis",
+            "shortFirstName": "Kaj",
+            "shortLastName": "Sierhuis",
+            "matchName": "K. Sierhuis",
+            "shirtNumber": 9,
+            "position": "Substitute",
+            "subPosition": "Attacker"
+          },
+          {
+            "playerId": "agwvouyocx93y39g7tmwaojx1",
+            "firstName": "Arbër",
+            "lastName": "Zeneli",
+            "shortFirstName": "Arbër",
+            "shortLastName": "Zeneli",
+            "matchName": "A. Zeneli",
+            "shirtNumber": 10,
+            "position": "Substitute",
+            "subPosition": "Midfielder"
+          }
+        ],
+        "teamOfficial": {
+          "id": "ccblusa4jrnoxgzc5o4zw8kb9",
+          "firstName": "David",
+          "lastName": "Guion",
+          "shortFirstName": "David",
+          "shortLastName": "Guion",
+          "type": "manager"
+        }
+      }
+    ],
+    "matchDetailsExtra": {
+      "attendance": "2933",
+      "matchOfficial": [
+        {
+          "id": "1ch8qs93kraoj5m3l1xfdytw5",
+          "type": "Main",
+          "firstName": "François",
+          "lastName": "Letexier",
+          "shortFirstName": "François",
+          "shortLastName": "Letexier"
+        },
+        {
+          "id": "1zc7tzevofkme1tmc9estj3dh",
+          "type": "Assistant referee 1",
+          "firstName": "Cyril",
+          "lastName": "Mugnier",
+          "shortFirstName": "Cyril",
+          "shortLastName": "Mugnier"
+        },
+        {
+          "id": "eky20xkl3yitd09g5lgeg7vth",
+          "type": "Assistant referee 2",
+          "firstName": "Erwan",
+          "lastName": "Finjean",
+          "shortFirstName": "Erwan",
+          "shortLastName": "Finjean"
+        },
+        {
+          "id": "19blui7tipowktbujnfm90mvp",
+          "type": "Fourth official",
+          "firstName": "Remi",
+          "lastName": "Landry",
+          "shortFirstName": "Remi",
+          "shortLastName": "Landry"
+        }
+      ]
+    }
+  }
+}

--- a/kloppy/tests/prs/pr_355/test_pr_355.py
+++ b/kloppy/tests/prs/pr_355/test_pr_355.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+from kloppy import statsperform
+
+
+class TestPR355:
+    def test_abandoned_match_end_timestamp(self, base_dir):
+        tracking_dataset = statsperform.load_tracking(
+            ma1_data=base_dir / "prs/pr_355/statsperform_tracking_ma1.json",
+            ma25_data=base_dir / "files/statsperform_tracking_ma25.txt",
+            tracking_system="sportvu",
+        )
+
+        assert tracking_dataset.metadata.periods[-1].end_timestamp == datetime(
+            2020, 8, 23, 12, 45, 22, tzinfo=timezone.utc
+        )


### PR DESCRIPTION
When a match is abandoned, the "end" attribute misses in the raw data. We handle that more gracefully and in case the datetime is present of when the match is abandonded we use that for the end of the period.