### PR TITLE
[StatsBomb] Insert synthetic ball out events at the correct position

### DIFF
--- a/kloppy/infra/serializers/event/statsbomb/specification.py
+++ b/kloppy/infra/serializers/event/statsbomb/specification.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from enum import Enum, EnumMeta
-from typing import List, Dict, Optional, NamedTuple, Union
+from typing import Dict, List, NamedTuple, Optional, Union
 
 from kloppy.domain import (
     BallState,
@@ -9,34 +9,35 @@ from kloppy.domain import (
     CardQualifier,
     CardType,
     CarryResult,
+    CounterAttackQualifier,
     DuelQualifier,
     DuelResult,
     DuelType,
     Event,
     EventFactory,
+    ExpectedGoals,
+    FormationType,
     GoalkeeperActionType,
     GoalkeeperQualifier,
     InterceptionResult,
     PassQualifier,
     PassResult,
     PassType,
+    PositionType,
+    PostShotExpectedGoals,
     SetPieceQualifier,
     SetPieceType,
     ShotResult,
     TakeOnResult,
-    FormationType,
-    PositionType,
-    CounterAttackQualifier,
-    ExpectedGoals,
-    PostShotExpectedGoals,
 )
+from kloppy.domain.models.event import GoalkeeperEvent
 from kloppy.exceptions import DeserializationError
 from kloppy.infra.serializers.event.statsbomb.helpers import (
-    parse_str_ts,
-    get_team_by_id,
     get_period_by_id,
+    get_team_by_id,
     parse_coordinates,
     parse_obv_values,
+    parse_str_ts,
 )
 
 
@@ -484,6 +485,13 @@ class PASS(EVENT):
             or "outcome" in pass_dict
             and PASS.OUTCOME(pass_dict["outcome"]) == PASS.OUTCOME.OUT
         ):
+            # If there is a related (failed) ball receipt event recorded for
+            # the pass, we create the ball out event from that event.
+            if any(
+                isinstance(related_event, BALL_RECEIPT)
+                for related_event in self.related_events
+            ):
+                return []
             generic_event_kwargs[
                 "event_id"
             ] = f"out-{generic_event_kwargs['event_id']}"
@@ -499,6 +507,39 @@ class PASS(EVENT):
                 **generic_event_kwargs,
             )
             return [ball_out_event]
+        return []
+
+
+class BALL_RECEIPT(EVENT):
+    """StatsBomb 42/Ball Receipt* event."""
+
+    def _create_ball_out_event(
+        self, event_factory: EventFactory, **generic_event_kwargs
+    ) -> List[Event]:
+        for related_event in self.related_events:
+            if isinstance(related_event, PASS):
+                pass_dict = related_event.raw_event.get("pass", {})
+                if (
+                    related_event.raw_event.get("out", False)
+                    or "outcome" in pass_dict
+                    and PASS.OUTCOME(pass_dict["outcome"]) == PASS.OUTCOME.OUT
+                ):
+                    generic_event_kwargs[
+                        "event_id"
+                    ] = f"out-{generic_event_kwargs['event_id']}"
+                    generic_event_kwargs["ball_state"] = BallState.DEAD
+                    generic_event_kwargs["coordinates"] = parse_coordinates(
+                        pass_dict["end_location"],
+                        self.fidelity_version,
+                    )
+
+                    ball_out_event = event_factory.build_ball_out(
+                        result=None,
+                        qualifiers=None,
+                        **generic_event_kwargs,
+                    )
+                    return [ball_out_event]
+                return []
         return []
 
 
@@ -584,6 +625,13 @@ class SHOT(EVENT):
             or "outcome" in shot_dict
             and SHOT.OUTCOME(shot_dict["outcome"]) == SHOT.OUTCOME.OFF_TARGET
         ):
+            # If there is a related goalkeeper event recorded for
+            # the shot, we create the ball out event from that event.
+            if any(
+                isinstance(related_event, GOALKEEPER)
+                for related_event in self.related_events
+            ):
+                return []
             generic_event_kwargs[
                 "event_id"
             ] = f"out-{generic_event_kwargs['event_id']}"
@@ -1064,6 +1112,31 @@ class GOALKEEPER(EVENT):
                 **generic_event_kwargs,
             )
             return [ball_out_event]
+        for related_event in self.related_events:
+            if isinstance(related_event, SHOT):
+                shot_dict = related_event.raw_event.get("shot", {})
+                if (
+                    related_event.raw_event.get("out", False)
+                    or "outcome" in shot_dict
+                    and SHOT.OUTCOME(shot_dict["outcome"])
+                    == SHOT.OUTCOME.OFF_TARGET
+                ):
+                    generic_event_kwargs[
+                        "event_id"
+                    ] = f"out-{generic_event_kwargs['event_id']}"
+                    generic_event_kwargs["ball_state"] = BallState.DEAD
+                    generic_event_kwargs["coordinates"] = parse_coordinates(
+                        shot_dict["end_location"],
+                        self.fidelity_version,
+                    )
+
+                    ball_out_event = event_factory.build_ball_out(
+                        result=None,
+                        qualifiers=None,
+                        **generic_event_kwargs,
+                    )
+                    return [ball_out_event]
+                return []
         return []
 
 
@@ -1367,6 +1440,7 @@ def _get_set_piece_qualifiers(
 def event_decoder(raw_event: Dict) -> Union[EVENT, Dict]:
     type_to_event = {
         EVENT_TYPE.PASS: PASS,
+        EVENT_TYPE.BALL_RECEIPT: BALL_RECEIPT,
         EVENT_TYPE.SHOT: SHOT,
         EVENT_TYPE.INTERCEPTION: INTERCEPTION,
         EVENT_TYPE.OWN_GOAL_FOR: OWN_GOAL_FOR,

--- a/kloppy/tests/test_state_builder.py
+++ b/kloppy/tests/test_state_builder.py
@@ -51,7 +51,7 @@ class TestStateBuilder:
             events_per_sequence[sequence_id] = len(events)
 
         assert events_per_sequence[0] == 4
-        assert events_per_sequence[51] == 6
+        assert events_per_sequence[51] == 7
 
     def test_lineup_state_builder(self, base_dir):
         dataset = self._load_dataset(base_dir, base_filename="statsbomb_15986")

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -698,6 +698,14 @@ class TestStatsBombPassEvent:
         )
         assert pass_event.next().event_name == "Ball Receipt*"
         assert pass_event.next().next().event_name == "ball_out"
+        assert (
+            pass_event.next().next().event_id
+            == "out-ac99f2ec-8138-4061-9bd3-bdc79ae7358e"
+        )
+        assert (
+            pass_event.next().next().raw_event["id"]
+            == "36c7ed4c-031e-4dd4-8557-3d9b8ee8762f"
+        )
 
 
 class TestStatsBombShotEvent:
@@ -753,11 +761,19 @@ class TestStatsBombShotEvent:
 
     def test_synthetic_out_events(self, dataset: EventDataset):
         """It should add synthetic ball out events after the goalkeeper event."""
-        pass_event = dataset.get_event_by_id(
+        shot_event = dataset.get_event_by_id(
             "221ce1cb-d70e-47aa-8d7e-c427a1c952ba"
         )
-        assert pass_event.next().event_name == "Goal Keeper"
-        assert pass_event.next().next().event_name == "ball_out"
+        assert shot_event.next().event_name == "Goal Keeper"
+        assert shot_event.next().next().event_name == "ball_out"
+        assert (
+            shot_event.next().next().event_id
+            == "out-64c5cfad-86a3-4d61-86c8-8784a4834682"
+        )
+        assert (
+            shot_event.next().next().raw_event["id"]
+            == "221ce1cb-d70e-47aa-8d7e-c427a1c952ba"
+        )
 
 
 class TestStatsBombInterceptionEvent:

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -1,58 +1,54 @@
 import os
 from collections import defaultdict
-from datetime import timedelta, datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import cast
 
 import pytest
 
+import kloppy.infra.serializers.event.statsbomb.specification as SB
+from kloppy import statsbomb
 from kloppy.domain import (
-    build_coordinate_system,
-    AttackingDirection,
-    TakeOnResult,
-    Dimension,
     BallState,
-    ImperialPitchDimensions,
-    CardQualifier,
-    DatasetFlag,
-    CarryResult,
-    InterceptionResult,
-    SubstitutionEvent,
     BodyPart,
     BodyPartQualifier,
+    CardQualifier,
+    CarryResult,
+    DatasetFlag,
     DatasetType,
+    Dimension,
     DuelQualifier,
-    DuelType,
     DuelResult,
+    DuelType,
+    EventDataset,
+    FormationType,
+    ImperialPitchDimensions,
+    InterceptionResult,
     Orientation,
     PassResult,
     Point,
     Point3D,
     Provider,
-    FormationType,
     SetPieceQualifier,
     SetPieceType,
     ShotResult,
-    EventDataset,
+    SubstitutionEvent,
+    TakeOnResult,
     Time,
+    build_coordinate_system,
 )
 from kloppy.domain.models import PositionType
-
-from kloppy.exceptions import DeserializationError
-from kloppy import statsbomb
 from kloppy.domain.models.event import (
     CardType,
+    CounterAttackQualifier,
+    EventType,
+    GoalkeeperActionType,
+    GoalkeeperQualifier,
     PassQualifier,
     PassType,
-    EventType,
-    GoalkeeperQualifier,
-    GoalkeeperActionType,
-    CounterAttackQualifier,
 )
-from kloppy.infra.serializers.event.statsbomb.helpers import (
-    parse_str_ts,
-)
-import kloppy.infra.serializers.event.statsbomb.specification as SB
+from kloppy.exceptions import DeserializationError
+from kloppy.infra.serializers.event.statsbomb.helpers import parse_str_ts
 
 ENABLE_PLOTTING = True
 API_URL = "https://raw.githubusercontent.com/statsbomb/open-data/master/data/"
@@ -695,6 +691,14 @@ class TestStatsBombPassEvent:
         ]
         assert duel.result == DuelResult.WON
 
+    def test_synthetic_out_events(self, dataset: EventDataset):
+        """It should add synthetic ball out events after the (failed) receipt."""
+        pass_event = dataset.get_event_by_id(
+            "36c7ed4c-031e-4dd4-8557-3d9b8ee8762f"
+        )
+        assert pass_event.next().event_name == "Ball Receipt*"
+        assert pass_event.next().next().event_name == "ball_out"
+
 
 class TestStatsBombShotEvent:
     """Tests related to deserialzing 16/Shot events"""
@@ -746,6 +750,14 @@ class TestStatsBombShotEvent:
             DuelType.AERIAL,
         ]
         assert duel.result == DuelResult.WON
+
+    def test_synthetic_out_events(self, dataset: EventDataset):
+        """It should add synthetic ball out events after the goalkeeper event."""
+        pass_event = dataset.get_event_by_id(
+            "221ce1cb-d70e-47aa-8d7e-c427a1c952ba"
+        )
+        assert pass_event.next().event_name == "Goal Keeper"
+        assert pass_event.next().next().event_name == "ball_out"
 
 
 class TestStatsBombInterceptionEvent:


### PR DESCRIPTION
StatsBomb adds 23/"Goal Keeper (Shot Faced)" events after off-target shots and 42/"Ball Receipt* (Incomplete)" events after passes that go out. Previously, the synthetic `BallOutEvent` generated for these events was inserted between the original shot/pass and the subsequent Goal Keeper/Ball Receipt* events. This caused the latter events to be incorrectly included in the next possession sequence. This commit resolves the issue by creating the ball out events from the Goal Keeper/Ball Receipt* events instead of from the shot/pass events.