### PR TITLE
ci: auto-commit pre-commit changes on dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out
+      - name: Check out (Dependabot)
+        if: github.actor == 'dependabot[bot]'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+      - name: Check out (Normal)
+        if: github.actor != 'dependabot[bot]'
+        uses: actions/checkout@v4
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,13 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
@@ -18,7 +22,17 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
       - name: Run pre-commit
+        id: pre-commit
         run: uv run pre-commit run -a --show-diff-on-failure
+        continue-on-error: true
+      - name: Auto-commit changes (Dependabot)
+        if: always() && github.actor == 'dependabot[bot]' && steps.pre-commit.outcome == 'failure'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(deps): auto-update requirements files"
+      - name: Fail if pre-commit failed
+        if: steps.pre-commit.outcome == 'failure' && github.actor != 'dependabot[bot]'
+        run: exit 1
       - name: Check lock file consistency
         run: uv sync --locked
   tests:


### PR DESCRIPTION
When Dependabot updates dependencies in our `pyproject.toml` and `uv.lock`, it does not re-export the associated `requirements-dev.txt` and `requirements-docs.txt` files. Consequently, when the CI workflow runs, the `uv-export` pre-commit hook exits with a failure code, and causes the entire CI pipeline to fail, requiring manual intervention to commit the exported files on every Dependabot PR.

This PR updates `.github/workflows/test.yml` to automatically intercept and commit these changes on Dependabot PRs:
* Grants the `pre-commit` job `contents: write` permissions.
* Utilizes `stefanzweifel/git-auto-commit-action` to automatically commit and push the updated `requirements-*.txt`
files back to the PR branch whenever Dependabot is the actor and the `pre-commit` check fails.
* Normal workflows triggered by actual users remain unchanged; if they fail the `pre-commit` check, the CI will still halt as expected to ensure the developer reviews the diff.