### PR TITLE
[SecondSpectrum] Fix reversed pitch dimensions 

### DIFF
--- a/kloppy/infra/serializers/tracking/secondspectrum.py
+++ b/kloppy/infra/serializers/tracking/secondspectrum.py
@@ -155,8 +155,8 @@ class SecondSpectrumDeserializer(
                     first_byte + inputs.meta_data.read()
                 ).match
                 frame_rate = int(match.attrib["iFrameRateFps"])
-                pitch_size_height = float(match.attrib["fPitchYSizeMeters"])
-                pitch_size_width = float(match.attrib["fPitchXSizeMeters"])
+                pitch_size_height = float(match.attrib["fPitchXSizeMeters"])
+                pitch_size_width = float(match.attrib["fPitchYSizeMeters"])
 
                 periods = []
                 for period in match.iterchildren(tag="period"):
@@ -243,7 +243,7 @@ class SecondSpectrumDeserializer(
         # Handles the tracking frame data
         with performance_logging("Loading data", logger=logger):
             transformer = self.get_transformer(
-                pitch_length=pitch_size_width, pitch_width=pitch_size_height
+                pitch_length=pitch_size_height, pitch_width=pitch_size_width
             )
 
             def _iter():


### PR DESCRIPTION
There was a consistency problem in the use of pitch_size_height and pitch_size_width depending on the format of the metadata file for SecondSpectrum. We made a fix to make the deserializer work in all cases.