### PR TITLE
[SkillCorner] Add `only_alive` functionality

### DIFF
--- a/kloppy/_providers/skillcorner.py
+++ b/kloppy/_providers/skillcorner.py
@@ -18,7 +18,7 @@ def load(
     coordinates: Optional[str] = None,
     include_empty_frames: Optional[bool] = False,
     data_version: Optional[str] = None,
-    only_alive: Optional[bool] = False,
+    only_alive: Optional[bool] = True,
 ) -> TrackingDataset:
     """
     Load SkillCorner broadcast tracking data.
@@ -66,7 +66,7 @@ def load_open_data(
     limit: Optional[int] = None,
     coordinates: Optional[str] = None,
     include_empty_frames: Optional[bool] = False,
-    only_alive: Optional[bool] = False,
+    only_alive: Optional[bool] = True,
 ) -> TrackingDataset:
     """
     Load SkillCorner open data.

--- a/kloppy/infra/serializers/tracking/skillcorner.py
+++ b/kloppy/infra/serializers/tracking/skillcorner.py
@@ -68,7 +68,7 @@ class SkillCornerDeserializer(TrackingDataDeserializer[SkillCornerInputs]):
         coordinate_system: Optional[Union[str, Provider]] = None,
         include_empty_frames: Optional[bool] = False,
         data_version: Optional[str] = None,
-        only_alive: bool = False,
+        only_alive: bool = True,
     ):
         super().__init__(limit, sample_rate, coordinate_system)
         self.include_empty_frames = include_empty_frames


### PR DESCRIPTION
In [release 3.17.1](https://github.com/PySport/kloppy/releases) we added SkillCorner BallState tracking. We did not include `only_alive` functionality, like we have for other providers.

This PR adds that functionality. I've also added a test, and updated some tests to reflect this change. The tests were changed because the old behavior would include _all_ frames, but the new behavior by default only includes _alive_ frames, as we do by default for all tracking providers. I've simply changed the tests to have `only_alive=False` (the old behavior of including everything) such that the tests still pass for existing tests.
