### PR TITLE
[BUG] Incorrect MinutesPlayed aggregation

### DIFF
--- a/kloppy/domain/services/aggregators/minutes_played.py
+++ b/kloppy/domain/services/aggregators/minutes_played.py
@@ -49,7 +49,7 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
                             MinutesPlayed(
                                 player=player,
                                 start_time=_start_time,
-                                end_time=_start_time,
+                                end_time=end_time,
                                 duration=end_time - _start_time,
                             )
                         )


### PR DESCRIPTION
Hi,

Just noticed we were incorrectly assigning `_start_time` to `end_time` in the dataset aggregator, this lead to end_time and end_period being 0 and 1 respectively for all starting players, also those that got subbed off.

```python
MinutesPlayed(
      player=player,
      start_time=_start_time,
      end_time=end_time, #<- this was _start_time
      duration=end_time - _start_time,
  )
```