### PR TITLE
[General] Fixed Undersirable "None" value for positions.last() 

### DIFF
--- a/kloppy/domain/models/time.py
+++ b/kloppy/domain/models/time.py
@@ -241,13 +241,20 @@ class TimeContainer(Generic[T]):
         return ranges_
 
     def last(self, include_time: bool = False, default=SENTINEL):
+        def __get_last_non_none_key(items):
+            for key, value in reversed(items.items()):
+                if value is not None:
+                    return key
+            return None
+
         if not len(self.items):
             if default == SENTINEL:
                 raise KeyError
             else:
                 return default
 
-        time = self.items.keys()[-1]
+        time = __get_last_non_none_key(self.items)
+
         if include_time:
             return time, self.items[time]
         else:

--- a/kloppy/infra/serializers/event/statsperform/parsers/f24_xml.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/f24_xml.py
@@ -57,7 +57,7 @@ class F24XMLParser(OptaXMLParser):
     def extract_date(self) -> Optional[str]:
         """Return the date of the game."""
         game_elm = self.root.find("Game")
-        if game_elm and "game_date" in game_elm.attrib:
+        if game_elm is not None and "game_date" in game_elm.attrib:
             return parse(game_elm.attrib["game_date"]).astimezone(timezone.utc)
         else:
             return None
@@ -65,15 +65,15 @@ class F24XMLParser(OptaXMLParser):
     def extract_game_week(self) -> Optional[str]:
         """Return the game_week of the game."""
         game_elm = self.root.find("Game")
-        if game_elm and "matchday" in game_elm.attrib:
+        if game_elm is not None and "matchday" in game_elm.attrib:
             return game_elm.attrib["matchday"]
         else:
             return None
 
     def extract_game_id(self) -> Optional[str]:
         """Return the game_id of the game."""
-        game_elm = self.root.find("Game")
-        if game_elm and "id" in game_elm.attrib:
+        game_elm: Optional[Element] = self.root.find("Game")
+        if game_elm is not None and "id" in game_elm.attrib:
             return game_elm.attrib["id"]
         else:
             return None


### PR DESCRIPTION
Hi,

I noticed that with the new `TimeContainer` functionality, when we call `player.positions.last()` we would get a `None` value as the last position for a lot of players. I'm assuming this is because of substitutions? 

I've resolved the issue by now simply returning the last not None value, such that at least for every player that was on the pitch during the game the `last()` call gives a valid position.

Additionally, since I was getting a deprecation warning I fixed some very small syntax in the f24 xml parsing. This is not part of the same problem though.