### PR TITLE
[IO] Support dict for HTTP Basic Auth config & fix docs

### DIFF
--- a/docs/user-guide/loading-data/index.md
+++ b/docs/user-guide/loading-data/index.md
@@ -94,25 +94,25 @@ To load data from a web server, you must provide a string representing a URL. It
 from kloppy import statsbomb
 
 dataset = statsbomb.load(
-    event_data=Path("http://someurl.com/match_3788741/events.json"),
-    lineup_data=Path("htpps://someurl.com/match_3788741/lineups.json"),
+    event_data="http://someurl.com/match_3788741/events.json",
+    lineup_data="htpps://someurl.com/match_3788741/lineups.json",
 )
 ```
 
-You can pass credentials for authentication via [`set_config`][kloppy.config.set_config].
+You can pass credentials for authentication via [`set_config`][kloppy.config.set_config] to allow fetching data from a protected API.
 
 ```python
-from kloppy import statsbomb
+from kloppy import wyscout
 from kloppy.config import set_config
 
 set_config(
     'adapters.http.basic_authentication',
-    { 'user': 'JohnDoe', 'pass': 'asecretkey' }
+    { 'login': 'JohnDoe', 'password': 'asecretkey' }
 )
 
-dataset = statsbomb.load(
-    event_data="http://someurl.com/match_3788741/events.json",
-    lineup_data="htpps://someurl.com/match_3788741/lineups.json",
+dataset = wyscout.load(
+    event_data="https://apirest.wyscout.com/v3/matches/3788741/events",
+    data_version="V3"
 )
 ```
 

--- a/docs/user-guide/loading-data/index.md
+++ b/docs/user-guide/loading-data/index.md
@@ -99,21 +99,22 @@ dataset = statsbomb.load(
 )
 ```
 
-You can pass credentials for authentication via [`set_config`][kloppy.config.set_config] to allow fetching data from a protected API.
+To fetch data from an API protected with [HTTP Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication), you can provide your credentials by setting the `adapters.http.basic_authentication` configuration variable.
 
 ```python
 from kloppy import wyscout
-from kloppy.config import set_config
+from kloppy.config import config_context
 
-set_config(
-    'adapters.http.basic_authentication',
-    { 'login': 'JohnDoe', 'password': 'asecretkey' }
-)
+# Use a dictionary or tuple/list: ("JohnDoe", "asecretkey")
+with config_context(
+    "adapters.http.basic_authentication",
+    {"login": "JohnDoe", "password": "asecretkey"}
+):
+    dataset = wyscout.load(
+        event_data="https://apirest.wyscout.com/v3/matches/3788741/events",
+        data_version="V3"
+    )
 
-dataset = wyscout.load(
-    event_data="https://apirest.wyscout.com/v3/matches/3788741/events",
-    data_version="V3"
-)
 ```
 
 #### S3

--- a/kloppy/infra/io/adapters/http.py
+++ b/kloppy/infra/io/adapters/http.py
@@ -48,12 +48,20 @@ class HTTPAdapter(FSSpecAdapter):
         client_kwargs = {}
         if basic_authentication:
             try:
-                client_kwargs["auth"] = aiohttp.BasicAuth(
-                    **basic_authentication
-                )
+                if isinstance(basic_authentication, dict):
+                    # Handle dictionary: unpack as keyword arguments (login=..., password=...)
+                    client_kwargs["auth"] = aiohttp.BasicAuth(
+                        **basic_authentication
+                    )
+                else:
+                    # Handle list/tuple: unpack as positional arguments (login, password)
+                    client_kwargs["auth"] = aiohttp.BasicAuth(
+                        *basic_authentication
+                    )
             except TypeError as e:
                 raise KloppyError(
-                    "Invalid basic authentication configuration. Provide a dictionary with 'login' and 'password' keys."
+                    "Invalid basic authentication configuration. "
+                    "Provide a dictionary with 'login' and 'password' keys, or tuple."
                 ) from e
 
         if no_cache:

--- a/kloppy/infra/io/adapters/http.py
+++ b/kloppy/infra/io/adapters/http.py
@@ -1,7 +1,7 @@
 import fsspec
 
 from kloppy.config import get_config
-from kloppy.exceptions import AdapterError
+from kloppy.exceptions import AdapterError, KloppyError
 
 from .fsspec import FSSpecAdapter
 
@@ -47,7 +47,14 @@ class HTTPAdapter(FSSpecAdapter):
 
         client_kwargs = {}
         if basic_authentication:
-            client_kwargs["auth"] = aiohttp.BasicAuth(*basic_authentication)
+            try:
+                client_kwargs["auth"] = aiohttp.BasicAuth(
+                    **basic_authentication
+                )
+            except TypeError as e:
+                raise KloppyError(
+                    "Invalid basic authentication configuration. Provide a dictionary with 'login' and 'password' keys."
+                ) from e
 
         if no_cache:
             return fsspec.filesystem("http", client_kwargs=client_kwargs)

--- a/kloppy/tests/test_io.py
+++ b/kloppy/tests/test_io.py
@@ -477,9 +477,18 @@ class TestHTTPAdapter:
 
     def test_read_with_basic_auth(self, httpserver):
         """It should read a file protected with basic authentication."""
+        # It should support a dict
         with config_context(
             "adapters.http.basic_authentication",
             {"login": "Aladdin", "password": "OpenSesame"},
+        ):
+            with open_as_file(httpserver.url_for("/auth.txt")) as fp:
+                assert fp.read() == b"Hello, world!"
+
+        # It should also support a tuple
+        with config_context(
+            "adapters.http.basic_authentication",
+            ("Aladdin", "OpenSesame"),
         ):
             with open_as_file(httpserver.url_for("/auth.txt")) as fp:
                 assert fp.read() == b"Hello, world!"


### PR DESCRIPTION
Kloppy supports fetching data from URLs protected with HTTP Basic Auth. Previously, the [documentation stated](https://kloppy.pysport.org/user-guide/loading-data/#http) that  this requires setting the following configuration:

```py
from kloppy.config import set_config

set_config(
    'adapters.http.basic_authentication',
    { 'user': 'JohnDoe', 'pass': 'asecretkey' }
)
```

However, since the configuration variable is unpacked as `aiohttp.BasicAuth(*basic_authentication)`, the correct way to set the configuration variable was to define it as a tuple:

```py
set_config(
    'adapters.http.basic_authentication',
    ('JohnDoe', 'asecretkey',)
)
```

Moreover, the keys used are incorrect, as `aiohttp.BasicAuth` uses "login" and "password".

I've updated the code such that 'adapters.http.basic_authentication' now accepts both a dict and a tuple, fixed the documentation, and added tests for retrieving data from URLs protected with HTTP Basic Auth.

--- 

- Support passing basic auth config to `aiohttp.BasicAuth` using keyword arguments
- Fix documentation example to use correct auth config keys
- Raise a clear KloppyError for malformed basic auth configuration
- Add tests for authenticated, unauthenticated, and invalid auth cases

Fixes #78 