### PR TITLE
Add functionality to list StatsBomb open competitions and available matches

### DIFF
--- a/kloppy/_providers/statsbomb.py
+++ b/kloppy/_providers/statsbomb.py
@@ -7,6 +7,10 @@ from kloppy.infra.serializers.event.statsbomb import (
     StatsBombDeserializer,
     StatsBombInputs,
 )
+from kloppy.infra.serializers.event.statsbomb.helpers import (
+    parse_open_competitions,
+    parse_open_matches,
+)
 from kloppy.domain import EventDataset, Optional, List, EventFactory
 from kloppy.io import open_as_file, FileLike, Source
 
@@ -76,4 +80,16 @@ def load_open_data(
         event_types=event_types,
         coordinates=coordinates,
         event_factory=event_factory,
+    )
+
+
+def list_open_competitions(detailed: bool = False):
+    return parse_open_competitions(detailed=detailed)
+
+
+def list_open_matches(
+    competition_id: int, season_id: int, detailed: bool = False
+):
+    return parse_open_matches(
+        competition_id=competition_id, season_id=season_id, detailed=detailed
     )

--- a/kloppy/infra/serializers/event/statsbomb/helpers.py
+++ b/kloppy/infra/serializers/event/statsbomb/helpers.py
@@ -206,7 +206,7 @@ def parse_open_matches(competition_id: int, season_id: int, detailed: bool):
             inplace=True,
             errors="ignore",
         )
-        return df
+        return df.sort_values(by="match_date", ascending=False)
     else:
         return df[
             [
@@ -219,7 +219,7 @@ def parse_open_matches(competition_id: int, season_id: int, detailed: bool):
                 "away_team_name",
                 "away_team_id",
             ]
-        ]
+        ].sort_values(by="match_date", ascending=False)
 
 
 def parse_open_competitions(detailed: bool):

--- a/kloppy/statsbomb.py
+++ b/kloppy/statsbomb.py
@@ -1,1 +1,6 @@
-from ._providers.statsbomb import load, load_open_data
+from ._providers.statsbomb import (
+    load,
+    load_open_data,
+    list_open_competitions,
+    list_open_matches,
+)


### PR DESCRIPTION
Hi!

While working on the docs I realized it wasn't very straightforward to see which competitions and matches are available in the StatsBomb open data repository, at least not from within Kloppy.

I have added functionality such that we can do:

```python
from kloppy import statsbomb

statsbomb.list_open_competitions(detailed=True)
statsbomb.list_open_matches(223, 282, detailed=True)
```

A couple things to consider:
- Both these functions return a pandas dataframe, but Kloppy has no explicit dependency on pandas. I have inserted a warning (similar to the one shown when doing `dataset.to_df()` if pandas has not been installed.
- I have added a `detailed` (bool=True) parameter to both functions. Setting it to `False` will provide _all_ available columns, leaving it to the default `True` will give us only the most relevant columns  
- I have moved the underlying functions to `kloppy.infra.serializers.event.statsbomb.helpers`. I'm not sure if this is desirable.
- Because of point 1, we cannot explicitly state the return type of our functions, ie we cannot do the following:
```python
def list_open_matches(
    competition_id: int, season_id: int, detailed: bool = False
) -> pd.DataFrame:
```
Instead we simply do:
```python
def list_open_matches(
    competition_id: int, season_id: int, detailed: bool = False
):
```