### PR TITLE
[BUG] Replacement player position overwritten to None

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -1079,10 +1079,14 @@ class EventDataset(Dataset[Event]):
                     replacement_player_position = event.player.positions.last(
                         default=PositionType.Unknown
                     )
-                event.replacement_player.set_position(
-                    event.time,
-                    replacement_player_position,
-                )
+                if (
+                    event.replacement_player.positions.last(default=None)
+                    is None
+                ):
+                    event.replacement_player.set_position(
+                        event.time,
+                        replacement_player_position,
+                    )
                 event.player.set_position(event.time, None)
 
             elif isinstance(event, FormationChangeEvent):


### PR DESCRIPTION
Hi,

This issue is related to #411, but wanted to create a separate PR, because I don't know if this is the  correct way to solve it. 

Problem was that I got the below exception.

```python
raise ValueError("Cannot create ranges when length < 2")
```

This happened when calling the `MinutesPlayedAggregator`. 

The problem seemed to be that the below could not be constructed, because this replacement player had None for their position, and they only had 1 position. 

```
for (
        start_time,
        end_time,
        position,
    ) in player.positions.ranges():
```

This meant that the below was bypassed, but we still ended up with only 1 item.

```
if self.items[items[-1]] is not None:
        current_period = items[0].period
        while current_period.next_period:
            current_period = current_period.next_period
        items.append(current_period.end_time)
```

Now, I think this happened because the same substitution event was processed 3 time, but I'm not 100% sure. 
Because we set the `event.player.set_position(event.time, None)` after processing them to coming of the field, the second time we process this same substitution the replacement player get their position replaced by None as well.

```
def _update_formations_and_positions(self):
        """Update team formations and player positions based on Substitution and TacticalShift events."""
        max_leeway = timedelta(seconds=60)
        for event in self.events:
            
            if isinstance(event, SubstitutionEvent):
                if event.replacement_player.starting_position:
                    replacement_player_position = (
                        event.replacement_player.starting_position
                    )
                else:
                    replacement_player_position = event.player.positions.last(
                        default=PositionType.Unknown
                    )
                if event.replacement_player.positions.last(default=None) is None:
                    event.replacement_player.set_position(
                        event.time,
                        replacement_player_position,
                    )
                event.player.set_position(event.time, None)
```

Like I said, I don't know if this is the preferred way to resolve, maybe we should avoid parsing the same substitution multiple times, but this TimeContainer code is incredibly confusing, so I was just glad to find something that works for me.
