### PR TITLE
[Sportec] update DFL Open Data urls + citation

### DIFF
--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -1,7 +1,5 @@
 from typing import List, Optional
 
-from requests.exceptions import HTTPError
-
 from kloppy.config import get_config
 from kloppy.domain import EventDataset, EventFactory, TrackingDataset
 from kloppy.infra.serializers.event.sportec import (
@@ -160,21 +158,13 @@ def load_open_event_data(
                spatiotemporal and event data in elite soccer." Sci Data 12, 195 (2025).
                https://doi.org/10.1038/s41597-025-04505-y
     """
-    try:
-        return load_event(
-            event_data=get_IDSSE_url(match_id, "event"),
-            meta_data=get_IDSSE_url(match_id, "meta"),
-            event_types=event_types,
-            coordinates=coordinates,
-            event_factory=event_factory,
-        )
-    except HTTPError as e:
-        raise HTTPError(
-            "Unable to retrieve data. The server hosting the data might be offline. "
-            "Please check the following URLs: ",
-            get_IDSSE_url(match_id, "event"),
-            get_IDSSE_url(match_id, "meta"),
-        ) from e
+    return load_event(
+        event_data=get_IDSSE_url(match_id, "event"),
+        meta_data=get_IDSSE_url(match_id, "meta"),
+        event_types=event_types,
+        coordinates=coordinates,
+        event_factory=event_factory,
+    )
 
 
 def load_open_tracking_data(
@@ -225,19 +215,11 @@ def load_open_tracking_data(
                dataset of synchronized spatiotemporal and event data in elite soccer."
                In Submission.
     """
-    try:
-        return load_tracking(
-            raw_data=get_IDSSE_url(match_id, "tracking"),
-            meta_data=get_IDSSE_url(match_id, "meta"),
-            sample_rate=sample_rate,
-            limit=limit,
-            coordinates=coordinates,
-            only_alive=only_alive,
-        )
-    except HTTPError as e:
-        raise HTTPError(
-            "Unable to retrieve data. The server hosting the data might be offline. "
-            "Please check the following URLs: ",
-            get_IDSSE_url(match_id, "tracking"),
-            get_IDSSE_url(match_id, "meta"),
-        ) from e
+    return load_tracking(
+        raw_data=get_IDSSE_url(match_id, "tracking"),
+        meta_data=get_IDSSE_url(match_id, "meta"),
+        sample_rate=sample_rate,
+        limit=limit,
+        coordinates=coordinates,
+        only_alive=only_alive,
+    )

--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -39,9 +39,10 @@ def load_event(
         coordinate_system=coordinates,
         event_factory=event_factory or get_config("event_factory"),
     )
-    with open_as_file(event_data) as event_data_fp, open_as_file(
-        meta_data
-    ) as meta_data_fp:
+    with (
+        open_as_file(event_data) as event_data_fp,
+        open_as_file(meta_data) as meta_data_fp,
+    ):
         return serializer.deserialize(
             SportecEventDataInputs(
                 event_data=event_data_fp, meta_data=meta_data_fp
@@ -90,16 +91,18 @@ def get_IDSSE_url(match_id: str, data_type: str) -> str:
     """Returns the URL for the meta, event or tracking data for a match in the IDDSE dataset."""
     # match_id -> file_id
     DATA_MAP = {
-        "J03WPY": {"meta": 48392497, "event": 48392542, "tracking": 48392572},
-        "J03WN1": {"meta": 48392491, "event": 48392527, "tracking": 48392512},
-        "J03WMX": {"meta": 48392485, "event": 48392524, "tracking": 48392539},
-        "J03WOH": {"meta": 48392515, "event": 48392500, "tracking": 48392578},
-        "J03WQQ": {"meta": 48392488, "event": 48392521, "tracking": 48392545},
-        "J03WOY": {"meta": 48392503, "event": 48392518, "tracking": 48392551},
-        "J03WR9": {"meta": 48392494, "event": 48392530, "tracking": 48392563},
+        "J03WPY": {"meta": 51643487, "event": 51643505, "tracking": 51643526},
+        "J03WN1": {"meta": 51643472, "event": 51643496, "tracking": 51643517},
+        "J03WMX": {"meta": 51643475, "event": 51643493, "tracking": 51643514},
+        "J03WOH": {"meta": 51643478, "event": 51643499, "tracking": 51643520},
+        "J03WQQ": {"meta": 51643484, "event": 51643508, "tracking": 51643529},
+        "J03WOY": {"meta": 51643481, "event": 51643502, "tracking": 51643523},
+        "J03WR9": {"meta": 51643490, "event": 51643511, "tracking": 51643532},
     }
     # URL constant
-    DATA_URL = "https://figshare.com/ndownloader/files/{file_id}?private_link=1f806cb3e755c6b54e05"
+    DATA_URL = (
+        "https://springernature.figshare.com/ndownloader/files/{file_id}"
+    )
 
     if data_type not in ["meta", "event", "tracking"]:
         raise ValueError(
@@ -154,9 +157,9 @@ def load_open_event_data(
         }
 
     References:
-        .. [1] Bassek, M., Weber, H., Rein, R., & Memmert, D. (2024). "An integrated
-               dataset of synchronized spatiotemporal and event data in elite soccer."
-               In Submission.
+        .. [1] Bassek, M., Rein, R., Weber, H. et al. "An integrated dataset of
+               spatiotemporal and event data in elite soccer." Sci Data 12, 195 (2025).
+               https://doi.org/10.1038/s41597-025-04505-y
     """
     try:
         return load_event(
@@ -168,8 +171,10 @@ def load_open_event_data(
         )
     except HTTPError as e:
         raise HTTPError(
-            "Unable to retrieve data. The dataset archive location may have changed. "
-            "See https://github.com/PySport/kloppy/issues/369 for details."
+            "Unable to retrieve data. The server hosting the data might be offline. "
+            "Please check the following URLs: ",
+            get_IDSSE_url(match_id, "event"),
+            get_IDSSE_url(match_id, "meta"),
         ) from e
 
 
@@ -232,6 +237,8 @@ def load_open_tracking_data(
         )
     except HTTPError as e:
         raise HTTPError(
-            "Unable to retrieve data. The dataset archive location may have changed. "
-            "See https://github.com/PySport/kloppy/issues/369 for details."
+            "Unable to retrieve data. The server hosting the data might be offline. "
+            "Please check the following URLs: ",
+            get_IDSSE_url(match_id, "tracking"),
+            get_IDSSE_url(match_id, "meta"),
         ) from e

--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -39,10 +39,9 @@ def load_event(
         coordinate_system=coordinates,
         event_factory=event_factory or get_config("event_factory"),
     )
-    with (
-        open_as_file(event_data) as event_data_fp,
-        open_as_file(meta_data) as meta_data_fp,
-    ):
+    with open_as_file(event_data) as event_data_fp, open_as_file(
+        meta_data
+    ) as meta_data_fp:
         return serializer.deserialize(
             SportecEventDataInputs(
                 event_data=event_data_fp, meta_data=meta_data_fp

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ def setup_package():
         },
         install_requires=[
             "lxml>=4.4.0",
-            "requests>=2.0.0,<3",
             "pytz>=2020.1",
             'typing_extensions;python_version<"3.11"',
             "sortedcontainers>=2",


### PR DESCRIPTION
As the [paper](https://www.nature.com/articles/s41597-025-04505-y) and [dataset](https://springernature.figshare.com/articles/dataset/An_integrated_dataset_of_spatiotemporal_and_event_data_in_elite_soccer/28196177) are now published, this PR updates the links and the paper reference.

Closes #369
See also #365

---

*Note*: Figshare is currently experiencing issues and downloads are extremely slow. Downloading the tracking data of a single game may take ~40 minutes.
