### PR TITLE
[Skillcorner BUG] Missing coaches

### DIFF
--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -383,12 +383,18 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
                 game_id = str(game_id)
 
             home_team_coach = metadata.get("home_team_coach")
-            if home_team_coach is not None:
-                home_coach = f"{home_team_coach['first_name']} {home_team_coach['last_name']}"
+            home_coach = (
+                f"{home_team_coach['first_name']} {home_team_coach['last_name']}"
+                if home_team_coach is not None
+                else None
+            )
 
             away_team_coach = metadata.get("away_team_coach")
-            if away_team_coach is not None:
-                away_coach = f"{away_team_coach['first_name']} {away_team_coach['last_name']}"
+            away_coach = (
+                f"{away_team_coach['first_name']} {away_team_coach['last_name']}"
+                if away_team_coach is not None
+                else None
+            )
 
             if game_id:
                 game_id = str(game_id)


### PR DESCRIPTION
Hi,

This PR contains a fix for:

```
UnboundLocalError: cannot access local variable 'home_coach' where it is not associated with a value
```

The `home_coach` and `away_coach` variables did not exist if `home_team_coach` (and `away_team_coach`) where `None`.