### PR TITLE
[SPORTEC] Load DFL Open Data

### DIFF
--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -13,6 +13,8 @@ from kloppy.infra.serializers.tracking.sportec import (
 from kloppy.io import open_as_file, FileLike
 from kloppy.utils import deprecated
 
+from requests.exceptions import HTTPError
+
 
 def load_event(
     event_data: FileLike,
@@ -121,19 +123,32 @@ def load_open_event_data(
     coordinates: Optional[str] = None,
     event_factory: Optional[EventFactory] = None,
 ) -> EventDataset:
+    """
+    Data associated with research paper:
+    Bassek, M., Weber, H., Rein, R., & Memmert, D. (2024).
+    "An integrated dataset of synchronized spatiotemporal and event data in elite soccer." In Submission.
+    """
 
     if not META_DATA_MAP.get(match_id):
         raise ValueError(
             f"This match_id is not available, please select from {list(META_DATA_MAP.keys())}"
         )
 
-    return load_event(
-        event_data=DATA_URL.format(file_id=EVENT_DATA_MAP[match_id]),
-        meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
-        event_types=event_types,
-        coordinates=coordinates,
-        event_factory=event_factory,
-    )
+    try:
+        return load_event(
+            event_data=DATA_URL.format(file_id=EVENT_DATA_MAP[match_id]),
+            meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
+            event_types=event_types,
+            coordinates=coordinates,
+            event_factory=event_factory,
+        )
+    except HTTPError as e:
+        raise HTTPError(
+            "Unable to retrieve data. The dataset archive location may have changed. "
+            "Please verify the `kloppy.sportec.DATA_URL` and file mappings. "
+            "This issue might be resolved by updating to the latest version of kloppy. "
+            "Original error: {}".format(e)
+        )
 
 
 def load_open_tracking_data(
@@ -143,17 +158,30 @@ def load_open_tracking_data(
     coordinates: Optional[str] = None,
     only_alive: Optional[bool] = True,
 ) -> EventDataset:
+    """
+    Data associated with research paper:
+    Bassek, M., Weber, H., Rein, R., & Memmert, D. (2024).
+    "An integrated dataset of synchronized spatiotemporal and event data in elite soccer." In Submission.
+    """
 
     if not META_DATA_MAP.get(match_id):
         raise ValueError(
             f"This match_id is not available, please select from {list(META_DATA_MAP.keys())}"
         )
 
-    return load_tracking(
-        raw_data=DATA_URL.format(file_id=TRACKING_DATA_MAP[match_id]),
-        meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
-        sample_rate=sample_rate,
-        limit=limit,
-        coordinates=coordinates,
-        only_alive=only_alive,
-    )
+    try:
+        return load_tracking(
+            raw_data=DATA_URL.format(file_id=TRACKING_DATA_MAP[match_id]),
+            meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
+            sample_rate=sample_rate,
+            limit=limit,
+            coordinates=coordinates,
+            only_alive=only_alive,
+        )
+    except HTTPError as e:
+        raise HTTPError(
+            "Unable to retrieve data. The dataset archive location may have changed. "
+            "Please verify the `kloppy.sportec.DATA_URL` and file mappings. "
+            "This issue might be resolved by updating to the latest version of kloppy. "
+            "Original error: {}".format(e)
+        )

--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -1,4 +1,6 @@
-from typing import Optional, List, Union
+from typing import List, Optional
+
+from requests.exceptions import HTTPError
 
 from kloppy.config import get_config
 from kloppy.domain import EventDataset, EventFactory, TrackingDataset
@@ -10,10 +12,8 @@ from kloppy.infra.serializers.tracking.sportec import (
     SportecTrackingDataDeserializer,
     SportecTrackingDataInputs,
 )
-from kloppy.io import open_as_file, FileLike
+from kloppy.io import FileLike, open_as_file
 from kloppy.utils import deprecated
-
-from requests.exceptions import HTTPError
 
 
 def load_event(
@@ -39,9 +39,10 @@ def load_event(
         coordinate_system=coordinates,
         event_factory=event_factory or get_config("event_factory"),
     )
-    with open_as_file(event_data) as event_data_fp, open_as_file(
-        meta_data
-    ) as meta_data_fp:
+    with (
+        open_as_file(event_data) as event_data_fp,
+        open_as_file(meta_data) as meta_data_fp,
+    ):
         return serializer.deserialize(
             SportecEventDataInputs(
                 event_data=event_data_fp, meta_data=meta_data_fp
@@ -63,9 +64,10 @@ def load_tracking(
         coordinate_system=coordinates,
         only_alive=only_alive,
     )
-    with open_as_file(meta_data) as meta_data_fp, open_as_file(
-        raw_data
-    ) as raw_data_fp:
+    with (
+        open_as_file(meta_data) as meta_data_fp,
+        open_as_file(raw_data) as raw_data_fp,
+    ):
         return deserializer.deserialize(
             inputs=SportecTrackingDataInputs(
                 meta_data=meta_data_fp, raw_data=raw_data_fp
@@ -86,35 +88,30 @@ def load(
     )
 
 
-META_DATA_MAP = {
-    "J03WPY": "48392497",
-    "J03WN1": "48392491",
-    "J03WMX": "48392485",
-    "J03WOH": "48392515",
-    "J03WQQ": "48392488",
-    "J03WOY": "48392503",
-    "J03WR9": "48392494",
-}
-EVENT_DATA_MAP = {
-    "J03WPY": "48392542",
-    "J03WN1": "48392527",
-    "J03WMX": "48392524",
-    "J03WOH": "48392500",
-    "J03WQQ": "48392521",
-    "J03WOY": "48392518",
-    "J03WR9": "48392530",
-}
-TRACKING_DATA_MAP = {
-    "J03WPY": "48392572",
-    "J03WN1": "48392512",
-    "J03WMX": "48392539",
-    "J03WOH": "48392578",
-    "J03WQQ": "48392545",
-    "J03WOY": "48392551",
-    "J03WR9": "48392563",
-}
+def get_IDSSE_url(match_id: str, data_type: str) -> str:
+    """Returns the URL for the meta, event or tracking data for a match in the IDDSE dataset."""
+    # match_id -> file_id
+    DATA_MAP = {
+        "J03WPY": {"meta": 48392497, "event": 48392542, "tracking": 48392572},
+        "J03WN1": {"meta": 48392491, "event": 48392527, "tracking": 48392512},
+        "J03WMX": {"meta": 48392485, "event": 48392524, "tracking": 48392539},
+        "J03WOH": {"meta": 48392515, "event": 48392500, "tracking": 48392578},
+        "J03WQQ": {"meta": 48392488, "event": 48392521, "tracking": 48392545},
+        "J03WOY": {"meta": 48392503, "event": 48392518, "tracking": 48392551},
+        "J03WR9": {"meta": 48392494, "event": 48392530, "tracking": 48392563},
+    }
+    # URL constant
+    DATA_URL = "https://figshare.com/ndownloader/files/{file_id}?private_link=1f806cb3e755c6b54e05"
 
-DATA_URL = "https://figshare.com/ndownloader/files/{file_id}?private_link=1f806cb3e755c6b54e05"
+    if data_type not in ["meta", "event", "tracking"]:
+        raise ValueError(
+            f"Data type should be one of ['meta', 'event', 'tracking'], but got {data_type}"
+        )
+    if match_id not in DATA_MAP:
+        raise ValueError(
+            f"This match_id is not available, please select from {list(DATA_MAP.keys())}"
+        )
+    return DATA_URL.format(file_id=str(DATA_MAP[match_id][data_type]))
 
 
 def load_open_event_data(
@@ -124,20 +121,49 @@ def load_open_event_data(
     event_factory: Optional[EventFactory] = None,
 ) -> EventDataset:
     """
-    Data associated with research paper:
-    Bassek, M., Weber, H., Rein, R., & Memmert, D. (2024).
-    "An integrated dataset of synchronized spatiotemporal and event data in elite soccer." In Submission.
+    Load event data for a game from the IDSSE dataset.
+
+    The IDSSE dataset will be released with the publication of the *An integrated
+    dataset of synchronized spatiotemporal and event data in elite soccer*
+    paper [1]_ and is released under the Creative Commons Attribution 4.0
+    license.
+
+    Args:
+        match_id (str, optional):
+            Match-ID of one of the matches. Defaults to `'J03WPY'`. See below
+            for available matches.
+        event_types:
+        coordinates:
+        event_factory:
+
+    Notes:
+        The dataset contains seven full matches of raw event and position data
+        for both teams and the ball from the German Men's Bundesliga season
+        2022/23 first and second division. A detailed description of the
+        dataset as well as the collection process can be found in the
+        accompanying paper.
+
+        The following matches are available::
+
+        matches = {
+            'J03WMX': 1. FC Köln vs. FC Bayern München,
+            'J03WN1': VfL Bochum 1848 vs. Bayer 04 Leverkusen,
+            'J03WPY': Fortuna Düsseldorf vs. 1. FC Nürnberg,
+            'J03WOH': Fortuna Düsseldorf vs. SSV Jahn Regensburg,
+            'J03WQQ': Fortuna Düsseldorf vs. FC St. Pauli,
+            'J03WOY': Fortuna Düsseldorf vs. F.C. Hansa Rostock,
+            'J03WR9': Fortuna Düsseldorf vs. 1. FC Kaiserslautern
+        }
+
+    References:
+        .. [1] Bassek, M., Weber, H., Rein, R., & Memmert, D. (2024). "An integrated
+               dataset of synchronized spatiotemporal and event data in elite soccer."
+               In Submission.
     """
-
-    if not META_DATA_MAP.get(match_id):
-        raise ValueError(
-            f"This match_id is not available, please select from {list(META_DATA_MAP.keys())}"
-        )
-
     try:
         return load_event(
-            event_data=DATA_URL.format(file_id=EVENT_DATA_MAP[match_id]),
-            meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
+            event_data=get_IDSSE_url(match_id, "event"),
+            meta_data=get_IDSSE_url(match_id, "meta"),
             event_types=event_types,
             coordinates=coordinates,
             event_factory=event_factory,
@@ -145,11 +171,8 @@ def load_open_event_data(
     except HTTPError as e:
         raise HTTPError(
             "Unable to retrieve data. The dataset archive location may have changed. "
-            "Please visit the GitHub Issue at https://github.com/PySport/kloppy/issues/369"
-            "and verify the `kloppy.sportec.DATA_URL` and file mappings. "
-            "This issue might be resolved by updating to the latest version of kloppy. "
-            "Original error: {}".format(e)
-        )
+            "See https://github.com/PySport/kloppy/issues/369 for details."
+        ) from e
 
 
 def load_open_tracking_data(
@@ -158,22 +181,52 @@ def load_open_tracking_data(
     limit: Optional[int] = None,
     coordinates: Optional[str] = None,
     only_alive: Optional[bool] = True,
-) -> EventDataset:
+) -> TrackingDataset:
     """
-    Data associated with research paper:
-    Bassek, M., Weber, H., Rein, R., & Memmert, D. (2024).
-    "An integrated dataset of synchronized spatiotemporal and event data in elite soccer." In Submission.
+    Load tracking data for a game from the IDSSE dataset.
+
+    The IDSSE dataset will be released with the publication of the *An integrated
+    dataset of synchronized spatiotemporal and event data in elite soccer*
+    paper [1]_ and is released under the Creative Commons Attribution 4.0
+    license.
+
+    Args:
+        match_id (str, optional):
+            Match-ID of one of the matches. Defaults to `'J03WPY'`. See below
+            for available matches.
+        sampe_rate:
+        limit:
+        coordinates:
+        only_alive:
+
+    Notes:
+        The dataset contains seven full matches of raw event and position data
+        for both teams and the ball from the German Men's Bundesliga season
+        2022/23 first and second division. A detailed description of the
+        dataset as well as the collection process can be found in the
+        accompanying paper.
+
+        The following matches are available::
+
+        matches = {
+            'J03WMX': 1. FC Köln vs. FC Bayern München,
+            'J03WN1': VfL Bochum 1848 vs. Bayer 04 Leverkusen,
+            'J03WPY': Fortuna Düsseldorf vs. 1. FC Nürnberg,
+            'J03WOH': Fortuna Düsseldorf vs. SSV Jahn Regensburg,
+            'J03WQQ': Fortuna Düsseldorf vs. FC St. Pauli,
+            'J03WOY': Fortuna Düsseldorf vs. F.C. Hansa Rostock,
+            'J03WR9': Fortuna Düsseldorf vs. 1. FC Kaiserslautern
+        }
+
+    References:
+        .. [1] Bassek, M., Weber, H., Rein, R., & Memmert, D. (2024). "An integrated
+               dataset of synchronized spatiotemporal and event data in elite soccer."
+               In Submission.
     """
-
-    if not META_DATA_MAP.get(match_id):
-        raise ValueError(
-            f"This match_id is not available, please select from {list(META_DATA_MAP.keys())}"
-        )
-
     try:
         return load_tracking(
-            raw_data=DATA_URL.format(file_id=TRACKING_DATA_MAP[match_id]),
-            meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
+            raw_data=get_IDSSE_url(match_id, "tracking"),
+            meta_data=get_IDSSE_url(match_id, "meta"),
             sample_rate=sample_rate,
             limit=limit,
             coordinates=coordinates,
@@ -182,8 +235,5 @@ def load_open_tracking_data(
     except HTTPError as e:
         raise HTTPError(
             "Unable to retrieve data. The dataset archive location may have changed. "
-            "Please visit the GitHub Issue at https://github.com/PySport/kloppy/issues/369"
-            "and verify the `kloppy.sportec.DATA_URL` and file mappings. "
-            "This issue might be resolved by updating to the latest version of kloppy. "
-            "Original error: {}".format(e)
-        )
+            "See https://github.com/PySport/kloppy/issues/369 for details."
+        ) from e

--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Union
 
 from kloppy.config import get_config
 from kloppy.domain import EventDataset, EventFactory, TrackingDataset
@@ -81,4 +81,79 @@ def load(
 ) -> EventDataset:
     return load_event(
         event_data, meta_data, event_types, coordinates, event_factory
+    )
+
+
+META_DATA_MAP = {
+    "J03WPY": "48392497",
+    "J03WN1": "48392491",
+    "J03WMX": "48392485",
+    "J03WOH": "48392515",
+    "J03WQQ": "48392488",
+    "J03WOY": "48392503",
+    "J03WR9": "48392494",
+}
+EVENT_DATA_MAP = {
+    "J03WPY": "48392542",
+    "J03WN1": "48392527",
+    "J03WMX": "48392524",
+    "J03WOH": "48392500",
+    "J03WQQ": "48392521",
+    "J03WOY": "48392518",
+    "J03WR9": "48392530",
+}
+TRACKING_DATA_MAP = {
+    "J03WPY": "48392572",
+    "J03WN1": "48392512",
+    "J03WMX": "48392539",
+    "J03WOH": "48392578",
+    "J03WQQ": "48392545",
+    "J03WOY": "48392551",
+    "J03WR9": "48392563",
+}
+
+DATA_URL = "https://figshare.com/ndownloader/files/{file_id}?private_link=1f806cb3e755c6b54e05"
+
+
+def load_open_event_data(
+    match_id: str = "J03WPY",
+    event_types: Optional[List[str]] = None,
+    coordinates: Optional[str] = None,
+    event_factory: Optional[EventFactory] = None,
+) -> EventDataset:
+
+    if not META_DATA_MAP.get(match_id):
+        raise ValueError(
+            f"This match_id is not available, please select from {list(META_DATA_MAP.keys())}"
+        )
+
+    return load_event(
+        event_data=DATA_URL.format(file_id=EVENT_DATA_MAP[match_id]),
+        meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
+        event_types=event_types,
+        coordinates=coordinates,
+        event_factory=event_factory,
+    )
+
+
+def load_open_tracking_data(
+    match_id: str = "J03WPY",
+    sample_rate: Optional[float] = None,
+    limit: Optional[int] = None,
+    coordinates: Optional[str] = None,
+    only_alive: Optional[bool] = True,
+) -> EventDataset:
+
+    if not META_DATA_MAP.get(match_id):
+        raise ValueError(
+            f"This match_id is not available, please select from {list(META_DATA_MAP.keys())}"
+        )
+
+    return load_tracking(
+        raw_data=DATA_URL.format(file_id=TRACKING_DATA_MAP[match_id]),
+        meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
+        sample_rate=sample_rate,
+        limit=limit,
+        coordinates=coordinates,
+        only_alive=only_alive,
     )

--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -145,7 +145,8 @@ def load_open_event_data(
     except HTTPError as e:
         raise HTTPError(
             "Unable to retrieve data. The dataset archive location may have changed. "
-            "Please verify the `kloppy.sportec.DATA_URL` and file mappings. "
+            "Please visit the GitHub Issue at https://github.com/PySport/kloppy/issues/369"
+            "and verify the `kloppy.sportec.DATA_URL` and file mappings. "
             "This issue might be resolved by updating to the latest version of kloppy. "
             "Original error: {}".format(e)
         )
@@ -181,7 +182,8 @@ def load_open_tracking_data(
     except HTTPError as e:
         raise HTTPError(
             "Unable to retrieve data. The dataset archive location may have changed. "
-            "Please verify the `kloppy.sportec.DATA_URL` and file mappings. "
+            "Please visit the GitHub Issue at https://github.com/PySport/kloppy/issues/369"
+            "and verify the `kloppy.sportec.DATA_URL` and file mappings. "
             "This issue might be resolved by updating to the latest version of kloppy. "
             "Original error: {}".format(e)
         )

--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -39,10 +39,9 @@ def load_event(
         coordinate_system=coordinates,
         event_factory=event_factory or get_config("event_factory"),
     )
-    with (
-        open_as_file(event_data) as event_data_fp,
-        open_as_file(meta_data) as meta_data_fp,
-    ):
+    with open_as_file(event_data) as event_data_fp, open_as_file(
+        meta_data
+    ) as meta_data_fp:
         return serializer.deserialize(
             SportecEventDataInputs(
                 event_data=event_data_fp, meta_data=meta_data_fp
@@ -64,10 +63,9 @@ def load_tracking(
         coordinate_system=coordinates,
         only_alive=only_alive,
     )
-    with (
-        open_as_file(meta_data) as meta_data_fp,
-        open_as_file(raw_data) as raw_data_fp,
-    ):
+    with open_as_file(meta_data) as meta_data_fp, open_as_file(
+        raw_data
+    ) as raw_data_fp:
         return deserializer.deserialize(
             inputs=SportecTrackingDataInputs(
                 meta_data=meta_data_fp, raw_data=raw_data_fp

--- a/kloppy/sportec.py
+++ b/kloppy/sportec.py
@@ -1,1 +1,7 @@
-from ._providers.sportec import load, load_event, load_tracking
+from ._providers.sportec import (
+    load,
+    load_event,
+    load_tracking,
+    load_open_event_data,
+    load_open_tracking_data,
+)


### PR DESCRIPTION
The [Floodlight Package](https://github.com/floodlight-sports/floodlight/blob/main/floodlight/io/datasets.py#L809) has a way to load 7 games of DFL event and tracking data. 

```python
{
        'J03WMX': 1. FC Köln vs. FC Bayern München,
        'J03WN1': VfL Bochum 1848 vs. Bayer 04 Leverkusen,
        'J03WPY': Fortuna Düsseldorf vs. 1. FC Nürnberg,
        'J03WOH': Fortuna Düsseldorf vs. SSV Jahn Regensburg,
        'J03WQQ': Fortuna Düsseldorf vs. FC St. Pauli,
        'J03WOY': Fortuna Düsseldorf vs. F.C. Hansa Rostock,
        'J03WR9': Fortuna Düsseldorf vs. 1. FC Kaiserslautern
        }
```

I have created an implementation to load this same data directly into Kloppy. We simply add:

```python
def load_open_event_data(
    match_id: str = "J03WPY",
    event_types: Optional[List[str]] = None,
    coordinates: Optional[str] = None,
    event_factory: Optional[EventFactory] = None,
) -> EventDataset:

    if not META_DATA_MAP.get(match_id):
        raise ValueError(
            f"This match_id is not available, please select from {list(META_DATA_MAP.keys())}"
        )

    return load_event(
        event_data=DATA_URL.format(file_id=EVENT_DATA_MAP[match_id]),
        meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
        event_types=event_types,
        coordinates=coordinates,
        event_factory=event_factory,
    )


def load_open_tracking_data(
    match_id: str = "J03WPY",
    sample_rate: Optional[float] = None,
    limit: Optional[int] = None,
    coordinates: Optional[str] = None,
    only_alive: Optional[bool] = True,
) -> EventDataset:

    if not META_DATA_MAP.get(match_id):
        raise ValueError(
            f"This match_id is not available, please select from {list(META_DATA_MAP.keys())}"
        )

    return load_tracking(
        raw_data=DATA_URL.format(file_id=TRACKING_DATA_MAP[match_id]),
        meta_data=DATA_URL.format(file_id=META_DATA_MAP[match_id]),
        sample_rate=sample_rate,
        limit=limit,
        coordinates=coordinates,
        only_alive=only_alive,
    )
```

I've added the following in the same file, but I'm not sure how desirable this is and if it needs to be put in another file.

```python
META_DATA_MAP = {
    "J03WPY": "48392497",
    "J03WN1": "48392491",
    "J03WMX": "48392485",
    "J03WOH": "48392515",
    "J03WQQ": "48392488",
    "J03WOY": "48392503",
    "J03WR9": "48392494",
}
EVENT_DATA_MAP = {
    "J03WPY": "48392542",
    "J03WN1": "48392527",
    "J03WMX": "48392524",
    "J03WOH": "48392500",
    "J03WQQ": "48392521",
    "J03WOY": "48392518",
    "J03WR9": "48392530",
}
TRACKING_DATA_MAP = {
    "J03WPY": "48392572",
    "J03WN1": "48392512",
    "J03WMX": "48392539",
    "J03WOH": "48392578",
    "J03WQQ": "48392545",
    "J03WOY": "48392551",
    "J03WR9": "48392563",
}

DATA_URL = "https://figshare.com/ndownloader/files/{file_id}?private_link=1f806cb3e755c6b54e05"
```

Finally, when loading `match_id="J03WN1"` or `match_id="J03WN1"` tracking data I get an error, but `match_id="J03WPY"` works fine. So, this would be an issue that we'd have to resolve, although it seems unrelated to this specific implementation.
