### PR TITLE
ci: configure dependabot to use uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Because we didn't have an explicit Dependabot configuration file, GitHub was automatically trying to guess the ecosystems. It sees `requirements-dev.txt` and `requirements-docs.txt` and guesses kloppy is a pip project instead of an uv project.
