### PR TITLE
Fix common bug in parsing of UTC datetimes; remove dateutil

### DIFF
--- a/kloppy/infra/serializers/event/datafactory/deserializer.py
+++ b/kloppy/infra/serializers/event/datafactory/deserializer.py
@@ -1,9 +1,8 @@
 import json
 import logging
-from datetime import timedelta, datetime, timezone
-from dateutil.parser import parse, _parser
 from dataclasses import replace
-from typing import Dict, List, Tuple, Union, IO, NamedTuple
+from datetime import datetime, timedelta, timezone
+from typing import IO, Dict, List, NamedTuple, Tuple, Union
 
 from kloppy.domain import (
     AttackingDirection,
@@ -40,7 +39,6 @@ from kloppy.domain import (
 from kloppy.exceptions import DeserializationError
 from kloppy.infra.serializers.event.deserializer import EventDataDeserializer
 from kloppy.utils import Readable, performance_logging
-
 
 logger = logging.getLogger(__name__)
 
@@ -435,7 +433,7 @@ class DatafactoryDeserializer(EventDataDeserializer[DatafactoryInputs]):
                     + status_update["time"]
                     + match["stadiumGMT"],
                     "%Y%m%d%H:%M:%S%z",
-                ).astimezone(timezone.utc)
+                )
                 half = status_update["t"]["half"]
                 if status_update["type"] == DF_EVENT_TYPE_STATUS_MATCH_START:
                     half = 1
@@ -458,8 +456,10 @@ class DatafactoryDeserializer(EventDataDeserializer[DatafactoryInputs]):
                 date = match["date"]
                 if date:
                     # TODO: scheduledStart and stadiumGMT should probably be used here too
-                    date = parse(date).astimezone(timezone.utc)
-            except _parser.ParserError:
+                    date = datetime.strptime(date, "%Y%m%d").replace(
+                        tzinfo=timezone.utc
+                    )
+            except ValueError:
                 date = None
             game_week = match.get("week", None)
             if game_week:

--- a/kloppy/infra/serializers/event/sportec/deserializer.py
+++ b/kloppy/infra/serializers/event/sportec/deserializer.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 from typing import Dict, List, NamedTuple, IO
 from datetime import timedelta, datetime, timezone
 import logging
-from dateutil.parser import parse
 from lxml import objectify
 
 from kloppy.domain import (
@@ -277,7 +276,7 @@ SPORTEC_EVENT_BODY_PART_RIGHT_FOOT = "rightLeg"
 
 
 def _parse_datetime(dt_str: str) -> datetime:
-    return parse(dt_str).astimezone(timezone.utc)
+    return datetime.fromisoformat(dt_str)
 
 
 def _get_event_qualifiers(event_chain: Dict) -> List[Qualifier]:
@@ -432,9 +431,9 @@ class SportecEventDataDeserializer(
             event_root = objectify.fromstring(inputs.event_data.read())
 
         with performance_logging("parse data", logger=logger):
-            date = parse(
+            date = datetime.fromisoformat(
                 match_root.MatchInformation.General.attrib["KickoffTime"]
-            ).astimezone(timezone.utc)
+            )
             game_week = match_root.MatchInformation.General.attrib["MatchDay"]
             game_id = match_root.MatchInformation.General.attrib["MatchId"]
 

--- a/kloppy/infra/serializers/event/statsperform/deserializer.py
+++ b/kloppy/infra/serializers/event/statsperform/deserializer.py
@@ -1,8 +1,9 @@
-import pytz
 import math
 from typing import Dict, List, NamedTuple, IO, Optional
 import logging
 from datetime import datetime, timedelta
+
+import pytz
 
 from kloppy.domain import (
     EventDataset,
@@ -793,11 +794,18 @@ class StatsPerformDeserializer(EventDataDeserializer[StatsPerformInputs]):
                     ):
                         if raw_event.type_id == EVENT_TYPE_SHOT_GOAL:
                             if 374 in raw_event.qualifiers:
+                                # Qualifier 374 specifies the actual time of the shot for all goal events
+                                # It uses London timezone for both MA3 and F24 feeds
+                                naive_datetime = datetime.strptime(
+                                    raw_event.qualifiers[374],
+                                    "%Y-%m-%d %H:%M:%S.%f",
+                                )
+                                timezone = pytz.timezone("Europe/London")
+                                aware_datetime = timezone.localize(
+                                    naive_datetime
+                                )
                                 generic_event_kwargs["timestamp"] = (
-                                    datetime.strptime(
-                                        raw_event.qualifiers[374],
-                                        "%Y-%m-%d %H:%M:%S.%f",
-                                    ).replace(tzinfo=pytz.utc)
+                                    aware_datetime.astimezone(pytz.utc)
                                     - period.start_timestamp
                                 )
                         shot_event_kwargs = _parse_shot(raw_event)

--- a/kloppy/infra/serializers/event/statsperform/parsers/base.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/base.py
@@ -61,7 +61,7 @@ class OptaParser:
         """Return the score of the game."""
         return None
 
-    def extract_date(self) -> Optional[str]:
+    def extract_date(self) -> Optional[datetime]:
         """Return the date of the game."""
         return None
 

--- a/kloppy/infra/serializers/event/statsperform/parsers/f24_xml.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/f24_xml.py
@@ -1,10 +1,11 @@
 """XML parser for Opta F24 feeds."""
-import pytz
-from datetime import datetime, timezone
-from typing import List, Optional
-from dateutil.parser import parse
 
-from .base import OptaXMLParser, OptaEvent
+from datetime import datetime
+from typing import List, Optional
+
+import pytz
+
+from .base import OptaEvent, OptaXMLParser
 
 
 def _parse_f24_datetime(dt_str: str) -> datetime:
@@ -15,9 +16,10 @@ def _parse_f24_datetime(dt_str: str) -> datetime:
         return ".".join(parts[:-1] + ["{:03d}".format(int(parts[-1]))])
 
     dt_str = zero_pad_milliseconds(dt_str)
-    return datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f").replace(
-        tzinfo=pytz.utc
-    )
+    naive_datetime = datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f")
+    timezone = pytz.timezone("Europe/London")
+    aware_datetime = timezone.localize(naive_datetime)
+    return aware_datetime.astimezone(pytz.utc)
 
 
 class F24XMLParser(OptaXMLParser):
@@ -54,11 +56,16 @@ class F24XMLParser(OptaXMLParser):
             for event in game_elm.iterchildren("Event")
         ]
 
-    def extract_date(self) -> Optional[str]:
+    def extract_date(self) -> Optional[datetime]:
         """Return the date of the game."""
         game_elm = self.root.find("Game")
         if game_elm and "game_date" in game_elm.attrib:
-            return parse(game_elm.attrib["game_date"]).astimezone(timezone.utc)
+            naive_datetime = datetime.strptime(
+                game_elm.attrib["game_date"], "%Y-%m-%dT%H:%M:%S"
+            )
+            timezone = pytz.timezone("Europe/London")
+            aware_datetime = timezone.localize(naive_datetime)
+            return aware_datetime.astimezone(pytz.utc)
         else:
             return None
 

--- a/kloppy/infra/serializers/event/statsperform/parsers/ma1_json.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/ma1_json.py
@@ -1,10 +1,11 @@
 """JSON parser for Stats Perform MA1 feeds."""
-import pytz
-from datetime import datetime, timezone
-from typing import Any, Optional, List, Tuple, Dict
 
-from kloppy.domain import Period, Score, Team, Ground, Player
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from kloppy.domain import Ground, Period, Player, Score, Team
 from kloppy.exceptions import DeserializationError
+
 from .base import OptaJSONParser
 
 
@@ -30,12 +31,12 @@ class MA1JSONParser(OptaJSONParser):
                     id=period["id"],
                     start_timestamp=datetime.strptime(
                         period_start_raw, "%Y-%m-%dT%H:%M:%SZ"
-                    ).replace(tzinfo=pytz.utc)
+                    ).replace(tzinfo=timezone.utc)
                     if period_start_raw
                     else None,
                     end_timestamp=datetime.strptime(
                         period_end_raw, "%Y-%m-%dT%H:%M:%SZ"
-                    ).replace(tzinfo=pytz.utc)
+                    ).replace(tzinfo=timezone.utc)
                     if period_end_raw
                     else None,
                 )
@@ -95,12 +96,12 @@ class MA1JSONParser(OptaJSONParser):
             raise DeserializationError("Lineup incomplete")
         return home_team, away_team
 
-    def extract_date(self) -> Optional[str]:
+    def extract_date(self) -> Optional[datetime]:
         """Return the date of the game."""
         if "matchInfo" in self.root and "date" in self.root["matchInfo"]:
             return datetime.strptime(
                 self.root["matchInfo"]["date"], "%Y-%m-%dZ"
-            ).astimezone(timezone.utc)
+            ).replace(tzinfo=timezone.utc)
         else:
             return None
 

--- a/kloppy/infra/serializers/event/statsperform/parsers/ma1_xml.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/ma1_xml.py
@@ -1,6 +1,5 @@
 """XML parser for Stats Perform MA1 feeds."""
-import pytz
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional, List, Dict, Tuple
 
 from kloppy.domain import Period, Score, Team, Ground, Player
@@ -22,10 +21,10 @@ class MA1XMLParser(OptaXMLParser):
                     id=int(period.get("id")),
                     start_timestamp=datetime.strptime(
                         period.get("start"), "%Y-%m-%dT%H:%M:%SZ"
-                    ).replace(tzinfo=pytz.utc),
+                    ).replace(tzinfo=timezone.utc),
                     end_timestamp=datetime.strptime(
                         period.get("end"), "%Y-%m-%dT%H:%M:%SZ"
-                    ).replace(tzinfo=pytz.utc),
+                    ).replace(tzinfo=timezone.utc),
                 )
             )
         return parsed_periods

--- a/kloppy/infra/serializers/event/statsperform/parsers/ma3_json.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/ma3_json.py
@@ -1,6 +1,5 @@
 """JSON parser for Stats Perform MA3 feeds."""
-import pytz
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 from .base import OptaJSONParser, OptaEvent
@@ -9,12 +8,12 @@ from .base import OptaJSONParser, OptaEvent
 def _parse_ma3_datetime(dt_str: str) -> datetime:
     try:
         return datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
-            tzinfo=pytz.utc
+            tzinfo=timezone.utc
         )
 
     except ValueError:
         return datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%SZ").replace(
-            tzinfo=pytz.utc
+            tzinfo=timezone.utc
         )
 
 

--- a/kloppy/infra/serializers/event/statsperform/parsers/ma3_xml.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/ma3_xml.py
@@ -1,6 +1,5 @@
 """XML parser for Stats Perform MA3 feeds."""
-import pytz
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 from .base import OptaXMLParser, OptaEvent
@@ -9,11 +8,11 @@ from .base import OptaXMLParser, OptaEvent
 def _parse_ma3_datetime(dt_str: str) -> datetime:
     try:
         return datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
-            tzinfo=pytz.utc
+            tzinfo=timezone.utc
         )
     except ValueError:
         return datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%SZ").replace(
-            tzinfo=pytz.utc
+            tzinfo=timezone.utc
         )
 
 

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -1,11 +1,9 @@
 import json
 import logging
 from dataclasses import replace
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Dict, List, Optional
-
-from dateutil.parser import parse
 
 from kloppy.domain import (
     BodyPart,
@@ -709,7 +707,9 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
             )
             date = raw_events["match"].get("dateutc")
             if date:
-                date = parse(date).astimezone(timezone.utc)
+                date = datetime.strptime(date, "%Y-%m-%d %H:%M:%S").replace(
+                    tzinfo=timezone.utc
+                )
             game_week = raw_events["match"].get("gameweek")
             if game_week:
                 game_week = str(game_week)

--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -1,15 +1,14 @@
-import logging
-from datetime import timedelta, timezone
-from dateutil.parser import parse
-import warnings
-from typing import NamedTuple, IO, Optional, Union, Dict
-from collections import Counter
-import numpy as np
 import json
+import logging
+import warnings
+from collections import Counter
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import IO, Dict, NamedTuple, Optional, Union
+
+import numpy as np
 
 from kloppy.domain import (
-    attacking_direction_from_frame,
     AttackingDirection,
     DatasetFlag,
     Frame,
@@ -18,6 +17,7 @@ from kloppy.domain import (
     Orientation,
     Period,
     Player,
+    PlayerData,
     Point,
     Point3D,
     PositionType,
@@ -25,7 +25,7 @@ from kloppy.domain import (
     Score,
     Team,
     TrackingDataset,
-    PlayerData,
+    attacking_direction_from_frame,
 )
 from kloppy.infra.serializers.tracking.deserializer import (
     TrackingDataDeserializer,
@@ -367,7 +367,9 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
 
             date = metadata.get("date_time")
             if date:
-                date = parse(date).astimezone(timezone.utc)
+                date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ").replace(
+                    tzinfo=timezone.utc
+                )
 
             game_id = metadata.get("id")
             if game_id:

--- a/kloppy/infra/serializers/tracking/sportec/deserializer.py
+++ b/kloppy/infra/serializers/tracking/sportec/deserializer.py
@@ -2,8 +2,7 @@ import logging
 import warnings
 from collections import defaultdict
 from typing import NamedTuple, Optional, Union, IO
-from datetime import timedelta, timezone
-from dateutil.parser import parse
+from datetime import datetime, timedelta
 
 from lxml import objectify
 
@@ -131,9 +130,9 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
             away_coach = sportec_metadata.away_coach
 
         with performance_logging("parse raw data", logger=logger):
-            date = parse(
+            date = datetime.fromisoformat(
                 match_root.MatchInformation.General.attrib["KickoffTime"]
-            ).astimezone(timezone.utc)
+            )
             game_week = match_root.MatchInformation.General.attrib["MatchDay"]
             game_id = match_root.MatchInformation.General.attrib["MatchId"]
 

--- a/kloppy/infra/serializers/tracking/tracab/tracab_dat.py
+++ b/kloppy/infra/serializers/tracking/tracab/tracab_dat.py
@@ -1,9 +1,8 @@
 import logging
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 import warnings
 from typing import Dict, Optional, Union
 import html
-from dateutil.parser import parse
 
 from lxml import objectify
 
@@ -184,9 +183,9 @@ class TRACABDatDeserializer(TrackingDataDeserializer[TRACABInputs]):
                 pitch_size_height = float(
                     match.attrib["fPitchYSizeMeters"].replace(",", ".")
                 )
-                date = parse(meta_data.match.attrib["dtDate"]).astimezone(
-                    timezone.utc
-                )
+                date = datetime.strptime(
+                    meta_data.match.attrib["dtDate"], "%Y-%m-%d %H:%M:%S"
+                ).replace(tzinfo=timezone.utc)
                 game_id = meta_data.match.attrib["iId"]
 
                 for period in match.iterchildren(tag="period"):
@@ -205,7 +204,9 @@ class TRACABDatDeserializer(TrackingDataDeserializer[TRACABInputs]):
                             )
                         )
             elif hasattr(meta_data, "Phase1StartFrame"):
-                date = parse(str(meta_data["Kickoff"]))
+                date = datetime.strptime(
+                    str(meta_data["Kickoff"]), "%Y-%m-%d %H:%M:%S"
+                ).replace(tzinfo=timezone.utc)
                 game_id = str(meta_data["GameID"])
                 id_suffix = "ID"
                 player_item = "item"

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -61,11 +61,11 @@ def test_parse_f24_datetime():
     """Test if the F24 datetime is correctly parsed"""
     # timestamps have millisecond precision
     assert _parse_f24_datetime("2018-09-23T15:02:13.608") == datetime(
-        2018, 9, 23, 15, 2, 13, 608000, tzinfo=timezone.utc
+        2018, 9, 23, 14, 2, 13, 608000, tzinfo=timezone.utc
     )
     # milliseconds are not left-padded
     assert _parse_f24_datetime("2018-09-23T15:02:14.39") == datetime(
-        2018, 9, 23, 15, 2, 14, 39000, tzinfo=timezone.utc
+        2018, 9, 23, 14, 2, 14, 39000, tzinfo=timezone.utc
     )
 
 
@@ -325,7 +325,7 @@ class TestOptaShotEvent:
         )
 
     def test_timestamp_goal(self, dataset: EventDataset):
-        """Check timestamp from qualifier in case of goal"""
+        """Check timestamp from qualifier 374 in case of goal"""
         goal = dataset.get_event_by_id("2318695229")
         assert goal.timestamp == (
             _parse_f24_datetime("2018-09-23T16:07:48.525")  # event timestamp

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ def setup_package():
             "requests>=2.0.0,<3",
             "pytz>=2020.1",
             'typing_extensions;python_version<"3.11"',
-            "python-dateutil>=2.8.1,<3",
             "sortedcontainers>=2",
         ],
         extras_require={


### PR DESCRIPTION
This PR addresses a common bug related to parsing UTC datetimes, fixes the timezone of Opta F24 data and removes the `dateutil` dependency.

The following conventions are used:
- All datetimes are timezone-aware
- If the local timezone is known, the local timezone is used
- If the local timezone is not known, UTC is used

## `astimezone` -> `replace`
Often, datetimes are specified as a string and use the UTC timezone. In kloppy, we want to parse these a timezone-aware `datetime`. Then, then string was usually parsed and converted to a timezone-aware datetime as follows:

```py
>>> parse("2024-12-14 12:00").astimezone(timezone.utc)
datetime.datetime(2024, 12, 14, 11, 0, tzinfo=datetime.timezone.utc)  # on a system with local timezone UTC+1
```

The correct implementation is:

```py
>>> parse("2024-12-14 12:00").replace(tzinfo=timezone.utc)
datetime.datetime(2024, 12, 14, 12, 0, tzinfo=datetime.timezone.utc)
```

The former _changes_ the timezone, while the latter _sets_ the timezone (i.e., makes the datetime timezone-aware).

## Opta F24 timezone

According to the documentation, timestamps in the F24 files use the timezone "Europe/London".

## Remove `dateutil`

We know the exact format of the date string in advance. Hence, we don't need `dateutil`'s `parser` module.