### PR TITLE
[SPORTEC] Fix missing `players_data` 

### DIFF
--- a/kloppy/tests/test_sportec.py
+++ b/kloppy/tests/test_sportec.py
@@ -208,7 +208,7 @@ class TestSportecTrackingData:
             only_alive=True,
         )
         assert len(dataset) == 199
-        assert len(dataset.records[2].players_data.keys() == 1)
+        assert len(dataset.records[2].players_data.keys()) == 1
 
     def test_limit_sample(self, raw_data: Path, meta_data: Path):
         dataset = sportec.load_tracking(

--- a/kloppy/tests/test_sportec.py
+++ b/kloppy/tests/test_sportec.py
@@ -208,6 +208,7 @@ class TestSportecTrackingData:
             only_alive=True,
         )
         assert len(dataset) == 199
+        assert len(dataset.records[2].players_data.keys() == 1)
 
     def test_limit_sample(self, raw_data: Path, meta_data: Path):
         dataset = sportec.load_tracking(


### PR DESCRIPTION
As discussed on Slack PR https://github.com/PySport/kloppy/pull/463 introduced a bug into the parser because players don't have a BALL_STATUS attribute.

Because we cannot assume Ball is the first object we see for a given frame we first create a dictionary with ball status per frame id. It's a bit of a silly solution, not sure if there is a better fix.

After we have this we reset the raw_data and do the full iteration again with the correct ball status.

I've added a test to make sure the players_data is not empty (this fails for the old implementation). 