### PR TITLE
Add StatsBomb 3-2-4-1 formation mapping

### DIFF
--- a/kloppy/infra/serializers/event/statsbomb/specification.py
+++ b/kloppy/infra/serializers/event/statsbomb/specification.py
@@ -77,6 +77,7 @@ FORMATIONS = {
     32212: FormationType.THREE_TWO_TWO_ONE_TWO,
     32221: FormationType.THREE_TWO_TWO_TWO_ONE,
     3232: FormationType.THREE_TWO_THREE_TWO,
+    3241: FormationType.THREE_TWO_FOUR_ONE,
     3322: FormationType.THREE_THREE_TWO_TWO,
     3412: FormationType.THREE_FOUR_ONE_TWO,
     3421: FormationType.THREE_FOUR_TWO_ONE,


### PR DESCRIPTION
## Summary

 Add the missing StatsBomb `3241` formation mapping to `FormationType.THREE_TWO_FOUR_ONE`.

 StatsBomb can emit tactical shift events with `tactics.formation = 3241`, representing a `3-2-4-1` shape. Kloppy already defines `FormationType.THREE_TWO_FOUR_ONE`, but the StatsBomb `FORMATIONS` lookup did not include provider code `3241`. That means deserializing affected StatsBomb events can raise `KeyError: 3241` when building formation change events.

  ## Reproducing Statsbomb Data Point

  - `competition_id`: `44`
  - `season_id`: `316`
  - `match_id`: `4038279`
  - event id: `1c23cbe4-ccc9-4282-8480-e32b63de989c`
  - event type: `Tactical Shift`
  - team: `Portland Timbers`
  - `tactics.formation`: `3241`

  ## Change

  - Map StatsBomb formation code `3241` to the existing `FormationType.THREE_TWO_FOUR_ONE` enum value.