### PR TITLE
refactor: remove deprecated `to_pandas`

### DIFF
--- a/kloppy/domain/models/code.py
+++ b/kloppy/domain/models/code.py
@@ -1,17 +1,13 @@
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import Union
 
 from kloppy.domain.models.common import DatasetType
 from kloppy.utils import (
-    deprecated,
     docstring_inherit_attributes,
 )
 
 from .common import DataRecord, Dataset
-
-if TYPE_CHECKING:
-    from pandas import DataFrame
 
 
 @dataclass
@@ -57,45 +53,6 @@ class CodeDataset(Dataset[Code]):
     @property
     def codes(self):
         return self.records
-
-    @deprecated(
-        "to_pandas will be removed in the future. Please use to_df instead."
-    )
-    def to_pandas(
-        self,
-        record_converter: Optional[Callable[[Code], dict]] = None,
-        additional_columns=None,
-    ) -> "DataFrame":  # noqa: F821
-        try:
-            import pandas as pd
-        except ImportError:
-            raise ImportError(
-                "Seems like you don't have pandas installed. Please"
-                " install it using: pip install pandas"
-            )
-
-        if not record_converter:
-            from ..services.transformers.attribute import (
-                DefaultCodeTransformer,
-            )
-
-            record_converter = DefaultCodeTransformer()
-
-        def generic_record_converter(code: Code):
-            row = record_converter(code)
-            if additional_columns:
-                for k, v in additional_columns.items():
-                    if callable(v):
-                        value = v(code)
-                    else:
-                        value = v
-                    row.update({k: value})
-
-            return row
-
-        return pd.DataFrame.from_records(
-            map(generic_record_converter, self.records)
-        )
 
 
 __all__ = ["Code", "CodeDataset"]

--- a/kloppy/domain/models/common.py
+++ b/kloppy/domain/models/common.py
@@ -20,8 +20,6 @@ from typing import (
 from kloppy.utils import deprecated, snake_case
 
 if TYPE_CHECKING:
-    from pandas import DataFrame
-
     from ..services.transformers.data_record import (
         Column,
         NamedColumns,
@@ -1725,14 +1723,6 @@ class Dataset(ABC, Generic[T]):
     @abstractmethod
     def dataset_type(self) -> DatasetType:
         raise NotImplementedError
-
-    @abstractmethod
-    def to_pandas(
-        self,
-        record_converter: Callable[[T], dict] | None = None,
-        additional_columns: NamedColumns | None = None,
-    ) -> DataFrame:  # noqa: F821
-        pass
 
     def transform(self, *args, **kwargs):
         """

--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -26,7 +26,6 @@ from kloppy.domain.models.time import Time
 from kloppy.utils import (
     DeprecatedEnumValue,
     camelcase_to_snakecase,
-    deprecated,
     docstring_inherit_attributes,
     removes_suffix,
 )
@@ -37,9 +36,6 @@ from .formation import FormationType
 from .pitch import Point
 
 if TYPE_CHECKING:
-    from pandas import DataFrame
-
-    from ..services.transformers.data_record import NamedColumns
     from .tracking import Frame
 
 QualifierValueType = TypeVar("QualifierValueType")
@@ -1481,44 +1477,6 @@ class EventDataset(Dataset[Event]):
         from kloppy.domain.services.state_builder import add_state
 
         return add_state(self, *builder_keys)
-
-    @deprecated(
-        "to_pandas will be removed in the future. Please use to_df instead."
-    )
-    def to_pandas(
-        self,
-        record_converter: Callable[[Event], dict] | None = None,
-        additional_columns: NamedColumns | None = None,
-    ) -> "DataFrame":  # noqa F821
-        try:
-            import pandas as pd
-        except ImportError:
-            raise ImportError(
-                "Seems like you don't have pandas installed. Please"
-                " install it using: pip install pandas"
-            )
-
-        if not record_converter:
-            from ..services.transformers.attribute import (
-                DefaultEventTransformer,
-            )
-
-            record_converter = DefaultEventTransformer()
-
-        def generic_record_converter(event: Event):
-            row = record_converter(event)
-            if additional_columns:
-                for k, v in additional_columns.items():
-                    if callable(v):
-                        value = v(event)
-                    else:
-                        value = v
-                    row.update({k: value})
-            return row
-
-        return pd.DataFrame.from_records(
-            map(generic_record_converter, self.records)
-        )
 
     def aggregate(self, type_: str, **aggregator_kwargs) -> list[Any]:
         if type_ == "minutes_played":

--- a/kloppy/domain/models/tracking.py
+++ b/kloppy/domain/models/tracking.py
@@ -1,17 +1,13 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import Any, Optional
 
 from kloppy.domain.models.common import DatasetType
 from kloppy.utils import (
-    deprecated,
     docstring_inherit_attributes,
 )
 
 from .common import DataRecord, Dataset, Player
 from .pitch import Point, Point3D
-
-if TYPE_CHECKING:
-    from pandas import DataFrame
 
 
 @dataclass
@@ -82,45 +78,6 @@ class TrackingDataset(Dataset[Frame]):
     @property
     def frame_rate(self):
         return self.metadata.frame_rate
-
-    @deprecated(
-        "to_pandas will be removed in the future. Please use to_df instead."
-    )
-    def to_pandas(
-        self,
-        record_converter: Optional[Callable[[Frame], dict]] = None,
-        additional_columns=None,
-    ) -> "DataFrame":  # noqa: F821
-        try:
-            import pandas as pd
-        except ImportError:
-            raise ImportError(
-                "Seems like you don't have pandas installed. Please"
-                " install it using: pip install pandas"
-            )
-
-        if not record_converter:
-            from ..services.transformers.attribute import (
-                DefaultFrameTransformer,
-            )
-
-            record_converter = DefaultFrameTransformer()
-
-        def generic_record_converter(frame: Frame):
-            row = record_converter(frame)
-            if additional_columns:
-                for k, v in additional_columns.items():
-                    if callable(v):
-                        value = v(frame)
-                    else:
-                        value = v
-                    row.update({k: value})
-
-            return row
-
-        return pd.DataFrame.from_records(
-            map(generic_record_converter, self.records)
-        )
 
 
 __all__ = ["Frame", "TrackingDataset", "PlayerData"]


### PR DESCRIPTION
The `to_pandas` method was deprecated in favour of `to_df` in March 2023.