### PR TITLE
[FEATURE] Align SecondSpectrum position mapping + add PositionType.Unknown to StatsPerform & Metrica

### DIFF
--- a/kloppy/infra/serializers/tracking/metrica_csv.py
+++ b/kloppy/infra/serializers/tracking/metrica_csv.py
@@ -18,6 +18,7 @@ from kloppy.domain import (
     Ground,
     Player,
     PlayerData,
+    PositionType,
 )
 from kloppy.domain.services.frame_factory import create_frame
 from kloppy.infra.serializers.tracking.deserializer import (
@@ -77,6 +78,7 @@ class MetricaCSVTrackingDataDeserializer(
                         player_id=f"{team.ground}_{jersey_number}",
                         jersey_no=int(jersey_number),
                         team=team,
+                        starting_position=PositionType.Unknown,
                     )
                     for jersey_number in player_jersey_numbers
                 ]

--- a/kloppy/infra/serializers/tracking/secondspectrum.py
+++ b/kloppy/infra/serializers/tracking/secondspectrum.py
@@ -36,8 +36,8 @@ logger = logging.getLogger(__name__)
 
 position_mapping = {
     "GK": PositionType.Goalkeeper,
-    "RB": PositionType.RightWingBack,
-    "LB": PositionType.LeftWingBack,
+    "RB": PositionType.RightBack,
+    "LB": PositionType.LeftBack,
     "DM": PositionType.DefensiveMidfield,
     "RCB": PositionType.RightCenterBack,
     "LCB": PositionType.LeftCenterBack,

--- a/kloppy/infra/serializers/tracking/secondspectrum.py
+++ b/kloppy/infra/serializers/tracking/secondspectrum.py
@@ -23,6 +23,7 @@ from kloppy.domain import (
     Provider,
     PlayerData,
     Score,
+    PositionType,
 )
 from kloppy.domain.services.frame_factory import create_frame
 
@@ -31,6 +32,31 @@ from kloppy.utils import Readable, performance_logging
 from .deserializer import TrackingDataDeserializer
 
 logger = logging.getLogger(__name__)
+
+
+position_mapping = {
+    "GK": PositionType.Goalkeeper,
+    "RB": PositionType.RightWingBack,
+    "LB": PositionType.LeftWingBack,
+    "DM": PositionType.DefensiveMidfield,
+    "RCB": PositionType.RightCenterBack,
+    "LCB": PositionType.LeftCenterBack,
+    "CF": PositionType.Striker,
+    "AM": PositionType.AttackingMidfield,
+    "RW": PositionType.RightWing,
+    "LW": PositionType.LeftWing,
+    "CMR": PositionType.RightCentralMidfield,
+    "CML": PositionType.LeftCentralMidfield,
+    "CB": PositionType.CenterBack,
+    "WBR": PositionType.RightWingBack,
+    "WBL": PositionType.LeftWingBack,
+    "CM": PositionType.CentralMidfield,
+    "SS": PositionType.CenterAttackingMidfield,
+    "AMR": PositionType.RightAttackingMidfield,
+    "AML": PositionType.LeftAttackingMidfield,
+    "RWB": PositionType.RightWingBack,
+    "LWB": PositionType.LeftWingBack,
+}
 
 
 class SecondSpectrumInputs(NamedTuple):
@@ -228,7 +254,10 @@ class SecondSpectrumDeserializer(
                                 player_id=player_data["optaId"],
                                 name=player_data["name"],
                                 starting=player_data["position"] != "SUB",
-                                starting_position=player_data["position"],
+                                starting_position=position_mapping.get(
+                                    player_data["position"],
+                                    PositionType.Unknown,
+                                ),
                                 team=team,
                                 jersey_no=int(player_data["number"]),
                                 attributes=player_attributes,

--- a/kloppy/infra/serializers/tracking/statsperform.py
+++ b/kloppy/infra/serializers/tracking/statsperform.py
@@ -19,6 +19,7 @@ from kloppy.domain import (
     attacking_direction_from_frame,
 )
 from kloppy.domain.services.frame_factory import create_frame
+from kloppy.domain import PositionType
 from kloppy.exceptions import DeserializationError
 from kloppy.utils import performance_logging
 from kloppy.infra.serializers.event.statsperform.parsers import get_parser
@@ -124,6 +125,7 @@ class StatsPerformDeserializer(TrackingDataDeserializer[StatsPerformInputs]):
                         player_id=player_id,
                         team=team,
                         jersey_no=jersey_no,
+                        starting_position=PositionType.Unknown,
                     )
                     team.players.append(player)
 


### PR DESCRIPTION
In an attempt to align all providers to use the same `PositionType` I've added SecondSpectrum position mapping. As per the SecondSpectrum docs the positions they use are _"Player position for this game as specified by Opta"_.

Since the StatsPerform / Opta position mapping is done differently (they are associated to the provided formation id in the meta data) I've simply taken all textual unique position labels from the Opta docs and converted them as below.

```python
position_mapping = {
    "GK": PositionType.Goalkeeper,
    "RB": PositionType.RightWingBack,
    "LB": PositionType.LeftWingBack,
    "DM": PositionType.DefensiveMidfield,
    "RCB": PositionType.RightCenterBack,
    "LCB": PositionType.LeftCenterBack,
    "CF": PositionType.Striker,
    "AM": PositionType.AttackingMidfield,
    "RW": PositionType.RightWing,
    "LW": PositionType.LeftWing,
    "CMR": PositionType.RightCentralMidfield,
    "CML": PositionType.LeftCentralMidfield,
    "CB": PositionType.CenterBack,
    "WBR": PositionType.RightWingBack,
    "WBL": PositionType.LeftWingBack,
    "CM": PositionType.CentralMidfield,
    "SS": PositionType.CenterAttackingMidfield,
    "AMR": PositionType.RightAttackingMidfield,
    "AML": PositionType.LeftAttackingMidfield,
    "RWB": PositionType.RightWingBack,
    "LWB": PositionType.LeftWingBack,
}
```

Additionally I've added `PositionType.Unknown` as the `starting_position` parameter to StatsPerform and Metrica parsers, simply to align and have all `starting_position`s be of the same type. I think all other providers have been done already.