### PR TITLE
[Bugfix] Support substitution events with no replacement player

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -1076,18 +1076,22 @@ class EventDataset(Dataset[Event]):
 
         for event in self.events:
             if isinstance(event, SubstitutionEvent):
-                if event.replacement_player.starting_position:
-                    replacement_player_position = (
-                        event.replacement_player.starting_position
+                # substitution does not per se have a sub off (replacement player)
+                if event.replacement_player:
+                    if event.replacement_player.starting_position:
+                        replacement_player_position = (
+                            event.replacement_player.starting_position
+                        )
+                    else:
+                        replacement_player_position = (
+                            event.player.positions.last(
+                                default=PositionType.Unknown
+                            )
+                        )
+                    event.replacement_player.set_position(
+                        event.time,
+                        replacement_player_position,
                     )
-                else:
-                    replacement_player_position = event.player.positions.last(
-                        default=PositionType.Unknown
-                    )
-                event.replacement_player.set_position(
-                    event.time,
-                    replacement_player_position,
-                )
                 event.player.set_position(event.time, None)
 
             elif isinstance(event, FormationChangeEvent):


### PR DESCRIPTION
Currently, in our StatsPerform deserializer we potentially set the replacement_player as None in case the player off event is not directly followed by a player on event, which happens in approx 1% of the matches, see: https://github.com/PySport/kloppy/blob/master/kloppy/infra/serializers/event/statsperform/deserializer.py#L396-L406. 

In order to support substitution events where no new sub on player is coming on the pitch for the sub off player, we add a check to see whether the replacement player actually exists prior to updating its position.

For context, a related discussion on substitution events: https://github.com/PySport/kloppy/issues/362.

