### PR TITLE
[Sportec] Update IDSSE dataset URL

### DIFF
--- a/kloppy/_providers/sportec.py
+++ b/kloppy/_providers/sportec.py
@@ -115,7 +115,7 @@ def get_IDSSE_url(match_id: str, data_type: str) -> str:
         "J03WR9": {"meta": 51643490, "event": 51643511, "tracking": 51643532},
     }
     # URL constant
-    DATA_URL = "https://springernature.figshare.com/ndownloader/files/{file_id}"
+    DATA_URL = "https://ndownloader.figshare.com/files/{file_id}"
 
     if data_type not in ["meta", "event", "tracking"]:
         raise ValueError(


### PR DESCRIPTION
Figshare has changed how file downloads are handled. The URL that we used previously (https://springernature.figshare.com/ndownloader/files/{file_id}) now returns an empty response.

Fixes #527