### PR TITLE
[Wyscout v3] Create periods prior to creating events

### DIFF
--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -708,8 +708,9 @@ def _parse_period_id(raw_period: str) -> int:
     return period_id
 
 
-def create_periods(raw_events):
+def create_periods(raw_events, period_minutes_offset_mapping):
     periods = []
+
     for idx, raw_event in enumerate(raw_events["events"]):
         next_period_id = None
         if (idx + 1) < len(raw_events["events"]):
@@ -732,9 +733,15 @@ def create_periods(raw_events):
             )
 
         if next_period_id != period_id:
+            period_start_timestamp = periods[period_id - 1].start_timestamp
+            period_offset = (
+                period_start_timestamp
+                - period_minutes_offset_mapping[period_id]
+            )
             periods[-1] = replace(
                 periods[-1],
-                end_timestamp=timedelta(
+                end_timestamp=period_offset
+                + timedelta(
                     seconds=float(
                         raw_event["second"] + raw_event["minute"] * 60
                     )
@@ -805,7 +812,7 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
                         "shortName"
                     )
 
-            periods = create_periods(raw_events)
+            periods = create_periods(raw_events, start_ts)
 
             events = []
 

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -708,6 +708,41 @@ def _parse_period_id(raw_period: str) -> int:
     return period_id
 
 
+def create_periods(raw_events):
+    periods = []
+    for idx, raw_event in enumerate(raw_events["events"]):
+        next_period_id = None
+        if (idx + 1) < len(raw_events["events"]):
+            next_event = raw_events["events"][idx + 1]
+            next_period_id = _parse_period_id(next_event["matchPeriod"])
+
+        period_id = _parse_period_id(raw_event["matchPeriod"])
+
+        if len(periods) == 0 or periods[-1].id != period_id:
+            periods.append(
+                Period(
+                    id=period_id,
+                    start_timestamp=(
+                        timedelta(seconds=0)
+                        if len(periods) == 0
+                        else periods[-1].end_timestamp
+                    ),
+                    end_timestamp=None,
+                )
+            )
+
+        if next_period_id != period_id:
+            periods[-1] = replace(
+                periods[-1],
+                end_timestamp=timedelta(
+                    seconds=float(
+                        raw_event["second"] + raw_event["minute"] * 60
+                    )
+                ),
+            )
+    return periods
+
+
 class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
     @property
     def provider(self) -> Provider:
@@ -722,7 +757,6 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
                 if "id" not in event:
                     event["id"] = event["type"]["primary"]
 
-        periods = []
         # start timestamps are fixed
         start_ts = {
             1: timedelta(minutes=0),
@@ -771,18 +805,21 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
                         "shortName"
                     )
 
+            periods = create_periods(raw_events)
+
             events = []
 
             next_pass_is_kickoff = False
             for idx, raw_event in enumerate(raw_events["events"]):
                 next_event = None
-                next_period_id = None
+                ball_owning_team = None
                 if (idx + 1) < len(raw_events["events"]):
                     next_event = raw_events["events"][idx + 1]
-                    next_period_id = _parse_period_id(
-                        next_event["matchPeriod"]
-                    )
 
+                if raw_event["possession"]:
+                    ball_owning_team = teams[
+                        str(raw_event["possession"]["team"]["id"])
+                    ]
                 if (
                     idx == 0
                     or raw_event["matchPeriod"]
@@ -795,35 +832,6 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
                 team = teams[team_id]
                 player_id = str(raw_event["player"]["id"])
                 period_id = _parse_period_id(raw_event["matchPeriod"])
-
-                if len(periods) == 0 or periods[-1].id != period_id:
-                    periods.append(
-                        Period(
-                            id=period_id,
-                            start_timestamp=(
-                                timedelta(seconds=0)
-                                if len(periods) == 0
-                                else periods[-1].end_timestamp
-                            ),
-                            end_timestamp=None,
-                        )
-                    )
-
-                if next_period_id != period_id:
-                    periods[-1] = replace(
-                        periods[-1],
-                        end_timestamp=timedelta(
-                            seconds=float(
-                                raw_event["second"] + raw_event["minute"] * 60
-                            )
-                        ),
-                    )
-
-                ball_owning_team = None
-                if raw_event["possession"]:
-                    ball_owning_team = teams[
-                        str(raw_event["possession"]["team"]["id"])
-                    ]
 
                 if player_id == INVALID_PLAYER:
                     player = None

--- a/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
+++ b/kloppy/infra/serializers/event/wyscout/deserializer_v3.py
@@ -861,7 +861,7 @@ class WyscoutDeserializerV3(EventDataDeserializer[WyscoutInputs]):
                     "player": player,
                     "ball_owning_team": ball_owning_team,
                     "ball_state": None,
-                    "period": periods[-1],
+                    "period": periods[period_id - 1],
                     "timestamp": _create_timestamp_timedelta(
                         raw_event, start_ts, period_id
                     ),

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -242,8 +242,10 @@ class TestWyscoutV3:
     def test_timestamps(self, dataset: EventDataset):
         kickoff_p1 = dataset.get_event_by_id(1927028854)
         assert kickoff_p1.timestamp == timedelta(minutes=0, seconds=3)
+        assert kickoff_p1.time.period.id == 1
         kickoff_p2 = dataset.get_event_by_id(1927029460)
         assert kickoff_p2.timestamp == timedelta(minutes=0, seconds=0)
+        assert kickoff_p2.time.period.id == 2
 
     def test_coordinates(self, dataset: EventDataset):
         assert dataset.records[2].coordinates == Point(32.0, 56.0)

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -191,7 +191,7 @@ class TestWyscoutV3:
         )
         assert dataset.metadata.periods[1].end_timestamp == timedelta(
             minutes=45, seconds=5
-        ) + timedelta(minutes=46, seconds=53)
+        ) + timedelta(minutes=46, seconds=58)
 
         assert (
             dataset.metadata.teams[0].starting_formation
@@ -208,7 +208,7 @@ class TestWyscoutV3:
 
         second_period_end_time = Time(
             period=dataset.metadata.periods[1],
-            timestamp=timedelta(seconds=2813),
+            timestamp=timedelta(seconds=2818),
         )
         assert (
             dataset.metadata.teams[1]

--- a/kloppy/tests/test_wyscout.py
+++ b/kloppy/tests/test_wyscout.py
@@ -206,6 +206,17 @@ class TestWyscoutV3:
             == FormationType.FOUR_THREE_ONE_TWO
         )
 
+        second_period_end_time = Time(
+            period=dataset.metadata.periods[1],
+            timestamp=timedelta(seconds=2813),
+        )
+        assert (
+            dataset.metadata.teams[1]
+            .formations.items.keys()[0]
+            .period.end_time
+            == second_period_end_time
+        )
+
         cr7 = dataset.metadata.teams[0].get_player_by_id("3322")
 
         assert cr7.full_name == "Cristiano Ronaldo dos Santos Aveiro"


### PR DESCRIPTION
I now create periods prior to creating the events to make sure end times are properly set when passing period as argument to event builders.

Otherwise, the period passed to the events does not have an end time. This can cause issues when trying to e.g. calculate the duration of a period of a given event.

