### PR TITLE
[SPORTEC] Fixed Event Coordinate vertical_orientation (new)

### DIFF
--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -698,7 +698,7 @@ class SportecEventDataCoordinateSystem(ProviderCoordinateSystem):
 
     @property
     def vertical_orientation(self) -> VerticalOrientation:
-        return VerticalOrientation.TOP_TO_BOTTOM
+        return VerticalOrientation.BOTTOM_TO_TOP
 
     @property
     def pitch_dimensions(self) -> PitchDimensions:


### PR DESCRIPTION
Hi all, 

While writing the new docs @razor3598 noticed that in `SportecEventDataCoordinateSystem` the `vertical_orientation` was set to `VerticalOrientation.TOP_TO_BOTTOM`

```
@property
    def vertical_orientation(self) -> VerticalOrientation:
        return VerticalOrientation.TOP_TO_BOTTOM
```

We didn't know the correct answer. However, while I was working on the docs too when syncing events to tracking data I got this.

The ❌ here marks the event, and the jersey number indicates the event player in the tracking data.

### Upside Down
![upside-down-3](https://github.com/user-attachments/assets/c0679229-5efa-4ab5-82c4-bf99e0e5bf13)
![upside-down-2](https://github.com/user-attachments/assets/16565734-e5bc-415c-82ce-bda180e8288e)
![upside-down](https://github.com/user-attachments/assets/2d5808eb-8bdf-4b27-80dd-bbf08dd8fde2)

This has to mean that the Events are oriented in the wrong vertical orientation.

### Correct

![correct](https://github.com/user-attachments/assets/987a525d-75b5-4a6a-8694-abf32c08d1a5)

FWIW, the tracking data is oriented correctly, which I checked on multiple frames while referencing player positioning. 

