### PR TITLE
Allow `lxml>=5.0.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def setup_package():
             "console_scripts": ["kloppy-query = kloppy.cmdline:run_query"]
         },
         install_requires=[
-            "lxml>=4.4.0,<5",
+            "lxml>=4.4.0",
             "requests>=2.0.0,<3",
             "pytz>=2020.1",
             'typing_extensions;python_version<"3.11"',


### PR DESCRIPTION
Widens supported lxml version from `lxml>=4.4.0,<5` to `xml>=4.4.0`. There seem to be no breaking changes between v4 and v5, so let's keep support for both.

Closes #417