### PR TITLE
[BUG] Fixed aoihttp import 

### DIFF
--- a/kloppy/infra/io/adapters/http.py
+++ b/kloppy/infra/io/adapters/http.py
@@ -1,6 +1,5 @@
 from typing import BinaryIO, List
 
-import aiohttp
 import fsspec
 
 from kloppy.config import get_config
@@ -37,6 +36,14 @@ class HTTPAdapter(FSSpecAdapter):
     def _get_filesystem(
         self, url: str, no_cache: bool = False
     ) -> fsspec.AbstractFileSystem:
+        try:
+            import aiohttp
+        except ImportError:
+            raise AdapterError(
+                "Seems like you don't have `aiohttp` installed, which is required to authenticate. "
+                "Please install it using: pip install aiohttp"
+            )
+
         check_requests_patch()
 
         basic_authentication = get_config("adapters.http.basic_authentication")


### PR DESCRIPTION
The introduction of `fsspec` and `aiohttp` inside [kloppy/infra/io/adapters/http.py](https://github.com/PySport/kloppy/blob/master/kloppy/infra/io/adapters/http.py) seemed to have a top level import, namely:

```python
import aiohttp
```

But aiohttp is not a kloppy dependency, and it's only used in the `HTTPAdapter`.

I've moved it to the top of `_get_filesystem`, this should resolve the `ModuleNotFoundError: No module named 'aiohttp'` you'd get when importing `hawkeye`.

```python
def _get_filesystem(
        self, url: str, no_cache: bool = False
    ) -> fsspec.AbstractFileSystem:
        try:
            import aiohttp
        except ImportError:
            raise AdapterError(
                "Seems like you don't have `aiohttp` installed, which is required to authenticate. "
                "Please install it using: pip install aiohttp"
            )
```