### PR TITLE
[FEAT / BUG] Disassociate sample_rate and limit (+ minor fix)

### DIFF
--- a/kloppy/infra/serializers/tracking/metrica_csv.py
+++ b/kloppy/infra/serializers/tracking/metrica_csv.py
@@ -211,7 +211,7 @@ class MetricaCSVTrackingDataDeserializer(
                     teams = [home_partial_frame.team, away_partial_frame.team]
 
                 n += 1
-                if self.limit and n >= self.limit:
+                if self.limit and n + 1 >= (self.limit / self.sample_rate):
                     break
 
         try:

--- a/kloppy/infra/serializers/tracking/pff.py
+++ b/kloppy/infra/serializers/tracking/pff.py
@@ -362,7 +362,9 @@ class PFF_TrackingDeserializer(TrackingDataDeserializer[PFF_TrackingInputs]):
             def _iter():
                 sample = 1.0 / self.sample_rate
 
-                for n, raw_frame in enumerate(raw_data):
+                n = 0
+
+                for raw_frame in raw_data:
                     frame = json.loads(raw_frame)
                     # Identify Period
                     frame_period = frame.get("period")
@@ -397,7 +399,7 @@ class PFF_TrackingDeserializer(TrackingDataDeserializer[PFF_TrackingInputs]):
                                 else away_team
                             )
 
-                    if self.limit and n + 1 >= (self.limit / self.sample_rate):
+                    if self.limit and n >= (self.limit / self.sample_rate):
                         break
 
                     if self.only_alive and self._ball_state == BallState.DEAD:
@@ -405,6 +407,8 @@ class PFF_TrackingDeserializer(TrackingDataDeserializer[PFF_TrackingInputs]):
 
                     if frame_period is not None and n % sample == 0:
                         yield frame, frame_period
+
+                    n += 1
 
         frames, et_frames = [], []
         n_frames = 0

--- a/kloppy/infra/serializers/tracking/secondspectrum.py
+++ b/kloppy/infra/serializers/tracking/secondspectrum.py
@@ -274,7 +274,7 @@ class SecondSpectrumDeserializer(
                 frame = transformer.transform_frame(frame)
                 frames.append(frame)
 
-                if self.limit and n + 1 >= self.limit:
+                if self.limit and n + 1 >= (self.limit / self.sample_rate):
                     break
 
         try:

--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -483,7 +483,9 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
                 frames.append(frame)
                 n_frames += 1
 
-                if self.limit and n_frames >= self.limit:
+                if self.limit and n_frames + 1 >= (
+                    self.limit / self.sample_rate
+                ):
                     break
 
         attacking_directions = self._get_skillcorner_attacking_directions(

--- a/kloppy/infra/serializers/tracking/sportec/deserializer.py
+++ b/kloppy/infra/serializers/tracking/sportec/deserializer.py
@@ -215,7 +215,7 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
                 frame = transformer.transform_frame(frame)
                 frames.append(frame)
 
-                if self.limit and n >= self.limit:
+                if self.limit and n + 1 >= self.limit:
                     break
 
         try:

--- a/kloppy/infra/serializers/tracking/statsperform.py
+++ b/kloppy/infra/serializers/tracking/statsperform.py
@@ -190,7 +190,7 @@ class StatsPerformDeserializer(TrackingDataDeserializer[StatsPerformInputs]):
                     continue
                 frames.append(frame)
 
-                if self.limit and n >= self.limit:
+                if self.limit and n + 1 >= (self.limit / self.sample_rate):
                     break
 
         try:

--- a/kloppy/infra/serializers/tracking/tracab/tracab_dat.py
+++ b/kloppy/infra/serializers/tracking/tracab/tracab_dat.py
@@ -303,7 +303,7 @@ class TRACABDatDeserializer(TrackingDataDeserializer[TRACABInputs]):
                 frame = transformer.transform_frame(frame)
                 frames.append(frame)
 
-                if self.limit and n >= self.limit:
+                if self.limit and n + 1 >= (self.limit / self.sample_rate):
                     break
 
         if not orientation:

--- a/kloppy/infra/serializers/tracking/tracab/tracab_json.py
+++ b/kloppy/infra/serializers/tracking/tracab/tracab_json.py
@@ -221,7 +221,7 @@ class TRACABJSONDeserializer(TrackingDataDeserializer[TRACABInputs]):
 
                 frames.append(frame)
 
-                if self.limit and n >= self.limit:
+                if self.limit and n + 1 >= (self.limit / self.sample_rate):
                     break
 
         try:

--- a/kloppy/tests/test_metrica_epts.py
+++ b/kloppy/tests/test_metrica_epts.py
@@ -98,6 +98,24 @@ class TestMetricaEPTSTracking:
     def raw_data(self, base_dir) -> str:
         return base_dir / "files/epts_metrica_tracking.txt"
 
+    def test_correct_deserialization_limit_sample(
+        self, meta_data: str, raw_data: str
+    ):
+        dataset = metrica.load_tracking_epts(
+            meta_data=meta_data,
+            raw_data=raw_data,
+            limit=50,
+            sample_rate=(1 / 2),
+        )
+        assert len(dataset.records) == 50
+
+        dataset = metrica.load_tracking_epts(
+            meta_data=meta_data,
+            raw_data=raw_data,
+            limit=100,
+        )
+        assert len(dataset.records) == 100
+
     def test_correct_deserialization(self, meta_data: str, raw_data: str):
         dataset = metrica.load_tracking_epts(
             meta_data=meta_data, raw_data=raw_data

--- a/kloppy/tests/test_pff.py
+++ b/kloppy/tests/test_pff.py
@@ -54,6 +54,33 @@ class TestPFFTracking:
         assert dataset.metadata.periods[2].id == 3
         assert dataset.metadata.periods[3].id == 4
 
+    def test_correct_deserialization_limit_sample(
+        self,
+        raw_data_home_starts_left: Path,
+        meta_data: Path,
+        rosters_meta_data: Path,
+    ):
+        dataset = pff.load_tracking(
+            meta_data=meta_data,
+            roster_meta_data=rosters_meta_data,
+            raw_data=raw_data_home_starts_left,
+            coordinates="pff",
+            only_alive=True,
+            limit=100,
+            sample_rate=(1 / 2),
+        )
+        assert len(dataset.records) == 100
+
+        dataset = pff.load_tracking(
+            meta_data=meta_data,
+            roster_meta_data=rosters_meta_data,
+            raw_data=raw_data_home_starts_left,
+            coordinates="pff",
+            only_alive=True,
+            limit=100,
+        )
+        assert len(dataset.records) == 100
+
     def test_correct_deserialization(
         self,
         raw_data_home_starts_left: Path,

--- a/kloppy/tests/test_secondspectrum.py
+++ b/kloppy/tests/test_secondspectrum.py
@@ -27,6 +27,30 @@ class TestSecondSpectrumTracking:
     def additional_meta_data(self, base_dir) -> str:
         return base_dir / "files/second_spectrum_fake_metadata.json"
 
+    def test_correct_deserialization_limit_sample(
+        self, meta_data: Path, raw_data: Path, additional_meta_data: Path
+    ):
+        dataset = secondspectrum.load(
+            meta_data=meta_data,
+            raw_data=raw_data,
+            additional_meta_data=additional_meta_data,
+            only_alive=False,
+            coordinates="secondspectrum",
+            limit=100,
+            sample_rate=(1 / 2),
+        )
+        assert len(dataset.records) == 100
+
+        dataset = secondspectrum.load(
+            meta_data=meta_data,
+            raw_data=raw_data,
+            additional_meta_data=additional_meta_data,
+            only_alive=False,
+            coordinates="secondspectrum",
+            limit=100,
+        )
+        assert len(dataset.records) == 100
+
     def test_correct_deserialization(
         self, meta_data: Path, raw_data: Path, additional_meta_data: Path
     ):

--- a/kloppy/tests/test_sportec.py
+++ b/kloppy/tests/test_sportec.py
@@ -209,6 +209,26 @@ class TestSportecTrackingData:
         )
         assert len(dataset) == 199
 
+    def test_limit_sample(self, raw_data: Path, meta_data: Path):
+        dataset = sportec.load_tracking(
+            raw_data=raw_data,
+            meta_data=meta_data,
+            coordinates="sportec",
+            only_alive=True,
+            limit=100,
+            sample_rate=(1 / 2),
+        )
+        assert len(dataset.records) == 100
+
+        dataset = sportec.load_tracking(
+            raw_data=raw_data,
+            meta_data=meta_data,
+            coordinates="sportec",
+            only_alive=True,
+            limit=100,
+        )
+        assert len(dataset.records) == 100
+
     def test_enriched_metadata(self, raw_data: Path, meta_data: Path):
         dataset = sportec.load_tracking(
             raw_data=raw_data,

--- a/kloppy/tests/test_statsperform.py
+++ b/kloppy/tests/test_statsperform.py
@@ -277,6 +277,32 @@ class TestStatsPerformTracking:
     def test_flags(self, tracking_dataset):
         assert tracking_dataset.metadata.flags == DatasetFlag.BALL_STATE
 
+    def test_coordinate_system_with_pitch_dimensions(
+        self, tracking_data: Path, tracking_metadata_xml: Path
+    ):
+        tracking_dataset = statsperform.load_tracking(
+            ma1_data=tracking_metadata_xml,
+            ma25_data=tracking_data,
+            tracking_system="sportvu",
+            coordinates="sportvu",
+            pitch_length=105,
+            pitch_width=68,
+            limit=100,
+            sample_rate=(1 / 2),
+        )
+        assert len(tracking_dataset.records) == 100
+
+        tracking_dataset = statsperform.load_tracking(
+            ma1_data=tracking_metadata_xml,
+            ma25_data=tracking_data,
+            tracking_system="sportvu",
+            coordinates="sportvu",
+            pitch_length=105,
+            pitch_width=68,
+            limit=100,
+        )
+        assert len(tracking_dataset.records) == 100
+
     def test_coordinate_system_without_pitch_dimensions(
         self, tracking_data: Path, tracking_metadata_xml: Path
     ):

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -72,6 +72,28 @@ def test_correct_auto_recognize_deserialization(
 
 
 class TestTracabJSONTracking:
+    def test_correct_deserialization_limit_sample(
+        self, json_meta_data: Path, json_raw_data: Path
+    ):
+        dataset = tracab.load(
+            meta_data=json_meta_data,
+            raw_data=json_raw_data,
+            coordinates="tracab",
+            only_alive=False,
+            limit=4,
+            sample_rate=(1 / 2),
+        )
+        assert len(dataset.records) == 4
+
+        dataset = tracab.load(
+            meta_data=json_meta_data,
+            raw_data=json_raw_data,
+            coordinates="tracab",
+            only_alive=False,
+            limit=4,
+        )
+        assert len(dataset) == 4
+
     def test_correct_deserialization(
         self, json_meta_data: Path, json_raw_data: Path
     ):


### PR DESCRIPTION
Arguably the silliest of PRs, but I noticed that some tracking deserializers would return n+1 records when setting limit as n.

Additionally, it annoyed me that the sample rate would impact the limit. This meant that a sample_rate of (1/2) would give you only 50 samples if you set the limit to 100. 

I've disassociated the sample_rate from the limit. This means if we set the limit to 100 and the sample rate to (1/2) we still return 100 records, but they are still sampled at a rate of one in two.

I've added tests to all tracking providers for which this was handled incorrectly.