### PR TITLE
[Sportec] Reduce memory usage of tracking deserializer

### DIFF
--- a/kloppy/infra/serializers/tracking/sportec/deserializer.py
+++ b/kloppy/infra/serializers/tracking/sportec/deserializer.py
@@ -2,7 +2,7 @@ import logging
 import warnings
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import IO, Dict, NamedTuple, Optional, Union
+from typing import IO, Dict, NamedTuple, Optional, Set, Union
 
 from lxml import etree, objectify
 
@@ -29,6 +29,9 @@ from ..deserializer import TrackingDataDeserializer
 
 logger = logging.getLogger(__name__)
 
+BALL_STATUS = "BallStatus"
+BALL_POSSESSION = "BallPossession"
+
 GAME_SECTION_TO_PERIOD_ID = {
     "firstHalf": 1,
     "secondHalf": 2,
@@ -40,45 +43,60 @@ GAME_SECTION_TO_PERIOD_ID = {
 def _unstack_framesets(
     raw_data: IO[bytes],
     limit: Optional[int] = None,
-    only_alive: Optional[bool] = True,
+    only_alive: bool = True,
+    objects_to_skip: Optional[Set] = None,
 ) -> Dict[int, Dict[int, Dict]]:
-    """
-    Read all data and unstack framesets.
+    """Unstack framesets.
 
-    If a limit is given, will only parse the first `limit` frames
-    for each object.
+    Sportec groups frames per period and object in a frameset. This function
+    unstacks the framesets and returns a dictionary with the following format:
 
-    Output format:
-    {
-        10_000: {
-            'ball': {
-                'N': "10000",
-                'X': 20.92,
-                'Y': 2.84,
-                'Z': 0.08,
-                'S': 4.91,
-                'BallPossession': "2",
-                'BallStatus': "1"
-                [...]
+        {
+            10_000: {
+                'ball': {
+                    'N': "10000",
+                    'X': 20.92,
+                    'Y': 2.84,
+                    'Z': 0.08,
+                    'S': 4.91,
+                    'BallPossession': "2",
+                    'BallStatus': "1"
+                    [...]
+                },
+                'DFL-OBJ-002G3I': {
+                    'N': "10000",
+                    'X': "0.35",
+                    'Y': "-25.26",
+                    'S': "0.00",
+                    [...]
+                },
+                [....]
             },
-            'DFL-OBJ-002G3I': {
-                'N': "10000",
-                'X': "0.35",
-                'Y': "-25.26",
-                'S': "0.00",
-                [...]
-            },
-            [....]
-        },
-        10_001: {
-          ...
+            10_001: {
+              ...
+            }
         }
-    }
-    """
-    if not limit:
-        limit = float("inf")
 
-    raw_frames = defaultdict(lambda: defaultdict(dict))
+    The keys are the frame IDs, and the values are dictionaries with the object
+    IDs as keys and their attributes as values.
+
+    Args:
+        raw_data: The raw data stream to be parsed.
+        limit: If a limit is provided, the function will stop processing frames
+            for an object once the limit is reached.
+        only_alive: If True, only frames with a ball status of 1 will be
+            processed.
+        objects_to_skip: A set of object IDs to skip during processing.
+
+    Returns:
+        A dictionary with the unstacked framesets.
+
+    Notes:
+        This function assumes that the framesets are ordered by period and
+        that the frames in each frameset are ordered.
+    """
+    objects_to_skip = objects_to_skip or set()
+    frames = defaultdict(lambda: defaultdict(dict))
     frames_per_obj = defaultdict(int)
     current_period = None
     current_obj = None
@@ -92,12 +110,18 @@ def _unstack_framesets(
             if event == "start" and elem.tag == "FrameSet":
                 game_section = elem.get("GameSection")
                 if game_section in GAME_SECTION_TO_PERIOD_ID:
-                    # Do we still need to process this game section?
+                    # we can stop parsing if ...
                     if (
+                        # it is not a frameset of the first period
                         current_period is not None
+                        # we've finished parsing the current period
                         and current_period
                         != GAME_SECTION_TO_PERIOD_ID[game_section]
-                        and all(n > limit for n in frames_per_obj.values())
+                        # all objects have reached the limit
+                        and (
+                            limit
+                            and all(n > limit for n in frames_per_obj.values())
+                        )
                     ):
                         break
 
@@ -107,19 +131,30 @@ def _unstack_framesets(
                         if elem.get("TeamId") == "BALL"
                         else elem.get("PersonId")
                     )
+
+                    if current_obj in objects_to_skip:
+                        current_obj = (
+                            None  # Mark as invalid to skip Frame processing
+                        )
+
             elif event == "start" and elem.tag == "Frame":
+                # we can skip this frame if ...
                 if (
-                    current_period
-                    and current_obj
-                    and (int(elem.get("BallStatus", 0)) == 1 or not only_alive)
-                    and frames_per_obj.get(current_obj, 0) < limit
+                    # it does not track a known object in a known period
+                    (current_period and current_obj)
+                    # we are not tracking frames in which the ball is not in play
+                    and (not only_alive or int(elem.get(BALL_STATUS, 0)) == 1)
+                    # we have reached the limit for this object
+                    and (
+                        not limit or frames_per_obj.get(current_obj, 0) < limit
+                    )
                 ):
-                    frames_per_obj[current_obj] += 1
                     frame_id = int(elem.get("N"))
-                    raw_frames[current_period][frame_id][current_obj] = {
+                    frames[current_period][frame_id][current_obj] = {
                         k: v for k, v in elem.items()
                     }
-                elem.clear()
+                    frames_per_obj[current_obj] += 1
+
             elif event == "end" and elem.tag == "FrameSet":
                 elem.clear()
         finally:
@@ -127,7 +162,7 @@ def _unstack_framesets(
             while elem.getprevious() is not None:
                 del elem.getparent()[0]
 
-    return dict(raw_frames)
+    return dict(frames)
 
 
 class SportecTrackingDataInputs(NamedTuple):
@@ -145,7 +180,7 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
         limit: Optional[int] = None,
         sample_rate: Optional[float] = None,
         coordinate_system: Optional[Union[str, Provider]] = None,
-        only_alive: Optional[bool] = True,
+        only_alive: bool = True,
     ):
         super().__init__(limit, sample_rate, coordinate_system)
         self.only_alive = only_alive
@@ -156,27 +191,13 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
         with performance_logging("parse metadata", logger=logger):
             match_root = objectify.fromstring(inputs.meta_data.read())
             sportec_metadata = sportec_metadata_from_xml_elm(match_root)
-            teams = home_team, away_team = sportec_metadata.teams
             date = datetime.fromisoformat(
                 match_root.MatchInformation.General.attrib["KickoffTime"]
             )
             game_week = match_root.MatchInformation.General.attrib["MatchDay"]
             game_id = match_root.MatchInformation.General.attrib["MatchId"]
-
             periods = sportec_metadata.periods
-            transformer = self.get_transformer(
-                pitch_length=sportec_metadata.x_max,
-                pitch_width=sportec_metadata.y_max,
-            )
-
-        # Stream and process tracking data
-        with performance_logging("parse tracking data", logger=logger):
-            limit = self.limit
-            if self.sample_rate:
-                limit = int(limit / self.sample_rate) if limit else None
-            period_frames = _unstack_framesets(
-                inputs.raw_data, limit, self.only_alive
-            )
+            teams = home_team, away_team = sportec_metadata.teams
             player_map = {
                 player.player_id: player
                 for team in teams
@@ -187,16 +208,34 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
                 for official in (sportec_metadata.officials or [])
             }
 
+            transformer = self.get_transformer(
+                pitch_length=sportec_metadata.x_max,
+                pitch_width=sportec_metadata.y_max,
+            )
+
+        # Stream and process tracking data
+        with performance_logging("parse tracking data", logger=logger):
+            period_frames = _unstack_framesets(
+                inputs.raw_data,
+                limit=int(self.limit / self.sample_rate)
+                if self.sample_rate and self.limit
+                else self.limit,
+                only_alive=self.only_alive,
+                objects_to_skip=official_ids,
+            )
+
             frames = []
             sample = 1.0 / self.sample_rate if self.sample_rate else 1
             frame_count = 0
 
             for period in periods:
-                period_id = period.id
-                raw_period_frames = period_frames.get(period_id, {})
+                raw_period_frames = period_frames.get(period.id, {})
 
                 sorted_frame_ids = sorted(raw_period_frames.keys())
-                for i, frame_id in enumerate(sorted_frame_ids):
+                for (
+                    i,
+                    frame_id,
+                ) in enumerate(sorted_frame_ids):
                     if self.limit and frame_count >= self.limit:
                         break
 
@@ -204,8 +243,11 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
                     if "ball" not in frame_data:
                         continue
 
-                    ball_data = frame_data["ball"]
-                    if self.only_alive and ball_data.get("BallStatus") != "1":
+                    ball_data = frame_data.get("ball", {})
+                    if (
+                        self.only_alive
+                        and int(ball_data.get(BALL_STATUS, 0)) != 1
+                    ):
                         continue
 
                     if i % sample != 0:
@@ -223,24 +265,24 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
                                 / sportec_metadata.fps
                             ),
                             ball_owning_team=home_team
-                            if ball_data.get("BallPossession") == "1"
+                            if int(ball_data.get(BALL_POSSESSION, 0)) == 1
                             else away_team,
                             ball_state=BallState.ALIVE
-                            if ball_data.get("BallStatus") == "1"
+                            if int(ball_data.get(BALL_STATUS, 0)) == 1
                             else BallState.DEAD,
                             period=period,
                             players_data={
-                                player_map[player_id]: PlayerData(
+                                player_map[object_id]: PlayerData(
                                     coordinates=Point(
                                         x=float(data.get("X", 0)),
                                         y=float(data.get("Y", 0)),
                                     ),
                                     speed=float(data.get("S", 0)),
                                 )
-                                for player_id, data in frame_data.items()
-                                if player_id != "ball"
-                                and player_id not in official_ids
-                                and player_id in player_map
+                                for object_id, data in frame_data.items()
+                                if object_id != "ball"
+                                and object_id not in official_ids
+                                and object_id in player_map
                             },
                             ball_coordinates=Point3D(
                                 x=float(ball_data.get("X", 0)),
@@ -270,7 +312,7 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
             )
         except StopIteration:
             orientation = Orientation.NOT_SET
-            warnings.warn("Could not determine dataset orientation")
+            logger.warning("Could not determine dataset orientation")
 
         metadata = Metadata(
             teams=teams,

--- a/kloppy/infra/serializers/tracking/sportec/deserializer.py
+++ b/kloppy/infra/serializers/tracking/sportec/deserializer.py
@@ -1,47 +1,52 @@
 import logging
 import warnings
 from collections import defaultdict
-from typing import NamedTuple, Optional, Union, IO
 from datetime import datetime, timedelta
+from typing import IO, Dict, NamedTuple, Optional, Union
 
-from lxml import objectify
+from lxml import etree, objectify
 
 from kloppy.domain import (
-    TrackingDataset,
-    DatasetFlag,
     AttackingDirection,
+    BallState,
+    DatasetFlag,
+    Metadata,
+    Orientation,
+    PlayerData,
     Point,
     Point3D,
-    BallState,
-    Period,
-    Orientation,
-    attacking_direction_from_frame,
-    Metadata,
     Provider,
-    PlayerData,
+    TrackingDataset,
+    attacking_direction_from_frame,
 )
 from kloppy.domain.services.frame_factory import create_frame
-
-from kloppy.utils import performance_logging
-
-from ..deserializer import TrackingDataDeserializer
 from kloppy.infra.serializers.event.sportec.deserializer import (
     sportec_metadata_from_xml_elm,
 )
+from kloppy.utils import performance_logging
+
+from ..deserializer import TrackingDataDeserializer
 
 logger = logging.getLogger(__name__)
 
-PERIOD_ID_TO_GAME_SECTION = {
-    1: "firstHalf",
-    2: "secondHalf",
-    3: "firstHalfExtra",
-    4: "secondHalfExtra",
+GAME_SECTION_TO_PERIOD_ID = {
+    "firstHalf": 1,
+    "secondHalf": 2,
+    "firstHalfExtra": 3,
+    "secondHalfExtra": 4,
 }
 
 
-def _read_section_data(data_root, period: Period) -> dict:
+def _unstack_framesets(
+    raw_data: IO[bytes],
+    limit: Optional[int] = None,
+    only_alive: Optional[bool] = True,
+) -> Dict[int, Dict[int, Dict]]:
     """
-    Read all data for a single period from data_root.
+    Read all data and unstack framesets.
+
+    If a limit is given, will only parse the first `limit` frames
+    for each object.
 
     Output format:
     {
@@ -70,25 +75,59 @@ def _read_section_data(data_root, period: Period) -> dict:
         }
     }
     """
+    if not limit:
+        limit = float("inf")
 
-    game_section = PERIOD_ID_TO_GAME_SECTION[period.id]
-    frame_sets = data_root.findall(
-        f"Positions/FrameSet[@GameSection='{game_section}']"
+    raw_frames = defaultdict(lambda: defaultdict(dict))
+    frames_per_obj = defaultdict(int)
+    current_period = None
+    current_obj = None
+
+    context = etree.iterparse(
+        raw_data, events=("start", "end"), huge_tree=True
     )
 
-    raw_frames = defaultdict(dict)
-    for frame_set in frame_sets:
-        key = (
-            "ball"
-            if frame_set.attrib["TeamId"] == "BALL"
-            else frame_set.attrib["PersonId"]
-        )
-        for frame in frame_set.iterchildren("Frame"):
-            attr = frame.attrib
-            frame_id = int(attr["N"])
-            raw_frames[frame_id][key] = attr
+    for event, elem in context:
+        try:
+            if event == "start" and elem.tag == "FrameSet":
+                game_section = elem.get("GameSection")
+                if game_section in GAME_SECTION_TO_PERIOD_ID:
+                    # Do we still need to process this game section?
+                    if (
+                        current_period is not None
+                        and current_period
+                        != GAME_SECTION_TO_PERIOD_ID[game_section]
+                        and all(n > limit for n in frames_per_obj.values())
+                    ):
+                        break
 
-    return raw_frames
+                    current_period = GAME_SECTION_TO_PERIOD_ID[game_section]
+                    current_obj = (
+                        "ball"
+                        if elem.get("TeamId") == "BALL"
+                        else elem.get("PersonId")
+                    )
+            elif event == "start" and elem.tag == "Frame":
+                if (
+                    current_period
+                    and current_obj
+                    and (int(elem.get("BallStatus", 0)) == 1 or not only_alive)
+                    and frames_per_obj.get(current_obj, 0) < limit
+                ):
+                    frames_per_obj[current_obj] += 1
+                    frame_id = int(elem.get("N"))
+                    raw_frames[current_period][frame_id][current_obj] = {
+                        k: v for k, v in elem.items()
+                    }
+                elem.clear()
+            elif event == "end" and elem.tag == "FrameSet":
+                elem.clear()
+        finally:
+            elem.clear()
+            while elem.getprevious() is not None:
+                del elem.getparent()[0]
+
+    return dict(raw_frames)
 
 
 class SportecTrackingDataInputs(NamedTuple):
@@ -114,110 +153,111 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
     def deserialize(
         self, inputs: SportecTrackingDataInputs
     ) -> TrackingDataset:
-        with performance_logging("load data", logger=logger):
-            match_root = objectify.fromstring(inputs.meta_data.read())
-            data_root = objectify.fromstring(inputs.raw_data.read())
-
         with performance_logging("parse metadata", logger=logger):
+            match_root = objectify.fromstring(inputs.meta_data.read())
             sportec_metadata = sportec_metadata_from_xml_elm(match_root)
             teams = home_team, away_team = sportec_metadata.teams
-
-            periods = sportec_metadata.periods
-            transformer = self.get_transformer(
-                pitch_length=sportec_metadata.x_max,
-                pitch_width=sportec_metadata.y_max,
-            )
-            home_coach = sportec_metadata.home_coach
-            away_coach = sportec_metadata.away_coach
-
-            official_ids = []
-            if sportec_metadata.officials:
-                official_ids = [
-                    x.official_id for x in sportec_metadata.officials
-                ]
-
-        with performance_logging("parse raw data", logger=logger):
             date = datetime.fromisoformat(
                 match_root.MatchInformation.General.attrib["KickoffTime"]
             )
             game_week = match_root.MatchInformation.General.attrib["MatchDay"]
             game_id = match_root.MatchInformation.General.attrib["MatchId"]
 
-            def _iter():
-                player_map = {}
-                for player in home_team.players:
-                    player_map[player.player_id] = player
-                for player in away_team.players:
-                    player_map[player.player_id] = player
+            periods = sportec_metadata.periods
+            transformer = self.get_transformer(
+                pitch_length=sportec_metadata.x_max,
+                pitch_width=sportec_metadata.y_max,
+            )
 
-                sample = 1.0 / self.sample_rate
-
-                for period in periods:
-                    raw_frames = _read_section_data(data_root, period)
-
-                    # Since python 3.6 dict keep insertion order. Don't need to sort
-                    # on frame ID as it's already sorted.
-                    # Ball FrameSet is always first and contains ALL frame ids. This
-                    # makes sure even with substitutes the data is on order.
-                    for i, (frame_id, frame_data) in enumerate(
-                        sorted(raw_frames.items())
-                    ):
-                        if "ball" not in frame_data:
-                            # Frames without ball data are corrupt.
-                            continue
-
-                        ball_data = frame_data["ball"]
-                        if self.only_alive and ball_data["BallStatus"] != "1":
-                            continue
-
-                        if i % sample == 0:
-                            yield create_frame(
-                                frame_id=frame_id,
-                                timestamp=timedelta(
-                                    seconds=(
-                                        frame_id
-                                        # Do subtraction with integers to prevent floating errors
-                                        - period.start_timestamp.seconds
-                                        * sportec_metadata.fps
-                                    )
-                                    / sportec_metadata.fps
-                                ),
-                                ball_owning_team=home_team
-                                if ball_data["BallPossession"] == "1"
-                                else away_team,
-                                ball_state=BallState.ALIVE
-                                if ball_data["BallStatus"] == "1"
-                                else BallState.DEAD,
-                                period=period,
-                                players_data={
-                                    player_map[player_id]: PlayerData(
-                                        coordinates=Point(
-                                            x=float(raw_player_data["X"]),
-                                            y=float(raw_player_data["Y"]),
-                                        ),
-                                        speed=float(raw_player_data["S"]),
-                                    )
-                                    for player_id, raw_player_data in frame_data.items()
-                                    if player_id != "ball"
-                                    and player_id not in official_ids
-                                },
-                                other_data={},
-                                ball_coordinates=Point3D(
-                                    x=float(ball_data["X"]),
-                                    y=float(ball_data["Y"]),
-                                    z=float(ball_data["Z"]),
-                                ),
-                                ball_speed=float(ball_data["S"]),
-                            )
+        # Stream and process tracking data
+        with performance_logging("parse tracking data", logger=logger):
+            limit = self.limit
+            if self.sample_rate:
+                limit = int(limit / self.sample_rate) if limit else None
+            period_frames = _unstack_framesets(
+                inputs.raw_data, limit, self.only_alive
+            )
+            player_map = {
+                player.player_id: player
+                for team in teams
+                for player in team.players
+            }
+            official_ids = {
+                official.official_id
+                for official in (sportec_metadata.officials or [])
+            }
 
             frames = []
-            for n, frame in enumerate(_iter()):
-                frame = transformer.transform_frame(frame)
-                frames.append(frame)
+            sample = 1.0 / self.sample_rate if self.sample_rate else 1
+            frame_count = 0
 
-                if self.limit and n + 1 >= self.limit:
-                    break
+            for period in periods:
+                period_id = period.id
+                raw_period_frames = period_frames.get(period_id, {})
 
+                sorted_frame_ids = sorted(raw_period_frames.keys())
+                for i, frame_id in enumerate(sorted_frame_ids):
+                    if self.limit and frame_count >= self.limit:
+                        break
+
+                    frame_data = raw_period_frames[frame_id]
+                    if "ball" not in frame_data:
+                        continue
+
+                    ball_data = frame_data["ball"]
+                    if self.only_alive and ball_data.get("BallStatus") != "1":
+                        continue
+
+                    if i % sample != 0:
+                        continue
+
+                    try:
+                        frame = create_frame(
+                            frame_id=frame_id,
+                            timestamp=timedelta(
+                                seconds=(
+                                    frame_id
+                                    - period.start_timestamp.seconds
+                                    * sportec_metadata.fps
+                                )
+                                / sportec_metadata.fps
+                            ),
+                            ball_owning_team=home_team
+                            if ball_data.get("BallPossession") == "1"
+                            else away_team,
+                            ball_state=BallState.ALIVE
+                            if ball_data.get("BallStatus") == "1"
+                            else BallState.DEAD,
+                            period=period,
+                            players_data={
+                                player_map[player_id]: PlayerData(
+                                    coordinates=Point(
+                                        x=float(data.get("X", 0)),
+                                        y=float(data.get("Y", 0)),
+                                    ),
+                                    speed=float(data.get("S", 0)),
+                                )
+                                for player_id, data in frame_data.items()
+                                if player_id != "ball"
+                                and player_id not in official_ids
+                                and player_id in player_map
+                            },
+                            ball_coordinates=Point3D(
+                                x=float(ball_data.get("X", 0)),
+                                y=float(ball_data.get("Y", 0)),
+                                z=float(ball_data.get("Z", 0)),
+                            ),
+                            ball_speed=float(ball_data.get("S", 0)),
+                            other_data={},
+                        )
+                        frames.append(transformer.transform_frame(frame))
+                        frame_count += 1
+                    except KeyError as e:
+                        logger.warning(
+                            f"Skipping frame {frame_id} due to missing data: {e}"
+                        )
+
+        # Determine orientation
         try:
             first_frame = next(
                 frame for frame in frames if frame.period.id == 1
@@ -229,10 +269,8 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
                 else Orientation.AWAY_HOME
             )
         except StopIteration:
-            warnings.warn(
-                "Could not determine orientation of dataset, defaulting to NOT_SET"
-            )
             orientation = Orientation.NOT_SET
+            warnings.warn("Could not determine dataset orientation")
 
         metadata = Metadata(
             teams=teams,
@@ -247,8 +285,8 @@ class SportecTrackingDataDeserializer(TrackingDataDeserializer):
             date=date,
             game_week=game_week,
             game_id=game_id,
-            home_coach=home_coach,
-            away_coach=away_coach,
+            home_coach=sportec_metadata.home_coach,
+            away_coach=sportec_metadata.away_coach,
             officials=sportec_metadata.officials,
         )
 


### PR DESCRIPTION
This pull request refactors and optimizes the Sportec tracking data deserialization proces. The deserializer previously parsed the entire content of the tracking data feed into an object tree, which requires several times more memory than the original file size. The new implementation uses lxml's `iterparse` method, effectively reducing the memory requirements for parsing a single tracking data feed from ~7GB to 0.5GB.

It also leverages the `limit` and `only_alive` parameters during the parsing of the XML to further optimize the deserializer's efficiency.