### PR TITLE
docs(events): Add entry for ShotResult.OWN_GOAL

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -57,6 +57,7 @@ class ShotResult(ResultType):
         POST (ShotResult): Shot hit the post
         BLOCKED (ShotResult): Shot was blocked by another player
         SAVED (ShotResult): Shot was saved by the keeper
+        OWN_GOAL (ShotResult): Shot resulted in an own goal
     """
 
     GOAL = "GOAL"


### PR DESCRIPTION
There is a missing doc entry for `OWN_GOAL` in `ShotResult`. It also hasn't been added in #346.