### PR TITLE
[SPORTEC] Added AssistantVAR and pre-kick-off events filter

### DIFF
--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -122,9 +122,11 @@ class OfficialType(Enum):
     """Enumeration for types of officials (referees)."""
 
     VideoAssistantReferee = "Video Assistant Referee"
+    AssistantVideoAssistantReferee = "Assistant Video Assistant Referee"
     MainReferee = "Main Referee"
     AssistantReferee = "Assistant Referee"
     FourthOfficial = "Fourth Official"
+    Unknown = "Unknown"
 
     def __str__(self):
         return self.value

--- a/kloppy/infra/serializers/event/sportec/deserializer.py
+++ b/kloppy/infra/serializers/event/sportec/deserializer.py
@@ -493,12 +493,6 @@ class SportecEventDataDeserializer(
                 event_chain = _event_chain_from_xml_elm(event_elm)
                 timestamp = _parse_datetime(event_chain["Event"]["EventTime"])
 
-                # Skip any events that happened before the first kick off
-                # if period_id == 0 and not (SPORTEC_EVENT_NAME_KICKOFF in event_chain
-                #     and "GameSection"
-                #     in event_chain[SPORTEC_EVENT_NAME_KICKOFF]):
-                #     continue
-
                 if (
                     SPORTEC_EVENT_NAME_KICKOFF in event_chain
                     and "GameSection"

--- a/kloppy/infra/serializers/event/sportec/deserializer.py
+++ b/kloppy/infra/serializers/event/sportec/deserializer.py
@@ -59,6 +59,7 @@ referee_types_mapping: Dict[str, OfficialType] = {
     "referee": OfficialType.MainReferee,
     "firstAssistant": OfficialType.AssistantReferee,
     "videoReferee": OfficialType.VideoAssistantReferee,
+    "videoRefereeAssistant": OfficialType.AssistantVideoAssistantReferee,
     "secondAssistant": OfficialType.AssistantReferee,
     "fourthOfficial": OfficialType.FourthOfficial,
 }
@@ -241,7 +242,9 @@ def sportec_metadata_from_xml_elm(match_root) -> SportecMetadata:
                     name=ref_attrib["Shortname"],
                     first_name=ref_attrib["FirstName"],
                     last_name=ref_attrib["LastName"],
-                    role=referee_types_mapping[ref_attrib["Role"]],
+                    role=referee_types_mapping.get(
+                        ref_attrib["Role"], OfficialType.Unknown
+                    ),
                 )
             )
     else:
@@ -490,6 +493,12 @@ class SportecEventDataDeserializer(
                 event_chain = _event_chain_from_xml_elm(event_elm)
                 timestamp = _parse_datetime(event_chain["Event"]["EventTime"])
 
+                # Skip any events that happened before the first kick off
+                # if period_id == 0 and not (SPORTEC_EVENT_NAME_KICKOFF in event_chain
+                #     and "GameSection"
+                #     in event_chain[SPORTEC_EVENT_NAME_KICKOFF]):
+                #     continue
+
                 if (
                     SPORTEC_EVENT_NAME_KICKOFF in event_chain
                     and "GameSection"
@@ -514,6 +523,9 @@ class SportecEventDataDeserializer(
                     periods.append(period)
                 elif SPORTEC_EVENT_NAME_FINAL_WHISTLE in event_chain:
                     period.end_timestamp = timestamp
+                    continue
+                elif period_id == 0:
+                    # Skip any events that happened before the first kick off
                     continue
 
                 team = None


### PR DESCRIPTION
A small fix for the Sportec event data deserializer:

I added both `OfficialType.AssistantVideoAssistantReferee` and `OfficialType.Unknown` as a fallback, because they broke some stuff.

I know AssistantVideoAssistantReferee isn't great, but it's to be consistent. 

```python
class OfficialType(Enum):
    """Enumeration for types of officials (referees)."""

    VideoAssistantReferee = "Video Assistant Referee"
    AssistantVideoAssistantReferee = "Assistant Video Assistant Referee"
    MainReferee = "Main Referee"
    AssistantReferee = "Assistant Referee"
    FourthOfficial = "Fourth Official"
    Unknown = "Unknown"

    def __str__(self):
        return self.value
```

I also added the below lines to the deserializer because for some weird reason I was getting some VAR notification events prior to kick off. We should skip any events that happen prior to kick off, otherwise we get a `UnboundLocalError: local variable 'period' referenced before assignment` error.

```python
elif period_id == 0:
      # Skip any events that happened before the first kick off
      continue
```

What this does is simply skip any events we have while the period_id has not been updated to period_id = 1. This only happens for events priod to the `KickOff` `FirstHalf` because the set of Sportec events has already been ordered by timestamp.