### PR TITLE
[Opta/Stats Perform] Add FormationType.UNKNOWN and PostionType.Unknown handling

### DIFF
--- a/kloppy/infra/serializers/event/statsperform/deserializer.py
+++ b/kloppy/infra/serializers/event/statsperform/deserializer.py
@@ -401,7 +401,9 @@ def _parse_substitution(next_event: OptaEvent, team: Team) -> Dict:
 
     raw_position_line = next_event.qualifiers.get(44)
     if raw_position_line:
-        position = position_line_mapping[raw_position_line]
+        position = position_line_mapping.get(
+            raw_position_line, PositionType.Unknown
+        )
 
     return dict(replacement_player=replacement_player, position=position)
 

--- a/kloppy/infra/serializers/event/statsperform/parsers/f7_xml.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/f7_xml.py
@@ -148,11 +148,13 @@ class F7XMLParser(OptaXMLParser):
         )
         players = []
 
-        if hasattr(team_elm, "Formation"):
-            formation_string = team_elm.attrib["Formation"]
-            formation_name_mapping.get(formation_string, FormationType.UNKNOWN)
-        else:
-            formation = FormationType.UNKNOWN
+        formation = (
+            formation_name_mapping.get(
+                team_elm.attrib["Formation"], FormationType.UNKNOWN
+            )
+            if "Formation" in team_elm.attrib
+            else FormationType.UNKNOWN
+        )
 
         for player_elm in team_elm.find("PlayerLineUp").iterchildren(
             "MatchPlayer"

--- a/kloppy/infra/serializers/event/statsperform/parsers/f7_xml.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/f7_xml.py
@@ -147,9 +147,13 @@ class F7XMLParser(OptaXMLParser):
             ),
         )
         players = []
-        formation = formation_name_mapping.get(
-            team_elm.attrib["Formation"], FormationType.UNKNOWN
-        )
+
+        if hasattr(team_elm, "Formation"):
+            formation_string = team_elm.attrib["Formation"]
+            formation_name_mapping.get(formation_string, FormationType.UNKNOWN)
+        else:
+            formation = FormationType.UNKNOWN
+
         for player_elm in team_elm.find("PlayerLineUp").iterchildren(
             "MatchPlayer"
         ):

--- a/kloppy/infra/serializers/event/statsperform/parsers/ma1_json.py
+++ b/kloppy/infra/serializers/event/statsperform/parsers/ma1_json.py
@@ -3,13 +3,14 @@
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
-from kloppy.domain import Ground, Period, Player, Score, Team
+from kloppy.domain import Ground, Period, Player, Score, Team, PositionType
 from kloppy.exceptions import DeserializationError
 
 from .base import OptaJSONParser
 from ..formation_mapping import (
     formation_name_mapping,
     formation_position_mapping,
+    FormationType,
 )
 
 
@@ -134,7 +135,9 @@ class MA1JSONParser(OptaJSONParser):
         for line_up in line_ups:
             team_id = line_up["contestantId"]
             raw_formation = line_up["formationUsed"]
-            formation = formation_name_mapping[raw_formation]
+            formation = formation_name_mapping.get(
+                raw_formation, FormationType.UNKNOWN
+            )
             team_formations[team_id] = formation
 
         for team in teams:
@@ -156,15 +159,21 @@ class MA1JSONParser(OptaJSONParser):
         for line_up in line_ups:
             team_id = line_up["contestantId"]
             raw_formation = line_up["formationUsed"]
-            formation = formation_name_mapping[raw_formation]
+            formation = formation_name_mapping.get(
+                raw_formation, FormationType.UNKNOWN
+            )
 
             players = line_up["player"]
             for player in players:
                 player_id = player["playerId"]
                 if "formationPlace" in player:
-                    player_position = formation_position_mapping[formation][
-                        int(player["formationPlace"])
-                    ]
+                    player_position = (
+                        formation_position_mapping[formation][
+                            int(player["formationPlace"])
+                        ]
+                        if formation != FormationType.UNKNOWN
+                        else PositionType.Unknown
+                    )
                     starting = True
                 else:
                     player_position = None

--- a/kloppy/tests/test_statsperform.py
+++ b/kloppy/tests/test_statsperform.py
@@ -106,6 +106,7 @@ class TestStatsPerformMetadata:
     def test_teams(self, tracking_dataset: TrackingDataset):
         home_team = tracking_dataset.metadata.teams[0]
         home_player = home_team.players[2]
+
         assert home_player.player_id == "5g5wwp5luxo1rz1kp6chvz0x6"
         assert tracking_dataset.records[0].players_coordinates[
             home_player


### PR DESCRIPTION
To do a better job of using `FormationType.UNKNOWN` and `PostionType.Unknown` when we encounter stuff that isn't recognized as a standardized formation I've updated the StatsPerform / Opta meta data parsers for f7_xml, ma1_xml and ma1_json. 

This way we can continue to use kloppy without anything breaking, for example when the delivery format contains an unknown formation type. (In my case the formation was 4240?). 

@koenvo this should also resolve your Issue https://github.com/PySport/kloppy/issues/438 
