### PR TITLE
Freeze frame position loading

### DIFF
--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -264,7 +264,10 @@ class Team:
     def get_player_by_position(self, position: PositionType, time: Time):
         for player in self.players:
             if player.positions.items:
-                player_position = player.positions.value_at(time)
+                try:
+                    player_position = player.positions.value_at(time)
+                except KeyError:  # player that is subbed in later
+                    continue
                 if player_position and player_position == position:
                     return player
 

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -180,6 +180,17 @@ class TestStatsBombMetadata:
         )
         assert home_ending_lam.player_id == "5633"  # Yannick Ferreira Carrasco
 
+    def test_freeze_frame_loads_correctly(self, dataset):
+        event_uuid = "0f525aa9-70f4-4f85-8a8d-6103722aee50"
+        event = [  # pick out the event record in question
+            event for event in dataset if event.event_id == event_uuid
+        ][0]
+
+        keeper = list(event.freeze_frame.players_coordinates.keys())[
+            0
+        ]  # keeper happens to be first
+        assert keeper.player_id == "5205"  # Rui Pedro dos Santos Patrício
+
     def test_get_player_by_position_works_with_subs(self, dataset):
 
         event_uuid = "0f525aa9-70f4-4f85-8a8d-6103722aee50"

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -180,6 +180,18 @@ class TestStatsBombMetadata:
         )
         assert home_ending_lam.player_id == "5633"  # Yannick Ferreira Carrasco
 
+    def test_get_player_by_position_works_with_subs(self, dataset):
+
+        event_uuid = "0f525aa9-70f4-4f85-8a8d-6103722aee50"
+        event = [  # pick out the event record in question
+            event for event in dataset if event.event_id == event_uuid
+        ][0]
+
+        keeper = event.team.get_player_by_position(
+            PositionType.Goalkeeper, time=event.time
+        )
+        assert keeper.player_id == "5205"  # Rui Pedro dos Santos Patrício
+
     def test_periods(self, dataset):
         """It should create the periods"""
         assert len(dataset.metadata.periods) == 2


### PR DESCRIPTION
Hi there! 

I was trying to use freeze frame data from statsbomb and I think I encountered a couple of small bugs in how player information was connected to the player tracking data. First, there seems to be an issue when getting player positions if a player hasn't been subbed in yet, which I resolved by catching the error and just continuing. Then there's a timing issue when deserializing the data, where position information doesn't seem to be added until the `EventDataset` is created. I resolved that issue by postponing setting the freeze frame data until after the `EventDataset` is initialized.

I wasn't sure exactly how the unit tests are laid out, so I added a test for each apparent bug in the `test_statsbomb` test module, let me know if there's a better place for them. Also, I have no idea if this is the right way to solve these issues (or whether it's about to be obviated by the changes in #377), so please feel free to let me know if there's another way to do it or just close the PR; I just figured I should share my workarounds for the problems I had in case they're more broadly helpful. 