### PR TITLE
[BUG] - use correct attributes in AngleToGoalTransformer

### DIFF
--- a/kloppy/domain/services/transformers/attribute.py
+++ b/kloppy/domain/services/transformers/attribute.py
@@ -57,12 +57,16 @@ class AngleToGoalTransformer(EventAttributeTransformer):
         if not event.coordinates:
             return {"angle_to_goal": None}
 
-        if metadata.pitch_dimensions.width:
+        if metadata.pitch_dimensions.pitch_width:
             # Calculate in metric system
-            event_x = event.coordinates.x * metadata.pitch_dimensions.length
-            event_y = event.coordinates.y * metadata.pitch_dimensions.width
-            goal_x = metadata.pitch_dimensions.length
-            goal_y = metadata.pitch_dimensions.width / 2
+            event_x = (
+                event.coordinates.x * metadata.pitch_dimensions.pitch_length
+            )
+            event_y = (
+                event.coordinates.y * metadata.pitch_dimensions.pitch_width
+            )
+            goal_x = metadata.pitch_dimensions.pitch_length
+            goal_y = metadata.pitch_dimensions.pitch_width / 2
         else:
             event_x = event.coordinates.x
             event_y = event.coordinates.y

--- a/kloppy/tests/test_to_records.py
+++ b/kloppy/tests/test_to_records.py
@@ -8,6 +8,7 @@ from kloppy.domain import EventDataset, Point
 from kloppy.domain.services.transformers.attribute import (
     DistanceToGoalTransformer,
     DistanceToOwnGoalTransformer,
+    AngleToGoalTransformer,
 )
 
 
@@ -74,6 +75,7 @@ class TestToRecords:
             "coordinates_*",
             DistanceToGoalTransformer(),
             DistanceToOwnGoalTransformer(),
+            AngleToGoalTransformer(),
         )
         assert records[0] == {
             "timestamp": timedelta(seconds=0.098),
@@ -82,4 +84,5 @@ class TestToRecords:
             "coordinates_y": 40.5,
             "distance_to_goal": 59.50210080324896,
             "distance_to_own_goal": 60.502066080424065,
+            "angle_to_goal": 90.48146580583835,
         }


### PR DESCRIPTION
Fixing the bug mentioned in [Issue 413](https://github.com/PySport/kloppy/issues/413).