### PR TITLE
[SIGNALITY] Signality period times as `deltatime`

### DIFF
--- a/kloppy/domain/models/time.py
+++ b/kloppy/domain/models/time.py
@@ -24,22 +24,19 @@ class Period:
     Attributes:
         id: `1` for first half, `2` for second half, `3` for first half of
             overtime, `4` for second half of overtime, `5` for penalty shootout
-        start_timestamp: The UTC datetime of the kick-off or, if the
+        start_timestamp: The timedelta datetime of the kick-off or, if the
             absolute datetime is not available, the offset between the start
             of the data feed and the period's kick-off
-        start_time: Same as `start_timestamp`, but as a [`Time`][kloppy.domain.Time] object.
-        end_timestamp: The UTC datetime of the final whistle or, if the
+        end_timestamp: The timedelta of the final whistle or, if the
             absolute datetime is not available, the offset between the start
             of the data feed and the period's final whistle
-        end_time: Same as `end_timestamp`, but as a [`Time`][kloppy.domain.Time] object.
-        duration: The length of the period.
         prev_period: Period before this period.
         next_period: Period after this period.
     """
 
     id: int
-    start_timestamp: Union[datetime, timedelta]
-    end_timestamp: Optional[Union[datetime, timedelta]]
+    start_timestamp: timedelta
+    end_timestamp: Optional[timedelta]
 
     prev_period: Optional["Period"] = field(init=False)
     next_period: Optional["Period"] = field(init=False)

--- a/kloppy/infra/serializers/tracking/signality.py
+++ b/kloppy/infra/serializers/tracking/signality.py
@@ -150,7 +150,7 @@ class SignalityDeserializer(TrackingDataDeserializer[SignalityInputs]):
         return frame_rate
 
     @classmethod
-    def __get_periods(cls, raw_data_feeds) -> List[Period]:
+    def __get_periods(cls, raw_data_feeds, frame_rate) -> List[Period]:
         """gets the Periods contained in the tracking data"""
         periods = []
         for period_id, p_tracking in enumerate(raw_data_feeds, 1):
@@ -174,8 +174,12 @@ class SignalityDeserializer(TrackingDataDeserializer[SignalityInputs]):
             periods.append(
                 Period(
                     id=period_id,
-                    start_timestamp=start_time,
-                    end_timestamp=end_time,
+                    start_timestamp=timedelta(
+                        seconds=first_frame["match_time"] / 1000
+                    ),
+                    end_timestamp=timedelta(
+                        seconds=last_frame["match_time"] / 1000
+                    ),
                 )
             )
 
@@ -230,7 +234,7 @@ class SignalityDeserializer(TrackingDataDeserializer[SignalityInputs]):
         with performance_logging("Loading metadata", logger=logger):
             frame_rate = self.__get_frame_rate(p1_raw_data)
             teams = self.__create_teams(metadata)
-            periods = self.__get_periods(raw_data_feeds)
+            periods = self.__get_periods(raw_data_feeds, frame_rate)
             pitch_size_length = venue_information["pitch_size"][0]
             pitch_size_width = venue_information["pitch_size"][1]
 

--- a/kloppy/tests/test_signality.py
+++ b/kloppy/tests/test_signality.py
@@ -52,18 +52,20 @@ class TestSignalityTracking:
         assert len(dataset.metadata.periods) == 2
         assert dataset.metadata.orientation == Orientation.HOME_AWAY
         assert dataset.metadata.periods[0].id == 1
-        assert dataset.metadata.periods[0].start_timestamp == datetime(
-            2024, 10, 6, 12, 0, 1, 408000, timezone.utc
+        assert dataset.metadata.periods[0].start_timestamp == timedelta(
+            milliseconds=12
         )
-        assert dataset.metadata.periods[0].end_timestamp == datetime(
-            2024, 10, 6, 12, 48, 43, 858000, timezone.utc
+        assert dataset.metadata.periods[0].end_timestamp == timedelta(
+            seconds=2922,
+            milliseconds=450,
         )
         assert dataset.metadata.periods[1].id == 2
-        assert dataset.metadata.periods[1].start_timestamp == datetime(
-            2024, 10, 6, 13, 4, 45, 775000, timezone.utc
+        assert dataset.metadata.periods[1].start_timestamp == timedelta(
+            milliseconds=12
         )
-        assert dataset.metadata.periods[1].end_timestamp == datetime(
-            2024, 10, 6, 13, 54, 11, 730000, timezone.utc
+        assert dataset.metadata.periods[1].end_timestamp == timedelta(
+            seconds=2965,
+            milliseconds=955,
         )
 
         start_frame = dataset.records[0]


### PR DESCRIPTION
Just noticed in the recent Signality addition the Period times are in UTC instead of timedelta. 

To standardize this should be changed. I have also updated `Period` to such that `start_timestamp` and `end_timestamp` no longer have two different time options (removed `datetime`). 

I'm working on a different PR that re-introduces date times as `start_timestamp_utc` or something, because after an update all this information was lost. (It was still mentioned in the docstrings). 

Have these actual timestamps for periods should make it trivial to recompute the actual timestamps for each frame or event by simply adding timedelta to utc time, but currently we don't have this ability. 