### PR TITLE
[StatsPerform] Use metadata parser to read in match metadata

### DIFF
--- a/kloppy/infra/serializers/event/statsperform/deserializer.py
+++ b/kloppy/infra/serializers/event/statsperform/deserializer.py
@@ -731,9 +731,9 @@ class StatsPerformDeserializer(EventDataDeserializer[StatsPerformInputs]):
             periods = metadata_parser.extract_periods()
             score = metadata_parser.extract_score()
             teams = metadata_parser.extract_lineups()
-            date = events_parser.extract_date()
-            game_week = events_parser.extract_game_week()
-            game_id = events_parser.extract_game_id()
+            date = metadata_parser.extract_date()
+            game_week = metadata_parser.extract_game_week()
+            game_id = metadata_parser.extract_game_id()
             raw_events = [
                 event
                 for event in events_parser.extract_events()


### PR DESCRIPTION
I've seen StatsPerform F73 files with a different date format for the game_date than the F24 files have. In order to fix this, I propose to look at the F7 metadata file to retrieve the date, game week and game id. 

I think it makes more sense to read in the metadata from the F7 file than from the F24/F73 file, since the F7 file is all about match metdata. This also makes it more aligned with how we read in the match metadata in the StatsPerform tracking deserializer (serializers/tracking/statsperform.py).

Example of F73 file date format I've encountered:
`<Game game_date="20240818T1200+0100">`

Example of F24 file date format I "normally" observe:
` <Game game_date="2024-08-18T12:00:00">`