### PR TITLE
Extend MinutesPlayedAggregator with minutes played per possession state

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -978,13 +978,13 @@ class PassEvent(
         event_type (EventType): `EventType.PASS`
         event_name (str): `"pass"`
         result (PassResult): The pass's outcome.
-        receive_timestamp (Time): The time the pass was received.
+        receive_timestamp (timedelta): The time the pass was received.
         receiver_coordinates (Point): The coordinates where the pass was received.
         receiver_player (Player): The intended receiver of the pass.
         qualifiers: A list of qualifiers providing additional information about the pass.
     """
 
-    receive_timestamp: Optional[Time] = None
+    receive_timestamp: Optional[timedelta] = None
     receiver_player: Optional[Player] = None
     receiver_coordinates: Optional[Point] = None
 
@@ -1036,13 +1036,13 @@ class CarryEvent(
     Attributes:
         event_type (EventType): `EventType.CARRY`
         event_name (str): `"carry"`
-        end_timestamp (Time): Duration of the carry.
+        end_timestamp (timedelta): Duration of the carry.
         end_coordinates (Point): Coordinate on the pitch where the carry ended.
         result (CarryResult): The outcome of the carry.
         qualifiers: A list of qualifiers providing additional information about the carry.
     """
 
-    end_timestamp: Time
+    end_timestamp: timedelta
     end_coordinates: Point
 
     @property
@@ -1387,11 +1387,11 @@ class PressureEvent(
     Attributes:
         event_type (EventType): `EventType.Pressure`
         event_name (str): `"pressure"`
-        end_timestamp (Time): When the pressing ended.
+        end_timestamp (timedelta): When the pressing ended.
         qualifiers: A list of qualifiers providing additional information about the pressure event.
     """
 
-    end_timestamp: Time
+    end_timestamp: timedelta
 
     @property
     def event_type(self) -> EventType:

--- a/kloppy/domain/models/time.py
+++ b/kloppy/domain/models/time.py
@@ -210,6 +210,19 @@ class Time:
         return self.period < other.period or (
             self.period == other.period and self.timestamp < other.timestamp
         )
+    def __le__(self, other):
+        return self.period < other.period or (
+                self.period == other.period and self.timestamp <= other.timestamp
+        )
+    def __gt__(self, other):
+        return self.period > other.period or (
+            self.period == other.period and self.timestamp > other.timestamp
+        )
+    def __ge__(self, other):
+        return self.period > other.period or (
+            self.period == other.period and self.timestamp >= other.timestamp
+        )
+
 
     def __str__(self):
         m, s = divmod(self.timestamp.total_seconds(), 60)

--- a/kloppy/domain/models/time.py
+++ b/kloppy/domain/models/time.py
@@ -210,19 +210,21 @@ class Time:
         return self.period < other.period or (
             self.period == other.period and self.timestamp < other.timestamp
         )
+
     def __le__(self, other):
         return self.period < other.period or (
-                self.period == other.period and self.timestamp <= other.timestamp
+            self.period == other.period and self.timestamp <= other.timestamp
         )
+
     def __gt__(self, other):
         return self.period > other.period or (
             self.period == other.period and self.timestamp > other.timestamp
         )
+
     def __ge__(self, other):
         return self.period > other.period or (
             self.period == other.period and self.timestamp >= other.timestamp
         )
-
 
     def __str__(self):
         m, s = divmod(self.timestamp.total_seconds(), 60)

--- a/kloppy/domain/services/aggregators/minutes_played.py
+++ b/kloppy/domain/services/aggregators/minutes_played.py
@@ -3,19 +3,37 @@ from datetime import timedelta
 from typing import List, NamedTuple, Optional, Dict, Tuple
 from enum import Enum
 
-from kloppy.domain import EventDataset, Player, Team, Time, PositionType, BallState, FoulCommittedEvent, \
-    PassResult, SubstitutionEvent, CardEvent, PlayerOnEvent, PlayerOffEvent, Period, GenericEvent, ShotResult
+from kloppy.domain import (
+    EventDataset,
+    Player,
+    Team,
+    Time,
+    PositionType,
+    BallState,
+    FoulCommittedEvent,
+    PassResult,
+    SubstitutionEvent,
+    CardEvent,
+    PlayerOnEvent,
+    PlayerOffEvent,
+    Period,
+    GenericEvent,
+    ShotResult,
+)
 from kloppy.domain.services.aggregators.aggregator import (
     EventDatasetAggregator,
 )
+
+
 class BreakdownKey(Enum):
     POSITION = "position"
     POSSESSION_STATE = "possession_state"
 
+
 class PossessionState(Enum):
-    IN_POSSESSION = 'in-possession'
-    OUT_OF_POSSESSION = 'out-of-possession'
-    BALL_DEAD = 'ball-dead'
+    IN_POSSESSION = "in-possession"
+    OUT_OF_POSSESSION = "out-of-possession"
+    BALL_DEAD = "ball-dead"
 
 
 EVENTS_CAUSING_DEAD_BALL = (
@@ -32,6 +50,7 @@ RESULTS_CAUSING_DEAD_BALL = (
     ShotResult.OWN_GOAL,
 )
 
+
 @dataclass(frozen=True)
 class MinutesPlayedKey:
     player: Optional[Player] = None
@@ -40,10 +59,12 @@ class MinutesPlayedKey:
     possession_state: Optional[PossessionState] = None
 
     def __post_init__(self):
-        if (self.player is None and self.team is None) or (self.player is not None and self.team is not None):
-            raise ValueError("Either 'player' or 'team' must be provided, but not both.")
-
-
+        if (self.player is None and self.team is None) or (
+            self.player is not None and self.team is not None
+        ):
+            raise ValueError(
+                "Either 'player' or 'team' must be provided, but not both."
+            )
 
 
 class MinutesPlayed(NamedTuple):
@@ -57,7 +78,9 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
     def __init__(self, breakdown_key: Optional[BreakdownKey] = None):
         self.breakdown_key = breakdown_key
 
-    def get_possession_state(self, ball_state: BallState, ball_owning_team: Team, team: Team):
+    def get_possession_state(
+        self, ball_state: BallState, ball_owning_team: Team, team: Team
+    ):
         """Determine the possession state."""
         if ball_state == BallState.DEAD or ball_owning_team is None:
             return PossessionState.BALL_DEAD
@@ -67,7 +90,9 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
             else PossessionState.OUT_OF_POSSESSION
         )
 
-    def _flip_possession_state(self, state: PossessionState, flip: bool) -> PossessionState:
+    def _flip_possession_state(
+        self, state: PossessionState, flip: bool
+    ) -> PossessionState:
         if flip:
             if state == PossessionState.IN_POSSESSION:
                 return PossessionState.OUT_OF_POSSESSION
@@ -76,34 +101,40 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
         return state
 
     def _accumulate_player_time(
-            self,
-            time_per_player: Dict[Player, Dict[PossessionState, timedelta]],
-            players_start_end_times: Dict[Player, Tuple[Time, Time, bool]],
-            start_time: Time,
-            end_time: Time,
-            possession_state: PossessionState
+        self,
+        time_per_player: Dict[Player, Dict[PossessionState, timedelta]],
+        players_start_end_times: Dict[Player, Tuple[Time, Time, bool]],
+        start_time: Time,
+        end_time: Time,
+        possession_state: PossessionState,
     ):
-        for player, (start_player_time, end_player_time, _) in players_start_end_times.items():
+        for player, (
+            start_player_time,
+            end_player_time,
+            _,
+        ) in players_start_end_times.items():
             if start_player_time <= end_time and end_player_time >= start_time:
-                duration = min(end_time, end_player_time) - max(start_time, start_player_time)
+                duration = min(end_time, end_player_time) - max(
+                    start_time, start_player_time
+                )
                 time_per_player[player][possession_state] += duration
 
-    def aggregate(
-        self, dataset: EventDataset
-    ) -> List[MinutesPlayed]:
+    def aggregate(self, dataset: EventDataset) -> List[MinutesPlayed]:
         items = []
 
         if self.breakdown_key == BreakdownKey.POSITION:
             for team in dataset.metadata.teams:
                 for player in team.players:
                     for (
-                            start_timestamp,
-                            end_time,
-                            position,
+                        start_timestamp,
+                        end_time,
+                        position,
                     ) in player.positions.ranges():
                         items.append(
                             MinutesPlayed(
-                                key=MinutesPlayedKey(player=player, position=position),
+                                key=MinutesPlayedKey(
+                                    player=player, position=position
+                                ),
                                 start_time=start_timestamp,
                                 end_time=end_time,
                                 duration=end_time - start_timestamp,
@@ -118,21 +149,26 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
                     _start_time = None
                     end_time = None
                     for (
-                            start_timestamp,
-                            end_time,
-                            position,
+                        start_timestamp,
+                        end_time,
+                        position,
                     ) in player.positions.ranges():
                         if not _start_time:
                             _start_time = start_timestamp
 
                     if _start_time:
-                        flip_possession_state = (team != first_team)
-                        players_start_end_times[player] = (_start_time, end_time, flip_possession_state)
+                        flip_possession_state = team != first_team
+                        players_start_end_times[player] = (
+                            _start_time,
+                            end_time,
+                            flip_possession_state,
+                        )
             time_per_possession_state = {
                 state: timedelta(0) for state in PossessionState
             }
             time_per_player = {
-                player: {state: timedelta(0) for state in PossessionState} for player in players_start_end_times.keys()
+                player: {state: timedelta(0) for state in PossessionState}
+                for player in players_start_end_times.keys()
             }
             start_time: Optional[Time] = dataset.metadata.periods[0].start_time
             ball_owning_team: Optional[Team] = None
@@ -143,21 +179,30 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
                     continue
                 actual_event_ball_state = (
                     BallState.DEAD
-                    if isinstance(event, EVENTS_CAUSING_DEAD_BALL) or
-                       (event.result in RESULTS_CAUSING_DEAD_BALL)
+                    if isinstance(event, EVENTS_CAUSING_DEAD_BALL)
+                    or (event.result in RESULTS_CAUSING_DEAD_BALL)
                     else event.ball_state
                 )
                 if event.period != period:
 
-                    possession_state = self.get_possession_state(ball_state, ball_owning_team, first_team)
-                    end_time = Time(period=period, timestamp=(period.end_timestamp - period.start_timestamp))
-                    time_per_possession_state[possession_state] += end_time - start_time
+                    possession_state = self.get_possession_state(
+                        ball_state, ball_owning_team, first_team
+                    )
+                    end_time = Time(
+                        period=period,
+                        timestamp=(
+                            period.end_timestamp - period.start_timestamp
+                        ),
+                    )
+                    time_per_possession_state[possession_state] += (
+                        end_time - start_time
+                    )
                     self._accumulate_player_time(
                         time_per_player,
                         players_start_end_times,
                         start_time,
                         end_time,
-                        possession_state
+                        possession_state,
                     )
 
                     start_time = event.time
@@ -165,41 +210,59 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
                     ball_state = actual_event_ball_state
                     ball_owning_team = event.ball_owning_team
 
-                if actual_event_ball_state != ball_state or event.ball_owning_team != ball_owning_team:
+                if (
+                    actual_event_ball_state != ball_state
+                    or event.ball_owning_team != ball_owning_team
+                ):
 
-                    possession_state = self.get_possession_state(ball_state, ball_owning_team, first_team)
-                    time_per_possession_state[possession_state] += event.time - start_time
+                    possession_state = self.get_possession_state(
+                        ball_state, ball_owning_team, first_team
+                    )
+                    time_per_possession_state[possession_state] += (
+                        event.time - start_time
+                    )
                     self._accumulate_player_time(
                         time_per_player,
                         players_start_end_times,
                         start_time,
                         event.time,
-                        possession_state
+                        possession_state,
                     )
 
                     start_time = event.time
                     ball_state = actual_event_ball_state
                     ball_owning_team = event.ball_owning_team
             # Handle the last event in the period
-            possession_state = self.get_possession_state(ball_state, ball_owning_team, first_team)
-            end_time = Time(period=period, timestamp=(period.end_timestamp - period.start_timestamp))
-            time_per_possession_state[possession_state] += end_time - start_time
+            possession_state = self.get_possession_state(
+                ball_state, ball_owning_team, first_team
+            )
+            end_time = Time(
+                period=period,
+                timestamp=(period.end_timestamp - period.start_timestamp),
+            )
+            time_per_possession_state[possession_state] += (
+                end_time - start_time
+            )
             self._accumulate_player_time(
                 time_per_player,
                 players_start_end_times,
                 start_time,
                 end_time,
-                possession_state
+                possession_state,
             )
 
             for team in dataset.metadata.teams:
-                flip_possession = (team != first_team)
+                flip_possession = team != first_team
                 for state, duration in time_per_possession_state.items():
-                    possession_state = self._flip_possession_state(state, flip_possession)
+                    possession_state = self._flip_possession_state(
+                        state, flip_possession
+                    )
 
                     items.append(
                         MinutesPlayed(
-                            key=MinutesPlayedKey(team=team, possession_state=possession_state),
+                            key=MinutesPlayedKey(
+                                team=team, possession_state=possession_state
+                            ),
                             start_time=dataset.metadata.periods[0].start_time,
                             end_time=dataset.metadata.periods[1].end_time,
                             duration=duration,
@@ -208,12 +271,21 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
                 for player in team.players:
                     if player in time_per_player:
                         for state, duration in time_per_player[player].items():
-                            possession_state = self._flip_possession_state(state, flip_possession)
+                            possession_state = self._flip_possession_state(
+                                state, flip_possession
+                            )
                             items.append(
                                 MinutesPlayed(
-                                    key=MinutesPlayedKey(player=player, possession_state=possession_state),
-                                    start_time=dataset.metadata.periods[0].start_time,
-                                    end_time=dataset.metadata.periods[1].end_time,
+                                    key=MinutesPlayedKey(
+                                        player=player,
+                                        possession_state=possession_state,
+                                    ),
+                                    start_time=dataset.metadata.periods[
+                                        0
+                                    ].start_time,
+                                    end_time=dataset.metadata.periods[
+                                        1
+                                    ].end_time,
                                     duration=duration,
                                 )
                             )
@@ -233,9 +305,9 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
                     _start_time = None
                     end_time = None
                     for (
-                            start_timestamp,
-                            end_time,
-                            position,
+                        start_timestamp,
+                        end_time,
+                        position,
                     ) in player.positions.ranges():
                         if not _start_time:
                             _start_time = start_timestamp

--- a/kloppy/domain/services/aggregators/minutes_played.py
+++ b/kloppy/domain/services/aggregators/minutes_played.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import List, NamedTuple, Optional
+from typing import List, NamedTuple, Optional, Dict, Tuple
 from enum import Enum
 
 from kloppy.domain import EventDataset, Player, Team, Time, PositionType, BallState, FoulCommittedEvent, \
@@ -77,8 +77,8 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
 
     def _accumulate_player_time(
             self,
-            time_per_player: dict[Player, dict[PossessionState, timedelta]],
-            players_start_end_times: dict[Player, tuple[Time, Time, bool]],
+            time_per_player: Dict[Player, Dict[PossessionState, timedelta]],
+            players_start_end_times: Dict[Player, Tuple[Time, Time, bool]],
             start_time: Time,
             end_time: Time,
             possession_state: PossessionState

--- a/kloppy/domain/services/aggregators/minutes_played.py
+++ b/kloppy/domain/services/aggregators/minutes_played.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import List, NamedTuple, Optional, Dict, Tuple
+from typing import List, NamedTuple, Optional, Dict, Tuple, Union
 from enum import Enum
 
 from kloppy.domain import (
@@ -84,8 +84,14 @@ class MinutesPlayed(NamedTuple):
 
 
 class MinutesPlayedAggregator(EventDatasetAggregator):
-    def __init__(self, breakdown_key: Optional[BreakdownKey] = None):
-        self.breakdown_key = breakdown_key
+    def __init__(self, breakdown_key: Optional[Union[BreakdownKey, str]] = None):
+        if isinstance(breakdown_key, str):
+            try:
+                breakdown_key = BreakdownKey(breakdown_key)
+            except ValueError:
+                raise ValueError(
+                    f"BreakdownKey {breakdown_key} not found. Known keys: {', '.join(key.value for key in BreakdownKey)}")
+            self.breakdown_key = breakdown_key
 
     @staticmethod
     def get_possession_state(

--- a/kloppy/domain/services/aggregators/minutes_played.py
+++ b/kloppy/domain/services/aggregators/minutes_played.py
@@ -91,7 +91,7 @@ class MinutesPlayedAggregator(EventDatasetAggregator):
             except ValueError:
                 raise ValueError(
                     f"BreakdownKey {breakdown_key} not found. Known keys: {', '.join(key.value for key in BreakdownKey)}")
-            self.breakdown_key = breakdown_key
+        self.breakdown_key = breakdown_key
 
     @staticmethod
     def get_possession_state(

--- a/kloppy/domain/services/aggregators/minutes_played.py
+++ b/kloppy/domain/services/aggregators/minutes_played.py
@@ -1,71 +1,252 @@
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import List, NamedTuple, Union
+from typing import List, NamedTuple, Optional
+from enum import Enum
 
-from kloppy.domain import EventDataset, Player, Time, PositionType
+from kloppy.domain import EventDataset, Player, Team, Time, PositionType, BallState, FoulCommittedEvent, \
+    PassResult, SubstitutionEvent, CardEvent, PlayerOnEvent, PlayerOffEvent, Period, GenericEvent, ShotResult
 from kloppy.domain.services.aggregators.aggregator import (
     EventDatasetAggregator,
 )
+class BreakdownKey(Enum):
+    POSITION = "position"
+    POSSESSION_STATE = "possession_state"
+
+class PossessionState(Enum):
+    IN_POSSESSION = 'in-possession'
+    OUT_OF_POSSESSION = 'out-of-possession'
+    BALL_DEAD = 'ball-dead'
+
+
+EVENTS_CAUSING_DEAD_BALL = (
+    FoulCommittedEvent,
+    SubstitutionEvent,
+    CardEvent,
+    PlayerOnEvent,
+    PlayerOffEvent,
+)
+
+RESULTS_CAUSING_DEAD_BALL = (
+    PassResult.OFFSIDE,
+    ShotResult.GOAL,
+    ShotResult.OWN_GOAL,
+)
+
+@dataclass(frozen=True)
+class MinutesPlayedKey:
+    player: Optional[Player] = None
+    team: Optional[Team] = None
+    position: Optional[PositionType] = None
+    possession_state: Optional[PossessionState] = None
+
+    def __post_init__(self):
+        if (self.player is None and self.team is None) or (self.player is not None and self.team is not None):
+            raise ValueError("Either 'player' or 'team' must be provided, but not both.")
+
+
 
 
 class MinutesPlayed(NamedTuple):
-    player: Player
-    start_time: Time
-    end_time: Time
-    duration: timedelta
-
-
-class MinutesPlayedPerPosition(NamedTuple):
-    player: Player
-    position: PositionType
+    key: MinutesPlayedKey
     start_time: Time
     end_time: Time
     duration: timedelta
 
 
 class MinutesPlayedAggregator(EventDatasetAggregator):
-    def __init__(self, include_position: bool = False):
-        self.include_position = include_position
+    def __init__(self, breakdown_key: Optional[BreakdownKey] = None):
+        self.breakdown_key = breakdown_key
+
+    def get_possession_state(self, ball_state: BallState, ball_owning_team: Team, team: Team):
+        """Determine the possession state."""
+        if ball_state == BallState.DEAD or ball_owning_team is None:
+            return PossessionState.BALL_DEAD
+        return (
+            PossessionState.IN_POSSESSION
+            if ball_owning_team == team
+            else PossessionState.OUT_OF_POSSESSION
+        )
+
+    def _flip_possession_state(self, state: PossessionState, flip: bool) -> PossessionState:
+        if flip:
+            if state == PossessionState.IN_POSSESSION:
+                return PossessionState.OUT_OF_POSSESSION
+            elif state == PossessionState.OUT_OF_POSSESSION:
+                return PossessionState.IN_POSSESSION
+        return state
+
+    def _accumulate_player_time(
+            self,
+            time_per_player: dict[Player, dict[PossessionState, timedelta]],
+            players_start_end_times: dict[Player, tuple[Time, Time, bool]],
+            start_time: Time,
+            end_time: Time,
+            possession_state: PossessionState
+    ):
+        for player, (start_player_time, end_player_time, _) in players_start_end_times.items():
+            if start_player_time <= end_time and end_player_time >= start_time:
+                duration = min(end_time, end_player_time) - max(start_time, start_player_time)
+                time_per_player[player][possession_state] += duration
 
     def aggregate(
         self, dataset: EventDataset
-    ) -> List[Union[MinutesPlayedPerPosition, MinutesPlayed]]:
+    ) -> List[MinutesPlayed]:
         items = []
 
-        for team in dataset.metadata.teams:
-            for player in team.players:
-                if not self.include_position:
+        if self.breakdown_key == BreakdownKey.POSITION:
+            for team in dataset.metadata.teams:
+                for player in team.players:
+                    for (
+                            start_timestamp,
+                            end_time,
+                            position,
+                    ) in player.positions.ranges():
+                        items.append(
+                            MinutesPlayed(
+                                key=MinutesPlayedKey(player=player, position=position),
+                                start_time=start_timestamp,
+                                end_time=end_time,
+                                duration=end_time - start_timestamp,
+                            )
+                        )
+        elif self.breakdown_key == BreakdownKey.POSSESSION_STATE:
+            first_team = dataset.metadata.teams[0]
+
+            players_start_end_times = {}
+            for team in dataset.metadata.teams:
+                for player in team.players:
                     _start_time = None
                     end_time = None
                     for (
-                        start_time,
-                        end_time,
-                        position,
+                            start_timestamp,
+                            end_time,
+                            position,
                     ) in player.positions.ranges():
                         if not _start_time:
-                            _start_time = start_time
+                            _start_time = start_timestamp
+
+                    if _start_time:
+                        flip_possession_state = (team != first_team)
+                        players_start_end_times[player] = (_start_time, end_time, flip_possession_state)
+            time_per_possession_state = {
+                state: timedelta(0) for state in PossessionState
+            }
+            time_per_player = {
+                player: {state: timedelta(0) for state in PossessionState} for player in players_start_end_times.keys()
+            }
+            start_time: Optional[Time] = dataset.metadata.periods[0].start_time
+            ball_owning_team: Optional[Team] = None
+            ball_state: Optional[BallState] = None
+            period: Optional[Period] = dataset.metadata.periods[0]
+            for event in dataset.events:
+                if isinstance(event, GenericEvent):
+                    continue
+                actual_event_ball_state = (
+                    BallState.DEAD
+                    if isinstance(event, EVENTS_CAUSING_DEAD_BALL) or
+                       (event.result in RESULTS_CAUSING_DEAD_BALL)
+                    else event.ball_state
+                )
+                if event.period != period:
+
+                    possession_state = self.get_possession_state(ball_state, ball_owning_team, first_team)
+                    end_time = Time(period=period, timestamp=(period.end_timestamp - period.start_timestamp))
+                    time_per_possession_state[possession_state] += end_time - start_time
+                    self._accumulate_player_time(
+                        time_per_player,
+                        players_start_end_times,
+                        start_time,
+                        end_time,
+                        possession_state
+                    )
+
+                    start_time = event.time
+                    period = event.period
+                    ball_state = actual_event_ball_state
+                    ball_owning_team = event.ball_owning_team
+
+                if actual_event_ball_state != ball_state or event.ball_owning_team != ball_owning_team:
+
+                    possession_state = self.get_possession_state(ball_state, ball_owning_team, first_team)
+                    time_per_possession_state[possession_state] += event.time - start_time
+                    self._accumulate_player_time(
+                        time_per_player,
+                        players_start_end_times,
+                        start_time,
+                        event.time,
+                        possession_state
+                    )
+
+                    start_time = event.time
+                    ball_state = actual_event_ball_state
+                    ball_owning_team = event.ball_owning_team
+            # Handle the last event in the period
+            possession_state = self.get_possession_state(ball_state, ball_owning_team, first_team)
+            end_time = Time(period=period, timestamp=(period.end_timestamp - period.start_timestamp))
+            time_per_possession_state[possession_state] += end_time - start_time
+            self._accumulate_player_time(
+                time_per_player,
+                players_start_end_times,
+                start_time,
+                end_time,
+                possession_state
+            )
+
+            for team in dataset.metadata.teams:
+                flip_possession = (team != first_team)
+                for state, duration in time_per_possession_state.items():
+                    possession_state = self._flip_possession_state(state, flip_possession)
+
+                    items.append(
+                        MinutesPlayed(
+                            key=MinutesPlayedKey(team=team, possession_state=possession_state),
+                            start_time=dataset.metadata.periods[0].start_time,
+                            end_time=dataset.metadata.periods[1].end_time,
+                            duration=duration,
+                        )
+                    )
+                for player in team.players:
+                    if player in time_per_player:
+                        for state, duration in time_per_player[player].items():
+                            possession_state = self._flip_possession_state(state, flip_possession)
+                            items.append(
+                                MinutesPlayed(
+                                    key=MinutesPlayedKey(player=player, possession_state=possession_state),
+                                    start_time=dataset.metadata.periods[0].start_time,
+                                    end_time=dataset.metadata.periods[1].end_time,
+                                    duration=duration,
+                                )
+                            )
+        else:
+            _start_time = dataset.metadata.periods[0].start_time
+            _end_time = dataset.metadata.periods[1].end_time
+            for team in dataset.metadata.teams:
+                items.append(
+                    MinutesPlayed(
+                        key=MinutesPlayedKey(team=team),
+                        start_time=_start_time,
+                        end_time=_end_time,
+                        duration=_end_time - _start_time,
+                    )
+                )
+                for player in team.players:
+                    _start_time = None
+                    end_time = None
+                    for (
+                            start_timestamp,
+                            end_time,
+                            position,
+                    ) in player.positions.ranges():
+                        if not _start_time:
+                            _start_time = start_timestamp
 
                     if _start_time:
                         items.append(
                             MinutesPlayed(
-                                player=player,
+                                key=MinutesPlayedKey(player=player),
                                 start_time=_start_time,
                                 end_time=end_time,
                                 duration=end_time - _start_time,
-                            )
-                        )
-                else:
-                    for (
-                        start_time,
-                        end_time,
-                        position,
-                    ) in player.positions.ranges():
-                        items.append(
-                            MinutesPlayedPerPosition(
-                                player=player,
-                                position=position,
-                                start_time=start_time,
-                                end_time=end_time,
-                                duration=end_time - start_time,
                             )
                         )
 

--- a/kloppy/domain/services/aggregators/minutes_played.py
+++ b/kloppy/domain/services/aggregators/minutes_played.py
@@ -84,13 +84,16 @@ class MinutesPlayed(NamedTuple):
 
 
 class MinutesPlayedAggregator(EventDatasetAggregator):
-    def __init__(self, breakdown_key: Optional[Union[BreakdownKey, str]] = None):
+    def __init__(
+        self, breakdown_key: Optional[Union[BreakdownKey, str]] = None
+    ):
         if isinstance(breakdown_key, str):
             try:
                 breakdown_key = BreakdownKey(breakdown_key)
             except ValueError:
                 raise ValueError(
-                    f"BreakdownKey {breakdown_key} not found. Known keys: {', '.join(key.value for key in BreakdownKey)}")
+                    f"BreakdownKey {breakdown_key} not found. Known keys: {', '.join(key.value for key in BreakdownKey)}"
+                )
         self.breakdown_key = breakdown_key
 
     @staticmethod

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -1227,7 +1227,9 @@ class TestStatsBombTacticalShiftEvent:
             event_data=base_dir / "files/statsbomb_event.json",
         )
 
-        for item in dataset.aggregate("minutes_played", breakdown_key = BreakdownKey.POSITION):
+        for item in dataset.aggregate(
+            "minutes_played", breakdown_key=BreakdownKey.POSITION
+        ):
             if item.key.player and item.key.position:
                 print(
                     f"{item.key.player} {item.key.player.player_id}- {item.start_time} - {item.end_time} - {item.duration} - {item.key.position}"

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -1228,7 +1228,7 @@ class TestStatsBombTacticalShiftEvent:
         )
 
         for item in dataset.aggregate(
-            "minutes_played", breakdown_key=BreakdownKey.POSITION
+            "minutes_played", breakdown_key="position"
         ):
             if item.key.player and item.key.position:
                 print(

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -49,6 +49,7 @@ from kloppy.domain.models.event import (
     PassType,
     UnderPressureQualifier,
 )
+from kloppy.domain.services.aggregators.minutes_played import BreakdownKey
 from kloppy.exceptions import DeserializationError
 from kloppy.infra.serializers.event.statsbomb.helpers import parse_str_ts
 
@@ -1226,10 +1227,11 @@ class TestStatsBombTacticalShiftEvent:
             event_data=base_dir / "files/statsbomb_event.json",
         )
 
-        for item in dataset.aggregate("minutes_played", include_position=True):
-            print(
-                f"{item.player} {item.player.player_id}- {item.start_time} - {item.end_time} - {item.duration} - {item.position}"
-            )
+        for item in dataset.aggregate("minutes_played", breakdown_key = BreakdownKey.POSITION):
+            if item.key.player and item.key.position:
+                print(
+                    f"{item.key.player} {item.key.player.player_id}- {item.start_time} - {item.end_time} - {item.duration} - {item.key.position}"
+                )
 
         home_team, away_team = dataset.metadata.teams
         period1, period2 = dataset.metadata.periods

--- a/kloppy/tests/test_time.py
+++ b/kloppy/tests/test_time.py
@@ -5,7 +5,10 @@ import pytest
 
 from kloppy import statsbomb
 from kloppy.domain import Time, Period, TimeContainer
-from kloppy.domain.services.aggregators.minutes_played import BreakdownKey, PossessionState
+from kloppy.domain.services.aggregators.minutes_played import (
+    BreakdownKey,
+    PossessionState,
+)
 
 
 @pytest.fixture
@@ -157,7 +160,9 @@ class TestAbsTime:
         home_team, away_team = dataset.metadata.teams
 
         player_minutes_played_map = {
-            item.key.player: item.duration for item in minutes_played if item.key.player
+            item.key.player: item.duration
+            for item in minutes_played
+            if item.key.player
         }
 
         """
@@ -218,6 +223,7 @@ class TestAbsTime:
                 ),
                 0.001,
             )
+
     def test_statsbomb_minutes_played_per_possession_state(self, base_dir):
         dataset = statsbomb.load(
             # 3788741
@@ -226,8 +232,9 @@ class TestAbsTime:
             event_data=base_dir / "files/statsbomb_event.json",
         )
 
-        minutes_played_per_possession_state = dataset.aggregate("minutes_played", breakdown_key= BreakdownKey.POSSESSION_STATE)
-
+        minutes_played_per_possession_state = dataset.aggregate(
+            "minutes_played", breakdown_key=BreakdownKey.POSSESSION_STATE
+        )
 
         player_minutes_played_map = {}
         team_minutes_played_map = {}
@@ -236,7 +243,9 @@ class TestAbsTime:
                 team = item.key.team
                 if team not in team_minutes_played_map:
                     team_minutes_played_map[team] = {}
-                team_minutes_played_map[team][item.key.possession_state] = item.duration
+                team_minutes_played_map[team][
+                    item.key.possession_state
+                ] = item.duration
             else:
                 player = item.key.player
                 possession_state = item.key.possession_state
@@ -245,18 +254,17 @@ class TestAbsTime:
                 if player and possession_state:
                     if player not in player_minutes_played_map:
                         player_minutes_played_map[player] = {}
-                    player_minutes_played_map[player][possession_state] = duration
-
-
-        
+                    player_minutes_played_map[player][
+                        possession_state
+                    ] = duration
 
         # Teams played entire match
         for item in team_minutes_played_map.values():
             total_duration = sum(item.values(), timedelta())
             assert total_duration == (
-                        dataset.metadata.periods[0].duration
-                        + dataset.metadata.periods[1].duration
-                )
+                dataset.metadata.periods[0].duration
+                + dataset.metadata.periods[1].duration
+            )
 
         home_team, away_team = dataset.metadata.teams
 
@@ -276,10 +284,15 @@ class TestAbsTime:
         assert sum(playtime_coutinho.values(), timedelta()) == timedelta(
             seconds=2852.053
         )
-        assert playtime_coutinho[PossessionState.IN_POSSESSION] == timedelta(seconds=1505.312)
-        assert playtime_coutinho[PossessionState.OUT_OF_POSSESSION] == timedelta(seconds=296.958)
-        assert playtime_coutinho[PossessionState.BALL_DEAD] == timedelta(seconds=1049.783)
-
+        assert playtime_coutinho[PossessionState.IN_POSSESSION] == timedelta(
+            seconds=1505.312
+        )
+        assert playtime_coutinho[
+            PossessionState.OUT_OF_POSSESSION
+        ] == timedelta(seconds=296.958)
+        assert playtime_coutinho[PossessionState.BALL_DEAD] == timedelta(
+            seconds=1049.783
+        )
 
         # Replaced in second half
         player_busquets = home_team.get_player_by_id(5203)
@@ -287,21 +300,32 @@ class TestAbsTime:
         assert sum(playtime_busquets.values(), timedelta()) == timedelta(
             seconds=5052.343
         )
-        assert playtime_busquets[PossessionState.IN_POSSESSION] == timedelta(seconds=2917.724)
-        assert playtime_busquets[PossessionState.OUT_OF_POSSESSION] == timedelta(seconds=652.343)
-        assert playtime_busquets[PossessionState.BALL_DEAD] == timedelta(seconds=1482.276)
+        assert playtime_busquets[PossessionState.IN_POSSESSION] == timedelta(
+            seconds=2917.724
+        )
+        assert playtime_busquets[
+            PossessionState.OUT_OF_POSSESSION
+        ] == timedelta(seconds=652.343)
+        assert playtime_busquets[PossessionState.BALL_DEAD] == timedelta(
+            seconds=1482.276
+        )
 
         # Played entire match
         player_ramos = home_team.get_player_by_id(5211)
         playtime_ramos = player_minutes_played_map[player_ramos]
         assert sum(playtime_ramos.values(), timedelta()) == (
-                dataset.metadata.periods[0].duration
-                + dataset.metadata.periods[1].duration
+            dataset.metadata.periods[0].duration
+            + dataset.metadata.periods[1].duration
         )
-        assert playtime_ramos[PossessionState.IN_POSSESSION] == timedelta(seconds=3020.965)
-        assert playtime_ramos[PossessionState.OUT_OF_POSSESSION] == timedelta(seconds=716.177)
-        assert playtime_ramos[PossessionState.BALL_DEAD] == timedelta(seconds=1820.178)
-
+        assert playtime_ramos[PossessionState.IN_POSSESSION] == timedelta(
+            seconds=3020.965
+        )
+        assert playtime_ramos[PossessionState.OUT_OF_POSSESSION] == timedelta(
+            seconds=716.177
+        )
+        assert playtime_ramos[PossessionState.BALL_DEAD] == timedelta(
+            seconds=1820.178
+        )
 
 
 class TestAbsTimeContainer:

--- a/kloppy/tests/test_time.py
+++ b/kloppy/tests/test_time.py
@@ -315,6 +315,7 @@ class TestAbsTime:
             PossessionState.OUT_OF_POSSESSION: timedelta(seconds=677.191000),
             PossessionState.BALL_DEAD: timedelta(seconds=1863.308000),
         }
+        assert playtime_ramos == team_minutes_played_map[home_team]
 
 
 class TestAbsTimeContainer:

--- a/kloppy/tests/test_time.py
+++ b/kloppy/tests/test_time.py
@@ -285,9 +285,9 @@ class TestAbsTime:
             seconds=2852.053
         )
         assert playtime_coutinho == {
-            PossessionState.IN_POSSESSION: timedelta(seconds=1617.151),
-            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=290.732),
-            PossessionState.BALL_DEAD: timedelta(seconds=944.17),
+            PossessionState.IN_POSSESSION: timedelta(seconds=1559.075),
+            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=287.916),
+            PossessionState.BALL_DEAD: timedelta(seconds=1005.062),
         }
 
         # Replaced in second half
@@ -298,9 +298,9 @@ class TestAbsTime:
         )
 
         assert playtime_busquets == {
-            PossessionState.IN_POSSESSION: timedelta(seconds=2859.285),
-            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=650.604),
-            PossessionState.BALL_DEAD: timedelta(seconds=1542.454),
+            PossessionState.IN_POSSESSION: timedelta(seconds=2751.232000),
+            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=611.662000),
+            PossessionState.BALL_DEAD: timedelta(seconds=1689.449000),
         }
 
         # Played entire match
@@ -310,10 +310,10 @@ class TestAbsTime:
             dataset.metadata.periods[0].duration
             + dataset.metadata.periods[1].duration
         )
-        assert playtime_busquets == {
-            PossessionState.IN_POSSESSION: timedelta(seconds=2859.285),
-            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=650.604),
-            PossessionState.BALL_DEAD: timedelta(seconds=1542.454),
+        assert playtime_ramos == {
+            PossessionState.IN_POSSESSION: timedelta(seconds=3016.821000),
+            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=677.191000),
+            PossessionState.BALL_DEAD: timedelta(seconds=1863.308000),
         }
 
 

--- a/kloppy/tests/test_time.py
+++ b/kloppy/tests/test_time.py
@@ -266,6 +266,12 @@ class TestAbsTime:
                 + dataset.metadata.periods[1].duration
             )
 
+        teams = list(team_minutes_played_map.keys())
+        assert team_minutes_played_map[teams[0]][PossessionState.IN_POSSESSION] == team_minutes_played_map[teams[1]][PossessionState.OUT_OF_POSSESSION]
+        assert team_minutes_played_map[teams[0]][PossessionState.OUT_OF_POSSESSION] == team_minutes_played_map[teams[1]][PossessionState.IN_POSSESSION]
+        assert team_minutes_played_map[teams[0]][PossessionState.BALL_DEAD] == team_minutes_played_map[teams[1]][PossessionState.BALL_DEAD]
+
+
         home_team, away_team = dataset.metadata.teams
 
         """

--- a/kloppy/tests/test_time.py
+++ b/kloppy/tests/test_time.py
@@ -267,10 +267,22 @@ class TestAbsTime:
             )
 
         teams = list(team_minutes_played_map.keys())
-        assert team_minutes_played_map[teams[0]][PossessionState.IN_POSSESSION] == team_minutes_played_map[teams[1]][PossessionState.OUT_OF_POSSESSION]
-        assert team_minutes_played_map[teams[0]][PossessionState.OUT_OF_POSSESSION] == team_minutes_played_map[teams[1]][PossessionState.IN_POSSESSION]
-        assert team_minutes_played_map[teams[0]][PossessionState.BALL_DEAD] == team_minutes_played_map[teams[1]][PossessionState.BALL_DEAD]
-
+        assert (
+            team_minutes_played_map[teams[0]][PossessionState.IN_POSSESSION]
+            == team_minutes_played_map[teams[1]][
+                PossessionState.OUT_OF_POSSESSION
+            ]
+        )
+        assert (
+            team_minutes_played_map[teams[0]][
+                PossessionState.OUT_OF_POSSESSION
+            ]
+            == team_minutes_played_map[teams[1]][PossessionState.IN_POSSESSION]
+        )
+        assert (
+            team_minutes_played_map[teams[0]][PossessionState.BALL_DEAD]
+            == team_minutes_played_map[teams[1]][PossessionState.BALL_DEAD]
+        )
 
         home_team, away_team = dataset.metadata.teams
 

--- a/kloppy/tests/test_time.py
+++ b/kloppy/tests/test_time.py
@@ -284,15 +284,11 @@ class TestAbsTime:
         assert sum(playtime_coutinho.values(), timedelta()) == timedelta(
             seconds=2852.053
         )
-        assert playtime_coutinho[PossessionState.IN_POSSESSION] == timedelta(
-            seconds=1505.312
-        )
-        assert playtime_coutinho[
-            PossessionState.OUT_OF_POSSESSION
-        ] == timedelta(seconds=296.958)
-        assert playtime_coutinho[PossessionState.BALL_DEAD] == timedelta(
-            seconds=1049.783
-        )
+        assert playtime_coutinho == {
+            PossessionState.IN_POSSESSION: timedelta(seconds=1617.151),
+            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=290.732),
+            PossessionState.BALL_DEAD: timedelta(seconds=944.17),
+        }
 
         # Replaced in second half
         player_busquets = home_team.get_player_by_id(5203)
@@ -300,15 +296,12 @@ class TestAbsTime:
         assert sum(playtime_busquets.values(), timedelta()) == timedelta(
             seconds=5052.343
         )
-        assert playtime_busquets[PossessionState.IN_POSSESSION] == timedelta(
-            seconds=2917.724
-        )
-        assert playtime_busquets[
-            PossessionState.OUT_OF_POSSESSION
-        ] == timedelta(seconds=652.343)
-        assert playtime_busquets[PossessionState.BALL_DEAD] == timedelta(
-            seconds=1482.276
-        )
+
+        assert playtime_busquets == {
+            PossessionState.IN_POSSESSION: timedelta(seconds=2859.285),
+            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=650.604),
+            PossessionState.BALL_DEAD: timedelta(seconds=1542.454),
+        }
 
         # Played entire match
         player_ramos = home_team.get_player_by_id(5211)
@@ -317,15 +310,11 @@ class TestAbsTime:
             dataset.metadata.periods[0].duration
             + dataset.metadata.periods[1].duration
         )
-        assert playtime_ramos[PossessionState.IN_POSSESSION] == timedelta(
-            seconds=3020.965
-        )
-        assert playtime_ramos[PossessionState.OUT_OF_POSSESSION] == timedelta(
-            seconds=716.177
-        )
-        assert playtime_ramos[PossessionState.BALL_DEAD] == timedelta(
-            seconds=1820.178
-        )
+        assert playtime_busquets == {
+            PossessionState.IN_POSSESSION: timedelta(seconds=2859.285),
+            PossessionState.OUT_OF_POSSESSION: timedelta(seconds=650.604),
+            PossessionState.BALL_DEAD: timedelta(seconds=1542.454),
+        }
 
 
 class TestAbsTimeContainer:


### PR DESCRIPTION
This PR represents an effort to implement the functionality described in [Issue 476](https://github.com/PySport/kloppy/issues/476).

- I refactored the MinutesPlayedAggregator to make it more flexible and extensible. 
- I added an option to calculate minutes played per possession state (in possession, out of possession and dead ball).

Some notes:
- The effective play time per game falls in the range of 55-65 which seems to be realistic.
- This PR involves a breaking change, as the `include_position` flag is no longer supported and `player` inside `MinutesPlayed` is replaced by a more generic `key`. For example, this breaks the [example in the documentation](https://kloppy.pysport.org/examples/aggregations/#extract-minutes-played), since you can no longer access `item.player` but should use `item.key.player`. How should we handle this?