### PR TITLE
docs: fix typos and incorrect function call in loading data notebooks

### DIFF
--- a/docs/user-guide/loading-data/datafactory.ipynb
+++ b/docs/user-guide/loading-data/datafactory.ipynb
@@ -216,7 +216,7 @@
     "For example you can pass:\n",
     "- Individual s3 file paths: (e.g `event_data=s3://.../datafactory_events.json`)\n",
     "\n",
-    "Note: Kloppy might throw an the first time to help you identify missing cloud specific dependencies like `s3fs`. "
+    "Note: Kloppy might throw an error the first time to help you identify missing cloud specific dependencies like `s3fs`. "
    ]
   },
   {

--- a/docs/user-guide/loading-data/hawkeye.ipynb
+++ b/docs/user-guide/loading-data/hawkeye.ipynb
@@ -70,7 +70,7 @@
     "- A list of s3 file paths: (e.g. `ball_feeds=[s3://.../hawkeye/scrubbed.samples.ball/*_*_*_1_14.football.samples.ball, s3://.../hawkeye/scrubbed.samples.ball/*_*_*_1_15.football.samples.ball]`)\n",
     "- A bucket / folder (e.g `ball_feeds=s3://.../hawkeye/scrubbed.samples.ball/`)\n",
     "\n",
-    "Note: Kloppy might throw an the first time to help you identify missing cloud specific dependencies like `s3fs`. "
+    "Note: Kloppy might throw an error the first time to help you identify missing cloud specific dependencies like `s3fs`. "
    ]
   },
   {

--- a/docs/user-guide/loading-data/secondspectrum.ipynb
+++ b/docs/user-guide/loading-data/secondspectrum.ipynb
@@ -166,7 +166,7 @@
     "For example you can pass:\n",
     "- Individual s3 file paths: (e.g `raw_data=s3://.../second_spectrum_fake_data.jsonl`)\n",
     "\n",
-    "Note: Kloppy might throw an the first time to help you identify missing cloud specific dependencies like `s3fs`. "
+    "Note: Kloppy might throw an error the first time to help you identify missing cloud specific dependencies like `s3fs`. "
    ]
   },
   {

--- a/docs/user-guide/loading-data/skillcorner.ipynb
+++ b/docs/user-guide/loading-data/skillcorner.ipynb
@@ -511,7 +511,7 @@
     "For example you can pass:\n",
     "- Individual s3 file paths: (e.g `raw_data=s3://.../skillcorner_match_data.jsonl`)\n",
     "\n",
-    "Note: Kloppy might throw an the first time to help you identify missing cloud specific dependencies like `s3fs`. "
+    "Note: Kloppy might throw an error the first time to help you identify missing cloud specific dependencies like `s3fs`. "
    ]
   },
   {
@@ -730,7 +730,7 @@
    "source": [
     "from kloppy import skillcorner\n",
     "\n",
-    "dataset = skillcorner.load_open_data(\n",
+    "dataset = skillcorner.load(\n",
     "    meta_data=\"s3://.../skillcorner_match_data.jsonl\",\n",
     "    raw_data=\"s3://.../skillcorner_structured_data.json\",\n",
     "    # Optional arguments\n",

--- a/docs/user-guide/loading-data/sportec.ipynb
+++ b/docs/user-guide/loading-data/sportec.ipynb
@@ -510,7 +510,7 @@
     "For example you can pass:\n",
     "- Individual s3 file paths: (e.g `raw_data=s3://.../sportec_positional.xml`)\n",
     "\n",
-    "Note: Kloppy might throw an the first time to help you identify missing cloud specific dependencies like `s3fs`. "
+    "Note: Kloppy might throw an error the first time to help you identify missing cloud specific dependencies like `s3fs`. "
    ]
   },
   {

--- a/docs/user-guide/loading-data/statsbomb.ipynb
+++ b/docs/user-guide/loading-data/statsbomb.ipynb
@@ -480,7 +480,7 @@
     "For example you can pass:\n",
     "- Individual s3 file paths: (e.g `event_data=s3://.../statsbomb_3788741_event.json`)\n",
     "\n",
-    "Note: Kloppy might throw an the first time to help you identify missing cloud specific dependencies like `s3fs`. "
+    "Note: Kloppy might throw an error the first time to help you identify missing cloud specific dependencies like `s3fs`. "
    ]
   },
   {

--- a/docs/user-guide/loading-data/statsperform.ipynb
+++ b/docs/user-guide/loading-data/statsperform.ipynb
@@ -1246,7 +1246,7 @@
     "For example you can pass:\n",
     "- Individual s3 file paths: (e.g `ma1_data=s3://.../statsperform_event_ma1.xml`)\n",
     "\n",
-    "Note: Kloppy might throw an the first time to help you identify missing cloud specific dependencies like `s3fs`. "
+    "Note: Kloppy might throw an error the first time to help you identify missing cloud specific dependencies like `s3fs`. "
    ]
   },
   {

--- a/docs/user-guide/loading-data/tracab.ipynb
+++ b/docs/user-guide/loading-data/tracab.ipynb
@@ -191,7 +191,7 @@
     "For example you can pass:\n",
     "- Individual s3 file paths: (e.g `meta_data=s3://.../tracab_meta.xml`)\n",
     "\n",
-    "Note: Kloppy might throw an the first time to help you identify missing cloud specific dependencies like `s3fs`. "
+    "Note: Kloppy might throw an error the first time to help you identify missing cloud specific dependencies like `s3fs`. "
    ]
   },
   {

--- a/docs/user-guide/loading-data/wyscout.ipynb
+++ b/docs/user-guide/loading-data/wyscout.ipynb
@@ -497,7 +497,7 @@
    "source": [
     "## Load open data\n",
     "\n",
-    "For loading Wyscout open data you can also use `wyscout.load_open_data`. The api is very simular but you don't have to pass the urls.\n",
+    "For loading Wyscout open data you can also use `wyscout.load_open_data`. The api is very similar but you don't have to pass the urls.\n",
     "\n",
     "For more information on the available games please refer to [this GitHub repository](https://github.com/koenvo/wyscout-soccer-match-event-dataset) and have a look at [this Table](https://github.com/koenvo/wyscout-soccer-match-event-dataset/blob/main/processed-v2/README.md)."
    ]


### PR DESCRIPTION
Addresses some open documentation tasks from #465.

- Fixes missing word in remote files note: "throw an the first time" → "throw an error the first time" (8 notebooks)
- Fixes incorrect function in SkillCorner S3 example: `load_open_data` → `load`
- Fixes typo in Wyscout notebook: "simular" → "similar"