### PR TITLE
[DOMAIN] Add PositionType.root

### DIFF
--- a/kloppy/domain/models/position.py
+++ b/kloppy/domain/models/position.py
@@ -78,6 +78,19 @@ class PositionType(Enum):
             return PositionType[self._parent]
         return None
 
+    @property
+    def root(self):
+        if self._parent is None:
+            return self
+
+        current = (
+            self.parent
+        )  # Start with the actual parent object, not the string
+        while current.parent is not None:
+            current = current.parent
+
+        return current
+
     def is_subtype_of(self, other):
         current = self
         while current is not None:

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -184,6 +184,15 @@ class TestStatsBombMetadata:
         )
         assert away_starting_gk.player_id == "5205"  # Rui Patricio
 
+        assert PositionType.Goalkeeper.root == PositionType.Goalkeeper
+        assert (
+            PositionType.CenterDefensiveMidfield.root
+            == PositionType.Midfielder
+        )
+        assert PositionType.AttackingMidfield.root == PositionType.Midfielder
+        assert PositionType.CenterBack.root == PositionType.Defender
+        assert PositionType.Striker.root == PositionType.Attacker
+
     def test_periods(self, dataset):
         """It should create the periods"""
         assert len(dataset.metadata.periods) == 2


### PR DESCRIPTION
We were lacking an ability to do something like:

```python
home_team, away_team = tracking.metadata.teams

for p in home_team.players + away_team.players:
    print(p.starting_position.root)
```

This would give the ability to quickly know if a PositionType is Goalkeeper, Defender, Midfielder or Attacker without having to resort to calling parent twice if a position has two parents and calling parent once of a position only has one parent. 