### PR TITLE
[SPORTEC] Fixed Event Coordinate vertical_orientation

### DIFF
--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -112,7 +112,6 @@ class Provider(Enum):
     STATSPERFORM = "statsperform"
     HAWKEYE = "hawkeye"
     SPORTVU = "sportvu"
-    RESPOVISION = "respovision"
     OTHER = "other"
 
     def __str__(self):
@@ -867,43 +866,6 @@ class SkillCornerCoordinateSystem(ProviderCoordinateSystem):
             )
 
 
-class RespoVisionCoordinateSystem(ProviderCoordinateSystem):
-    @property
-    def provider(self) -> Provider:
-        return Provider.RESPOVISION
-
-    @property
-    def origin(self) -> Origin:
-        return Origin.CENTER
-
-    @property
-    def vertical_orientation(self) -> VerticalOrientation:
-        return VerticalOrientation.BOTTOM_TO_TOP
-
-    @property
-    def pitch_dimensions(self) -> PitchDimensions:
-        if self._pitch_length is not None and self._pitch_width is not None:
-            return MetricPitchDimensions(
-                x_dim=Dimension(
-                    -1 * self._pitch_length / 2, self._pitch_length / 2
-                ),
-                y_dim=Dimension(
-                    -1 * self._pitch_width / 2, self._pitch_width / 2
-                ),
-                pitch_length=self._pitch_length,
-                pitch_width=self._pitch_width,
-                standardized=False,
-            )
-        else:
-            return MetricPitchDimensions(
-                x_dim=Dimension(None, None),
-                y_dim=Dimension(None, None),
-                pitch_length=None,
-                pitch_width=None,
-                standardized=False,
-            )
-
-
 class DatafactoryCoordinateSystem(ProviderCoordinateSystem):
     @property
     def provider(self) -> Provider:
@@ -1049,7 +1011,6 @@ def build_coordinate_system(
         Provider.DATAFACTORY: DatafactoryCoordinateSystem,
         Provider.SECONDSPECTRUM: SecondSpectrumCoordinateSystem,
         Provider.HAWKEYE: HawkEyeCoordinateSystem,
-        Provider.RESPOVISION: RespoVisionCoordinateSystem,
         Provider.SPORTVU: SportVUCoordinateSystem,
     }
 

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -112,6 +112,7 @@ class Provider(Enum):
     STATSPERFORM = "statsperform"
     HAWKEYE = "hawkeye"
     SPORTVU = "sportvu"
+    RESPOVISION = "respovision"
     OTHER = "other"
 
     def __str__(self):
@@ -698,7 +699,7 @@ class SportecEventDataCoordinateSystem(ProviderCoordinateSystem):
 
     @property
     def vertical_orientation(self) -> VerticalOrientation:
-        return VerticalOrientation.TOP_TO_BOTTOM
+        return VerticalOrientation.BOTTOM_TO_TOP
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:
@@ -833,6 +834,43 @@ class SkillCornerCoordinateSystem(ProviderCoordinateSystem):
     @property
     def provider(self) -> Provider:
         return Provider.SKILLCORNER
+
+    @property
+    def origin(self) -> Origin:
+        return Origin.CENTER
+
+    @property
+    def vertical_orientation(self) -> VerticalOrientation:
+        return VerticalOrientation.BOTTOM_TO_TOP
+
+    @property
+    def pitch_dimensions(self) -> PitchDimensions:
+        if self._pitch_length is not None and self._pitch_width is not None:
+            return MetricPitchDimensions(
+                x_dim=Dimension(
+                    -1 * self._pitch_length / 2, self._pitch_length / 2
+                ),
+                y_dim=Dimension(
+                    -1 * self._pitch_width / 2, self._pitch_width / 2
+                ),
+                pitch_length=self._pitch_length,
+                pitch_width=self._pitch_width,
+                standardized=False,
+            )
+        else:
+            return MetricPitchDimensions(
+                x_dim=Dimension(None, None),
+                y_dim=Dimension(None, None),
+                pitch_length=None,
+                pitch_width=None,
+                standardized=False,
+            )
+
+
+class RespoVisionCoordinateSystem(ProviderCoordinateSystem):
+    @property
+    def provider(self) -> Provider:
+        return Provider.RESPOVISION
 
     @property
     def origin(self) -> Origin:
@@ -1011,6 +1049,7 @@ def build_coordinate_system(
         Provider.DATAFACTORY: DatafactoryCoordinateSystem,
         Provider.SECONDSPECTRUM: SecondSpectrumCoordinateSystem,
         Provider.HAWKEYE: HawkEyeCoordinateSystem,
+        Provider.RESPOVISION: RespoVisionCoordinateSystem,
         Provider.SPORTVU: SportVUCoordinateSystem,
     }
 


### PR DESCRIPTION
Hi all, 

While writing the new docs @razor3598 noticed that in `SportecEventDataCoordinateSystem` the `vertical_orientation` was set to `VerticalOrientation.TOP_TO_BOTTOM`

```
@property
    def vertical_orientation(self) -> VerticalOrientation:
        return VerticalOrientation.TOP_TO_BOTTOM
```

We didn't know the correct answer. However, while I was working on the docs too when syncing events to tracking data I got this.

The ❌ here marks the event, and the jersey number indicates the event player in the tracking data.

### Upside Down
![upside-down-3](https://github.com/user-attachments/assets/c0679229-5efa-4ab5-82c4-bf99e0e5bf13)
![upside-down-2](https://github.com/user-attachments/assets/16565734-e5bc-415c-82ce-bda180e8288e)
![upside-down](https://github.com/user-attachments/assets/2d5808eb-8bdf-4b27-80dd-bbf08dd8fde2)

This has to mean that the Events are oriented in the wrong vertical orientation.

### Correct

![correct](https://github.com/user-attachments/assets/987a525d-75b5-4a6a-8694-abf32c08d1a5)

FWIW, the tracking data is oriented correctly, which I checked on multiple frames while referencing player positioning. 

