### PR TITLE
[StatsPerform] Ignore 19 - player on StatsPerform events as they are already incorporated in substitution event

### DIFF
--- a/kloppy/infra/serializers/event/statsperform/deserializer.py
+++ b/kloppy/infra/serializers/event/statsperform/deserializer.py
@@ -702,6 +702,8 @@ class StatsPerformDeserializer(EventDataDeserializer[StatsPerformInputs]):
                         f"Set end of period {period.id} to {raw_event.timestamp}"
                     )
                     period.end_timestamp = raw_event.timestamp
+                elif raw_event.type_id == EVENT_TYPE_PLAYER_ON:
+                    continue
                 else:
                     if not period.start_timestamp:
                         # not started yet

--- a/kloppy/tests/issues/issue_60/test_issue_60.py
+++ b/kloppy/tests/issues/issue_60/test_issue_60.py
@@ -16,7 +16,7 @@ class TestIssue60:
         assert deleted_event_id not in df["event_id"].to_list()
 
         # OPTA F24 file: Pass -> Deleted Event -> Tackle
-        assert event_dataset.events[16].event_name == "pass"
+        assert event_dataset.events[15].event_name == "pass"
         assert (
-            event_dataset.events[17].event_name == "duel"
+            event_dataset.events[16].event_name == "duel"
         )  # Deleted Event is filter out

--- a/kloppy/tests/test_adapter.py
+++ b/kloppy/tests/test_adapter.py
@@ -57,4 +57,4 @@ class TestAdapter:
             # Asserts borrowed from `test_opta.py`
             assert dataset.metadata.provider == Provider.OPTA
             assert dataset.dataset_type == DatasetType.EVENT
-            assert len(dataset.events) == 37
+            assert len(dataset.events) == 36

--- a/kloppy/tests/test_statsperform.py
+++ b/kloppy/tests/test_statsperform.py
@@ -177,7 +177,7 @@ class TestStatsPerformEvent:
             pitch_length=None,
             pitch_width=None,
         )
-        assert len(event_dataset.records) == 1652
+        assert len(event_dataset.records) == 1643
 
         substitution_events = event_dataset.find_all("substitution")
         assert len(substitution_events) == 9


### PR DESCRIPTION
Since we combine the 18 player off and 19 player on StatsPerform events into a SubstitutionEvent, we don't add the player on event afterwards as a generic event.

<img width="802" alt="image" src="https://github.com/user-attachments/assets/54520868-56f9-45d0-884a-938f1dd97e4d">

