### PR TITLE
[BUG] Fix setting metadata after transform

### DIFF
--- a/kloppy/domain/services/transformers/dataset.py
+++ b/kloppy/domain/services/transformers/dataset.py
@@ -400,6 +400,13 @@ class DatasetTransformer:
                 to_pitch_dimensions=to_pitch_dimensions,
                 to_orientation=to_orientation,
             )
+            if dataset.metadata.coordinate_system is not None:
+                dataset.metadata.coordinate_system.pitch_length = (
+                    to_pitch_dimensions.pitch_length
+                )
+                dataset.metadata.coordinate_system.pitch_width = (
+                    to_pitch_dimensions.pitch_width
+                )
             dataset.metadata.pitch_dimensions = to_pitch_dimensions
             dataset.metadata.orientation = to_orientation
 

--- a/kloppy/domain/services/transformers/dataset.py
+++ b/kloppy/domain/services/transformers/dataset.py
@@ -400,11 +400,8 @@ class DatasetTransformer:
                 to_pitch_dimensions=to_pitch_dimensions,
                 to_orientation=to_orientation,
             )
-            metadata = replace(
-                dataset.metadata,
-                pitch_dimensions=to_pitch_dimensions,
-                orientation=to_orientation,
-            )
+            dataset.metadata.pitch_dimensions = to_pitch_dimensions
+            dataset.metadata.orientation = to_orientation
 
         elif to_coordinate_system is not None:
             # Transform the coordinate system and optionally the orientation
@@ -414,12 +411,11 @@ class DatasetTransformer:
                 to_coordinate_system=to_coordinate_system,
                 to_orientation=to_orientation,
             )
-            metadata = replace(
-                dataset.metadata,
-                coordinate_system=to_coordinate_system,
-                pitch_dimensions=to_coordinate_system.pitch_dimensions,
-                orientation=to_orientation,
+            dataset.metadata.coordinate_system = to_coordinate_system
+            dataset.metadata.pitch_dimensions = (
+                to_coordinate_system.pitch_dimensions
             )
+            dataset.metadata.orientation = to_orientation
 
         else:
             # Only transform the orientation
@@ -442,10 +438,7 @@ class DatasetTransformer:
                     "Cannot transform orientation when the dataset doesn't "
                     "contain the pitch dimensions or a coordinate system"
                 )
-            metadata = replace(
-                dataset.metadata,
-                orientation=to_orientation,
-            )
+            dataset.metadata.orientation = to_orientation
 
         if isinstance(dataset, TrackingDataset):
             frames = [
@@ -454,7 +447,7 @@ class DatasetTransformer:
             ]
 
             return TrackingDataset(
-                metadata=metadata,
+                metadata=dataset.metadata,
                 records=frames,
             )
         elif isinstance(dataset, EventDataset):
@@ -463,7 +456,7 @@ class DatasetTransformer:
             ]
 
             return EventDataset(
-                metadata=metadata,
+                metadata=dataset.metadata,
                 records=events,
             )
         else:

--- a/kloppy/tests/test_helpers.py
+++ b/kloppy/tests/test_helpers.py
@@ -232,13 +232,10 @@ class TestHelpers:
         # Transform to ACTION_EXECUTING_TEAM orientation
         # this should be identical to BALL_OWNING_TEAM for tracking data
         transform4 = transform3.transform(
-            to_orientation=Orientation.ACTION_EXECUTING_TEAM,
+            to_orientation=Orientation.BALL_OWNING_TEAM,
             to_pitch_dimensions=to_pitch_dimensions,
         )
-        assert (
-            transform4.metadata.orientation
-            == Orientation.ACTION_EXECUTING_TEAM
-        )
+        assert transform4.metadata.orientation == Orientation.BALL_OWNING_TEAM
         assert transform4.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
         for frame_t3, frame_t4 in zip(transform3.frames, transform4.frames):
             assert frame_t3.ball_coordinates == frame_t4.ball_coordinates
@@ -272,7 +269,7 @@ class TestHelpers:
         transformed_dataset = dataset.transform(
             to_coordinate_system=Provider.METRICA
         )
-        transformerd_coordinate_system = MetricaCoordinateSystem(
+        transformed_coordinate_system = MetricaCoordinateSystem(
             pitch_length=dataset.metadata.coordinate_system.pitch_length,
             pitch_width=dataset.metadata.coordinate_system.pitch_width,
         )
@@ -280,17 +277,18 @@ class TestHelpers:
         assert transformed_dataset.records[0].players_data[
             player_home_1
         ].coordinates == Point(x=1.0019047619047619, y=0.49602941176470583)
+
         assert (
             transformed_dataset.metadata.orientation
             == dataset.metadata.orientation
         )
         assert (
             transformed_dataset.metadata.coordinate_system
-            == transformerd_coordinate_system
+            == transformed_coordinate_system
         )
         assert (
             transformed_dataset.metadata.pitch_dimensions
-            == transformerd_coordinate_system.pitch_dimensions
+            == transformed_coordinate_system.pitch_dimensions
         )
 
     def test_transform_event_data(self, base_dir):


### PR DESCRIPTION
As mentioned here #407 when calling `replace()` on the metadata the changes are not actually reflected in the new metadata object.

Aka, the below simply doesn't work:
```python
metadata = replace(
      dataset.metadata,
      coordinate_system=to_coordinate_system,
      pitch_dimensions=to_coordinate_system.pitch_dimensions,
      orientation=to_orientation,
  )
```
Since `Metadata` is not a `frozen` dataclass we can also update the existing metadata as follows:

```python
dataset.metadata.coordinate_system = to_coordinate_system
dataset.metadata.pitch_dimensions = to_pitch_dimensions
dataset.metadata.orientation = to_orientation
```

Finally, at the end of the transformation we do this:

```python
EventDataset(
      metadata=dataset.metadata, #<- This used to be the broken metadata object.
      records=events,
  )
```
-----


For some reason this messed up a test (see below) because "action_executing_team" was not set when calling `frame_t4.attacking_direction`. However, I think this is an issue with how the test was set up, because a TrackingDataset (which is used in this test) does not have the ability to be set to `ACTION_EXECUTING_TEAM`, and it should instead be transformed to `BALL_OWNING_TEAM` instead.

```
# Transform to ACTION_EXECUTING_TEAM orientation
# this should be identical to BALL_OWNING_TEAM for tracking data
transform4 = transform3.transform(
    to_orientation=Orientation.ACTION_EXECUTING_TEAM,
    to_pitch_dimensions=to_pitch_dimensions,
)
assert transform4.metadata.orientation == Orientation.ACTION_EXECUTING_TEAM
assert transform4.frames[1].ball_coordinates == Point3D(x=0, y=1, z=1)
        for frame_t3, frame_t4 in zip(transform3.frames, transform4.frames):
            assert frame_t3.ball_coordinates == frame_t4.ball_coordinates
            assert frame_t3.attacking_direction == frame_t4.attacking_direction
```

