### PR TITLE
fix: make CarryEvent and PressureEvent fields optional (#512)

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -1030,8 +1030,8 @@ class CarryEvent(
         qualifiers: A list of qualifiers providing additional information about the carry.
     """
 
-    end_timestamp: Time
-    end_coordinates: Point
+    end_timestamp: Optional[Time] = None
+    end_coordinates: Optional[Point] = None
 
     @property
     def event_type(self) -> EventType:
@@ -1379,7 +1379,7 @@ class PressureEvent(
         qualifiers: A list of qualifiers providing additional information about the pressure event.
     """
 
-    end_timestamp: Time
+    end_timestamp: Optional[Time] = None
 
     @property
     def event_type(self) -> EventType:


### PR DESCRIPTION
To ensure consistency with `PassEvent` and `ShotEvent` (which already treat their respective end-state fields as optional), this PR marks `end_timestamp` and `end_coordinates` as Optional in `CarryEvent` and marks `end_timestamp` as Optional in `PressureEvent`. We provide default values of `None` for these fields to avoid TypeError when data providers do not supply them.

Fixes #512 