### PR TITLE
[Tracab] ensure string type for player names

### DIFF
--- a/kloppy/infra/serializers/tracking/tracab/parsers/metadata/common.py
+++ b/kloppy/infra/serializers/tracking/tracab/parsers/metadata/common.py
@@ -38,8 +38,8 @@ def create_team(
         Player(
             player_id=str(player[f"Player{id_suffix}"]),
             team=team,
-            first_name=html.unescape(player["FirstName"]),
-            last_name=html.unescape(player["LastName"]),
+            first_name=str(html.unescape(player["FirstName"])),
+            last_name=str(html.unescape(player["LastName"])),
             name=html.unescape(player["FirstName"] + " " + player["LastName"]),
             jersey_no=int(player["JerseyNo"]),
             starting=player["StartFrameCount"] == start_frame_id,

--- a/kloppy/tests/test_tracab.py
+++ b/kloppy/tests/test_tracab.py
@@ -94,6 +94,10 @@ def meta_tracking_assertions(dataset):
         player.player_id for player in dataset.records[6].players_data.keys()
     ]
 
+    assert player_home_1.first_name == "Player"
+    assert player_home_1.last_name == "One"
+    assert player_home_1.name == "Player One"
+
 
 class TestTracabJSONTracking:
     def test_correct_deserialization_limit_sample(


### PR DESCRIPTION
`player.first_name` and `player.last_name` were of type `StringElement` instead `string`, when reading in Tracab XML metadata.