### PR TITLE
[SecondSpectrum] Meta Data Expansion

### DIFF
--- a/kloppy/tests/files/second_spectrum_fake_metadata2.json
+++ b/kloppy/tests/files/second_spectrum_fake_metadata2.json
@@ -1,0 +1,260 @@
+{
+    "MatchId": "1234456",
+    "CompetitionName": "FK1 - FK2 Championship",
+    "CompetitionId": "1234456",
+    "KickOffTime": {
+        "Date": "1900-01-26",
+        "DateTime": "1900-01-26T18:45:00Z",
+        "UTCOffsetInHours": 2
+    },
+    "MatchDay": "MD3",
+    "SeasonYear": "1900",
+    "HomeTeam": {
+        "Id": "123",
+        "Name": "FK1",
+        "Players": [
+            {
+                "Id": "pmafwsw7759idgzwmsae8absl4s043v0o2lt",
+                "Name": "y9xrbe545u3h",
+                "JerseyNumber": 1
+            },
+            {
+                "Id": "5mnvb8i8hxrram5dok68zmflj2i76ihmsfnq",
+                "Name": "pljb4cmv0t2z",
+                "JerseyNumber": 2
+            },
+            {
+                "Id": "fo4kmhzrknxs1ibs10a59swk54fhi3cozhtt",
+                "Name": "2hnoi7fknt5w",
+                "JerseyNumber": 3
+            },
+            {
+                "Id": "0j5hchyosbh83y8won01kb48hvulwmogumc8",
+                "Name": "z2224a1am6ne",
+                "JerseyNumber": 4
+            },
+            {
+                "Id": "o57l9ce1nihyjb1o24azg26bcw92g5dm0ij8",
+                "Name": "s3al5wlky1s7",
+                "JerseyNumber": 5
+            },
+            {
+                "Id": "5jp3vl5s2i7ly1cpjkk6g949tctsp6vascwk",
+                "Name": "xfkhouu9wppp",
+                "JerseyNumber": 6
+            },
+            {
+                "Id": "vsj66kfzeqm5mmvyfmimvjywlcok3qcn5ty9",
+                "Name": "fruoqyhyio73",
+                "JerseyNumber": 7
+            },
+            {
+                "Id": "o47hnemi4eso46t03330m91js45c180e1pp1",
+                "Name": "7axcwo4x6slo",
+                "JerseyNumber": 8
+            },
+            {
+                "Id": "mlspcvh7rswko6ababcqmfchzztryw7jhql9",
+                "Name": "xwol5cxmellx",
+                "JerseyNumber": 9
+            },
+            {
+                "Id": "67ub77tvf4i9d627odfe6ni33sq95bpjpumt",
+                "Name": "hcdfo582oz4g",
+                "JerseyNumber": 10
+            },
+            {
+                "Id": "ounznqziz3vtxl8npt4b0roamjaka3t6zob8",
+                "Name": "dacpohga5lht",
+                "JerseyNumber": 11
+            },
+            {
+                "Id": "ctglkajjq5qb8sx7dku5yoxm4oq40w3mnzns",
+                "Name": "antz61bhpdqb",
+                "JerseyNumber": 12
+            },
+            {
+                "Id": "g4hbf5qnu7r0qbawe2hkccwoq1j5l5hxnd9i",
+                "Name": "jnzm4acs4b8p",
+                "JerseyNumber": 13
+            },
+            {
+                "Id": "ynpvn297cz6cauziwfw40d6o7mhmwu60dzmw",
+                "Name": "6jjbi4p2nh2c",
+                "JerseyNumber": 14
+            },
+            {
+                "Id": "p5jrn0nyl5ik9yn8pkiin85d5zmuetm7bkcn",
+                "Name": "lab60egr8a0c",
+                "JerseyNumber": 15
+            },
+            {
+                "Id": "4oia2is8w1iji29l85d6uy7ig64sbx78x9d5",
+                "Name": "q9w9yolbn7nj",
+                "JerseyNumber": 16
+            },
+            {
+                "Id": "o2hdxbs3fyh7rh946af5tp9q8bgtmsqk97z3",
+                "Name": "8t3i0cmeticj",
+                "JerseyNumber": 17
+            },
+            {
+                "Id": "nulvti0zc3y4ztb323us9u61n3my7wu62trp",
+                "Name": "vi7hl0hgu9tw",
+                "JerseyNumber": 18
+            },
+            {
+                "Id": "44vxxq1yggcoq8981pxhznvm9okghwphl1y2",
+                "Name": "h8pglht9jmsk",
+                "JerseyNumber": 19
+            },
+            {
+                "Id": "712jbgbruvvh680sinq5vq18y7pwonx4y00r",
+                "Name": "iz21cqwk37wf",
+                "JerseyNumber": 20
+            },
+            {
+                "Id": "712jbgbruvvh680sinq5vq18y7pwonx4y00r",
+                "Name": "iz21cqwk37wf",
+                "JerseyNumber": 21
+            },
+            {
+                "Id": "712jbgbruvvh680sinq5vq18y7pwonx4y00r",
+                "Name": "iz21cqwk37wf",
+                "JerseyNumber": 22
+            },
+            {
+                "Id": "712jbgbruvvh680sinq5vq18y7pwonx4y00r",
+                "Name": "iz21cqwk37wf",
+                "JerseyNumber": 23
+            }
+        ]
+    },
+    "AwayTeam": {
+        "Id": "456",
+        "Name": "FK2",
+        "Players": [
+            {
+                "Id": "exkzuxbcc3f14k0oltdsvm9zanvl4su165wh",
+                "Name": "c6gupnmywca0",
+                "JerseyNumber": 1
+            },
+            {
+                "Id": "ysg04b3ailsdl9lnj383s8pvbkv79cqoadei",
+                "Name": "6dhssmztl3h3",
+                "JerseyNumber": 2
+            },
+            {
+                "Id": "7vz2bctjhdrkadsz3m2j7k7eg4s6hls1mfax",
+                "Name": "gyqlxo5rcvhn",
+                "JerseyNumber": 3
+            },
+            {
+                "Id": "65nit6f1fd7ln3hncx9uvvuu2txk3ow31g9u",
+                "Name": "ne8uj6ah5npc",
+                "JerseyNumber": 4
+            },
+            {
+                "Id": "lhe8p6vcw0cfrirmfajjpszituqdehivmpgk",
+                "Name": "60j1yv1rbowl",
+                "JerseyNumber": 5
+            },
+            {
+                "Id": "9c3a074a7gf3gih7a91t2sm8giul379lksr4",
+                "Name": "640fzrot7njs",
+                "JerseyNumber": 6
+            },
+            {
+                "Id": "6x0yiuaapy9n7o9iyc38fwgd3h3jyjl1vyge",
+                "Name": "bne4o954hzyv",
+                "JerseyNumber": 7
+            },
+            {
+                "Id": "cdby8yb4xlfn7ciypeue25ju6krya9xxza6x",
+                "Name": "rnlx2ina5frs",
+                "JerseyNumber": 8
+            },
+            {
+                "Id": "gl0nvpbkywd24ybj8mswpudoxf7b595rzso8",
+                "Name": "jgi0qzedhei6",
+                "JerseyNumber": 9
+            },
+            {
+                "Id": "wdfydi2l8yh4k6rv8y6kzv5py0aje6f45e5p",
+                "Name": "4kqjztd25fvo",
+                "JerseyNumber": 10
+            },
+            {
+                "Id": "tlvtu04csq94o3vsszv7byjnp5x8x9pmmzxv",
+                "Name": "toyo8gi9temj",
+                "JerseyNumber": 11
+            },
+            {
+                "Id": "u2zp3ezfhjs8zo55ymwpuwjnjur78kyrstj5",
+                "Name": "1w02mn5dc07a",
+                "JerseyNumber": 12
+            },
+            {
+                "Id": "reaa7v7o8mao0khye3ktzdwhnord0vt4be6m",
+                "Name": "2vspafo5in7z",
+                "JerseyNumber": 13
+            },
+            {
+                "Id": "skjamknv30h4co4y7f3ge34msy3hain27dqs",
+                "Name": "tilwmvwn05aa",
+                "JerseyNumber": 14
+            },
+            {
+                "Id": "npf8sg35gso4cddzar8t7ns7yolg1g5kkv4p",
+                "Name": "xrnp0q462tbi",
+                "JerseyNumber": 15
+            },
+            {
+                "Id": "ux9jbiwmum1bb3hsxtjrvavwpd1137htu6qa",
+                "Name": "ic7yufm76u08",
+                "JerseyNumber": 16
+            },
+            {
+                "Id": "ph04dvcgiw7jd45wdhduzn0mo7yuo66dfiop",
+                "Name": "iy75axf2n8qy",
+                "JerseyNumber": 17
+            },
+            {
+                "Id": "disn4hcjgz3qc2i8ixkdfjrqvw1syeec11wk",
+                "Name": "7gfm06ifb1y2",
+                "JerseyNumber": 18
+            },
+            {
+                "Id": "fjyghm80048r4nw2oxfdd1dckx5mwer7c59h",
+                "Name": "ur700ddnrd78",
+                "JerseyNumber": 19
+            },
+            {
+                "Id": "p190348pmn7u3pidfn8rvuug8axaztv1ht8e",
+                "Name": "zdsqx30l848t",
+                "JerseyNumber": 20
+            },
+            {
+                "Id": "p190348pmn7u3pidfn8rvuug8axaztv1ht8e",
+                "Name": "zdsqx30l848t",
+                "JerseyNumber": 21
+            },
+            {
+                "Id": "p190348pmn7u3pidfn8rvuug8axaztv1ht8e",
+                "Name": "zdsqx30l848t",
+                "JerseyNumber": 22
+            },
+            {
+                "Id": "p190348pmn7u3pidfn8rvuug8axaztv1ht8e",
+                "Name": "zdsqx30l848t",
+                "JerseyNumber": 23
+            }
+        ]
+    },
+    "Stadium": {
+        "Id": "62085",
+        "Name": "Anonymous Stadium",
+        "PitchLength": 104.8512,
+        "PitchWidth": 67.9704
+    }
+}

--- a/kloppy/tests/test_secondspectrum.py
+++ b/kloppy/tests/test_secondspectrum.py
@@ -20,6 +20,10 @@ class TestSecondSpectrumTracking:
         return base_dir / "files/second_spectrum_fake_metadata.xml"
 
     @pytest.fixture
+    def meta_data2(self, base_dir) -> str:
+        return base_dir / "files/second_spectrum_fake_metadata2.json"
+
+    @pytest.fixture
     def raw_data(self, base_dir) -> str:
         return base_dir / "files/second_spectrum_fake_data.jsonl"
 
@@ -122,6 +126,95 @@ class TestSecondSpectrumTracking:
         assert pitch_dimensions.x_dim.max == 52.425
         assert pitch_dimensions.y_dim.min == -33.985
         assert pitch_dimensions.y_dim.max == 33.985
+
+        # Check enriched metadata
+        date = dataset.metadata.date
+        if date:
+            assert isinstance(date, datetime)
+            assert date == datetime(1900, 1, 26, 0, 0, tzinfo=timezone.utc)
+
+        game_week = dataset.metadata.game_week
+        if game_week:
+            assert isinstance(game_week, str)
+            assert game_week == "1"
+
+        game_id = dataset.metadata.game_id
+        if game_id:
+            assert isinstance(game_id, str)
+            assert game_id == "1234456"
+
+    def test_correct_deserialization_2(
+        self, meta_data2: Path, raw_data: Path, additional_meta_data: Path
+    ):
+        dataset = secondspectrum.load(
+            meta_data=meta_data2,
+            raw_data=raw_data,
+            additional_meta_data=additional_meta_data,
+            only_alive=False,
+            coordinates="secondspectrum",
+        )
+
+        # Check provider, type, shape, etc
+        assert dataset.metadata.provider == Provider.SECONDSPECTRUM
+        assert dataset.dataset_type == DatasetType.TRACKING
+        assert len(dataset.records) == 376
+        assert len(dataset.metadata.periods) == 2
+        assert dataset.metadata.orientation == Orientation.AWAY_HOME
+
+        print("A", dataset.metadata.periods[0].end_timestamp)
+        print("B", timedelta(seconds=2982240 / 25))
+        # Check the Periods
+        assert dataset.metadata.periods[0].id == 1
+        assert dataset.metadata.periods[0].start_timestamp == timedelta(
+            seconds=0
+        )
+        assert dataset.metadata.periods[0].end_timestamp == timedelta(
+            seconds=2976
+        )
+
+        assert dataset.metadata.periods[1].id == 2
+        assert dataset.metadata.periods[1].start_timestamp == timedelta(
+            seconds=9, microseconds=720000
+        )
+        assert dataset.metadata.periods[1].end_timestamp == timedelta(
+            seconds=3017, microseconds=720000
+        )
+
+        # Check some timestamps
+        assert dataset.records[0].timestamp == timedelta(
+            seconds=0
+        )  # First frame
+        assert dataset.records[20].timestamp == timedelta(
+            seconds=320.0
+        )  # Later frame
+        assert dataset.records[187].timestamp == timedelta(
+            seconds=9.72
+        )  # Second period
+
+        # Check some players
+        home_player = dataset.metadata.teams[0].players[2]
+        assert home_player.player_id == "8xwx2"
+        assert dataset.records[0].players_coordinates[home_player] == Point(
+            x=-8.943903672572427, y=-28.171654132650365
+        )
+
+        away_player = dataset.metadata.teams[1].players[3]
+        assert away_player.player_id == "2q0uv"
+        assert dataset.records[0].players_coordinates[away_player] == Point(
+            x=-45.11871334915762, y=-20.06459030559596
+        )
+
+        # Check the ball
+        assert dataset.records[1].ball_coordinates == Point3D(
+            x=-23.147073918432426, y=13.69367399756424, z=0.0
+        )
+
+        # Check pitch dimensions
+        pitch_dimensions = dataset.metadata.pitch_dimensions
+        assert pitch_dimensions.x_dim.min == pytest.approx(-52.425, abs=0.001)
+        assert pitch_dimensions.x_dim.max == pytest.approx(52.425, abs=0.001)
+        assert pitch_dimensions.y_dim.min == pytest.approx(-33.985, abs=0.001)
+        assert pitch_dimensions.y_dim.max == pytest.approx(33.985, abs=0.001)
 
         # Check enriched metadata
         date = dataset.metadata.date

--- a/kloppy/utils.py
+++ b/kloppy/utils.py
@@ -178,3 +178,38 @@ class DeprecatedEnumValue:
 def snake_case(s: str) -> str:
     """Convert a string to snake_case."""
     return re.sub(r"[\s\-]+", "_", s.strip()).lower()
+
+
+def find_json_key(data, pattern, first_only=True):
+    def search(obj, path=""):
+        results = {}
+
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                current_path = f"{path}.{key}" if path else key
+
+                if pattern.lower() in key.lower():
+                    if first_only:
+                        return value
+                    results[current_path] = value
+
+                if isinstance(value, (dict, list)):
+                    nested = search(value, current_path)
+                    if first_only and nested is not None:
+                        return nested
+                    elif not first_only:
+                        results.update(nested)
+
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                current_path = f"{path}[{i}]" if path else f"[{i}]"
+                if isinstance(item, (dict, list)):
+                    nested = search(item, current_path)
+                    if first_only and nested is not None:
+                        return nested
+                    elif not first_only:
+                        results.update(nested)
+
+        return results if not first_only else None
+
+    return search(data)


### PR DESCRIPTION
Hi, 

I've rewritten a small part of the SecondSpectrum tracking data parser to hopefully accomodate more meta data formats.

It works with the old data, but it now also works with a broader set of meta data. 

I've introduced `find_json_key()` a function to search metadata a bit more flexibly. For example, some times "pitchLength" exists in the root, while other times it might exist in "Stadium"/"PitchLength". `find_json_key` will search for a value pitch length (disregarding capital letters) and then return the first found value. 

I think an approach like this might be a way forward to allow for way more flexible metadata parsing.

In total my approach does:
- Search for pitch length and width
- Search for fps, if it doesn't exist, extract it from the first 25 frames
- Extract periods if they are in the metadata, if not parse them from the frames using `self.__periods_from_raw_data`
- Finally, we also construct home and away team values a bit more flexibly. I'm not 100% satisfied with this approach, but that's mainly because here structures and available information might be all over the place, but I don't know, since I've only got 2 different meta data files.

Eitherway, it should be a lot more flexible already.